### PR TITLE
Fix prep module issues: Unified .ss extension, Unknown Project bug, and streamlined navigation

### DIFF
--- a/src/main/services/fileService.ts
+++ b/src/main/services/fileService.ts
@@ -19,31 +19,34 @@ export interface FileValidationResult {
   projectName?: string;
 }
 
-// Module-specific file extensions
-export const FILE_EXTENSIONS = {
-  PRODUCTION: 'ssp',    // ShowStack:Production
-  MANAGER: 'ssm',       // ShowStack:Manager
-  DESIGN: 'ssd'         // ShowStack:Design (Prep)
+// Unified file extension for all ShowStack projects
+export const FILE_EXTENSION = 'ss';
+
+// Legacy file extensions (for backward compatibility)
+export const LEGACY_EXTENSIONS = {
+  PRODUCTION: 'ssp',    // ShowStack:Production (legacy)
+  MANAGER: 'ssm',       // ShowStack:Manager (legacy)
+  DESIGN: 'ssd'         // ShowStack:Design (legacy)
 } as const;
 
-export type ModuleType = keyof typeof FILE_EXTENSIONS;
+export type ModuleType = keyof typeof LEGACY_EXTENSIONS;
 
 class FileService {
   private readonly SHOWSTACK_VERSION = '1.0.0';
   private readonly APP_VERSION = '0.1.0-alpha';
 
   /**
-   * Get all ShowStack file extensions
+   * Get all ShowStack file extensions (current + legacy for backward compatibility)
    */
   private getAllExtensions(): string[] {
-    return Object.values(FILE_EXTENSIONS);
+    return [FILE_EXTENSION, ...Object.values(LEGACY_EXTENSIONS)];
   }
 
   /**
-   * Get extension for a specific module
+   * Get extension for a specific module (always returns unified .ss extension)
    */
   getExtensionForModule(module: ModuleType): string {
-    return FILE_EXTENSIONS[module];
+    return FILE_EXTENSION;
   }
 
   /**
@@ -57,9 +60,6 @@ class FileService {
       title: 'Open ShowStack Project',
       filters: [
         { name: 'ShowStack Projects', extensions },
-        { name: 'Production Files', extensions: [FILE_EXTENSIONS.PRODUCTION] },
-        { name: 'Manager Files', extensions: [FILE_EXTENSIONS.MANAGER] },
-        { name: 'Design Files', extensions: [FILE_EXTENSIONS.DESIGN] },
         { name: 'All Files', extensions: ['*'] }
       ],
       properties: ['openFile']
@@ -75,19 +75,17 @@ class FileService {
   /**
    * Show save file dialog
    * @param defaultName Default filename
-   * @param module Module type (defaults to PRODUCTION)
+   * @param module Module type (for legacy compatibility, no longer used)
    * @returns File path or null if canceled
    */
   async showSaveDialog(defaultName?: string, module: ModuleType = 'PRODUCTION'): Promise<string | null> {
-    const extension = FILE_EXTENSIONS[module];
     const extensions = this.getAllExtensions();
 
     const result = await dialog.showSaveDialog({
       title: 'Save ShowStack Project',
       defaultPath: defaultName || 'Untitled Project',
       filters: [
-        { name: `ShowStack ${module} File`, extensions: [extension] },
-        { name: 'ShowStack Projects', extensions },
+        { name: 'ShowStack Project', extensions: [FILE_EXTENSION] },
         { name: 'All Files', extensions: ['*'] }
       ]
     });
@@ -101,25 +99,41 @@ class FileService {
     const hasValidExtension = extensions.some(ext => filePath.endsWith(`.${ext}`));
 
     if (!hasValidExtension) {
-      filePath += `.${extension}`;
+      filePath += `.${FILE_EXTENSION}`;
     }
 
     return filePath;
   }
 
   /**
-   * Export current database to ShowStack file (.ssp, .ssm, or .ssd)
+   * Export current database to ShowStack file (.ss)
    * @param filePath Destination file path
    */
   async exportProject(filePath: string): Promise<void> {
     try {
       const db = getDatabase();
 
-      // Update project's updated_at timestamp
-      db.run('UPDATE projects SET updated_at = ? WHERE id = ?', [
-        Date.now(),
-        'default-project'
-      ]);
+      // Update project's updated_at timestamp - try both table types
+      try {
+        // Check if there's a prep project
+        const isPrepProject = db.exec('SELECT id FROM prep_projects LIMIT 1')[0]?.values[0]?.[0];
+
+        if (isPrepProject) {
+          // Update prep_projects table
+          db.run('UPDATE prep_projects SET updated_at = ? WHERE id = ?', [
+            Date.now(),
+            isPrepProject
+          ]);
+        } else {
+          // Update projects table
+          db.run('UPDATE projects SET updated_at = ? WHERE id = ?', [
+            Date.now(),
+            'default-project'
+          ]);
+        }
+      } catch (error) {
+        // Ignore update errors, continue with export
+      }
 
       // Export database as binary
       const data = db.export();
@@ -136,7 +150,7 @@ class FileService {
   }
 
   /**
-   * Import ShowStack file (.ssp, .ssm, or .ssd) and replace current database
+   * Import ShowStack file (.ss or legacy formats) and replace current database
    * @param filePath Source file path
    * @returns Import result
    */
@@ -166,10 +180,25 @@ class FileService {
       const SQL = await initSqlJs();
       const importedDb = new SQL.Database(buffer);
 
-      // Query project info
-      const projectResult = importedDb.exec('SELECT id, name FROM projects LIMIT 1');
-      const projectId = projectResult[0]?.values[0]?.[0] as string || 'default-project';
-      let projectName = projectResult[0]?.values[0]?.[1] as string || 'Untitled Project';
+      // Query project info - try both prep_projects and projects tables
+      let projectId = 'default-project';
+      let projectName = 'Untitled Project';
+
+      try {
+        // First try prep_projects table (for Prep module files)
+        const prepResult = importedDb.exec('SELECT id, production_name FROM prep_projects LIMIT 1');
+        if (prepResult[0]?.values[0]?.[0]) {
+          projectId = prepResult[0].values[0][0] as string;
+          projectName = prepResult[0].values[0][1] as string || 'Untitled Project';
+        } else {
+          // Fall back to projects table (for Production/Manager files)
+          const projectResult = importedDb.exec('SELECT id, name FROM projects LIMIT 1');
+          projectId = projectResult[0]?.values[0]?.[0] as string || 'default-project';
+          projectName = projectResult[0]?.values[0]?.[1] as string || 'Untitled Project';
+        }
+      } catch (error) {
+        // Use defaults if we can't get project info
+      }
 
       // Close the temporary database
       importedDb.close();
@@ -188,12 +217,30 @@ class FileService {
 
         // Update the project name in the database
         const db = getDatabase();
-        db.run('UPDATE projects SET name = ?, updated_at = ? WHERE id = ?', [
-          projectName,
-          Date.now(),
-          projectId
-        ]);
-        saveDatabase();
+
+        // Determine if this is a prep project or regular project
+        try {
+          const isPrepProject = db.exec('SELECT id FROM prep_projects LIMIT 1')[0]?.values[0]?.[0];
+
+          if (isPrepProject) {
+            // Update prep_projects table
+            db.run('UPDATE prep_projects SET production_name = ?, updated_at = ? WHERE id = ?', [
+              projectName,
+              Date.now(),
+              projectId
+            ]);
+          } else {
+            // Update projects table
+            db.run('UPDATE projects SET name = ?, updated_at = ? WHERE id = ?', [
+              projectName,
+              Date.now(),
+              projectId
+            ]);
+          }
+          saveDatabase();
+        } catch (error) {
+          // Ignore update errors
+        }
       }
 
       return {
@@ -241,7 +288,7 @@ class FileService {
   }
 
   /**
-   * Validate ShowStack file format (.ssp, .ssm, or .ssd)
+   * Validate ShowStack file format (.ss or legacy formats)
    * @param filePath File to validate
    * @returns Validation result
    */
@@ -284,11 +331,18 @@ class FileService {
         };
       }
 
-      // Get project info
+      // Get project info - try both prep_projects and projects tables
       let projectName = 'Unknown Project';
       try {
-        const projectResult = db.exec('SELECT name FROM projects LIMIT 1');
-        projectName = projectResult[0]?.values[0]?.[0] as string || 'Unknown Project';
+        // First try prep_projects table (for Prep module files)
+        const prepResult = db.exec('SELECT production_name FROM prep_projects LIMIT 1');
+        if (prepResult[0]?.values[0]?.[0]) {
+          projectName = prepResult[0].values[0][0] as string;
+        } else {
+          // Fall back to projects table (for Production/Manager files)
+          const projectResult = db.exec('SELECT name FROM projects LIMIT 1');
+          projectName = projectResult[0]?.values[0]?.[0] as string || 'Unknown Project';
+        }
       } catch (error) {
         // Ignore if we can't get project name
       }

--- a/src/main/services/prepFileService.ts
+++ b/src/main/services/prepFileService.ts
@@ -33,13 +33,13 @@ class PrepFileService {
   private readonly VERSION = '1.0.0';
 
   /**
-   * Show open file dialog for .ssd files
+   * Show open file dialog for ShowStack files (.ss and legacy .ssd)
    */
   async showOpenDialog(): Promise<string | null> {
     const result = await dialog.showOpenDialog({
       title: 'Open Shop Order',
       filters: [
-        { name: 'ShowStack Design Files', extensions: ['ssd'] },
+        { name: 'ShowStack Files', extensions: ['ss', 'ssd'] },
         { name: 'All Files', extensions: ['*'] }
       ],
       properties: ['openFile']
@@ -53,14 +53,14 @@ class PrepFileService {
   }
 
   /**
-   * Show save file dialog for .ssd files
+   * Show save file dialog for ShowStack files (.ss)
    */
   async showSaveDialog(defaultName?: string): Promise<string | null> {
     const result = await dialog.showSaveDialog({
       title: 'Save Shop Order',
       defaultPath: defaultName || 'Shop Order',
       filters: [
-        { name: 'ShowStack Design Files', extensions: ['ssd'] },
+        { name: 'ShowStack Files', extensions: ['ss'] },
         { name: 'All Files', extensions: ['*'] }
       ]
     });
@@ -69,17 +69,17 @@ class PrepFileService {
       return null;
     }
 
-    // Ensure .ssd extension
+    // Ensure .ss extension
     let filePath = result.filePath;
-    if (!filePath.endsWith('.ssd')) {
-      filePath += '.ssd';
+    if (!filePath.endsWith('.ss') && !filePath.endsWith('.ssd')) {
+      filePath += '.ss';
     }
 
     return filePath;
   }
 
   /**
-   * Export prep project to .ssd file
+   * Export prep project to ShowStack file (.ss)
    */
   async exportProject(projectId: string, filePath: string): Promise<void> {
     try {
@@ -114,7 +114,7 @@ class PrepFileService {
   }
 
   /**
-   * Import prep project from .ssd file
+   * Import prep project from ShowStack file (.ss or legacy .ssd)
    */
   async importProject(filePath: string): Promise<PrepFileResult> {
     try {
@@ -215,12 +215,12 @@ class PrepFileService {
   }
 
   /**
-   * Get filename without extension
+   * Get filename without extension (supports .ss and legacy .ssd)
    */
   getFileName(filePath: string): string {
     const parts = filePath.split(/[\\/]/);
     const filename = parts[parts.length - 1];
-    return filename.replace(/\.ssd$/, '');
+    return filename.replace(/\.(ss|ssd)$/, '');
   }
 }
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -19,6 +19,8 @@ export default function App() {
         {/* Project-based routes */}
         <Route path="/project/:projectId" element={<ProjectPage />} />
         <Route path="/project/:projectId/module/production/system-docs" element={<SystemDocs />} />
+        <Route path="/project/:projectId/module/production" element={<Navigate to="system-docs" replace />} />
+        <Route path="/project/:projectId/module/design" element={<Navigate to="prep" replace />} />
         <Route path="/project/:projectId/module/prep" element={<Prep />} />
         <Route path="/project/:projectId/module/manager" element={<Manager />} />
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -2,7 +2,6 @@ import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-d
 import { Login } from './pages/Login';
 import { LandingPage } from './pages/LandingPage';
 import { ProjectPage } from './pages/ProjectPage';
-import { ModuleLanding } from './pages/ModuleLanding';
 import { Prep } from './pages/modules/Prep';
 import { SystemDocs } from './pages/modules/SystemDocs';
 import { Manager } from './pages/modules/Manager';
@@ -19,16 +18,16 @@ export default function App() {
 
         {/* Project-based routes */}
         <Route path="/project/:projectId" element={<ProjectPage />} />
-        <Route path="/project/:projectId/module/:moduleType" element={<ModuleLanding />} />
         <Route path="/project/:projectId/module/production/system-docs" element={<SystemDocs />} />
         <Route path="/project/:projectId/module/prep" element={<Prep />} />
         <Route path="/project/:projectId/module/manager" element={<Manager />} />
 
         {/* Direct module access (no project) */}
-        <Route path="/module/:moduleType" element={<ModuleLanding />} />
         <Route path="/module/production/system-docs" element={<SystemDocs />} />
         <Route path="/module/prep" element={<Prep />} />
         <Route path="/module/manager" element={<Manager />} />
+        <Route path="/module/production" element={<Navigate to="/module/production/system-docs" replace />} />
+        <Route path="/module/design" element={<Navigate to="/module/prep" replace />} />
 
         {/* Backwards compatibility - redirect old routes */}
         <Route path="/modules" element={<LandingPage />} />

--- a/src/renderer/src/pages/LandingPage.tsx
+++ b/src/renderer/src/pages/LandingPage.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { ModuleCard } from '../components/common/ModuleCard';
 import { NewProjectDialog } from '../components/common/NewProjectDialog';
 import { DeleteProjectDialog } from '../components/common/DeleteProjectDialog';
 import { useProjectStore, Project } from '../store/projectStore';
@@ -82,7 +81,7 @@ export function LandingPage() {
                     const { openFile } = useFileStore.getState();
                     await openFile(async () => {
                       await loadProjects();
-                      navigate('/modules/production');
+                      // Stay on landing page after opening file
                     });
                   }}
                   className="px-6 py-3 bg-gray-700 hover:bg-gray-600 rounded-lg font-medium transition flex items-center gap-2"
@@ -223,40 +222,6 @@ export function LandingPage() {
                 </button>
               </div>
             )}
-          </div>
-
-          {/* Modules Section */}
-          <div>
-            <div className="mb-6">
-              <h2 className="text-2xl font-bold mb-2">Modules</h2>
-              <p className="text-gray-400">Available tools in your subscription</p>
-            </div>
-
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              <ModuleCard
-                name="ShowStack:Prep"
-                description="Equipment orders and specifications for rental houses"
-                icon="📋"
-                route="/modules/prep"
-                isLocked={false}
-              />
-
-              <ModuleCard
-                name="ShowStack:Production"
-                description="Production management, fixtures, and technical planning"
-                icon="🎬"
-                route="/modules/production"
-                isLocked={false}
-              />
-
-              <ModuleCard
-                name="ShowStack:Manager"
-                description="Tour management, scheduling, and logistics"
-                icon="🚐"
-                route="/modules/manager"
-                isLocked={true}
-              />
-            </div>
           </div>
         </div>
       </main>

--- a/src/renderer/src/pages/modules/Prep.tsx
+++ b/src/renderer/src/pages/modules/Prep.tsx
@@ -711,7 +711,7 @@ export function Prep() {
                     {currentProject.parent_project_id ? (
                       <div className="flex items-center gap-2">
                         <span className="text-gray-300">
-                          {projects.find(p => p.id === currentProject.parent_project_id)?.production_name || 'Unknown Project'}
+                          {projects.find(p => p.id === currentProject.parent_project_id)?.name || 'Unknown Project'}
                         </span>
                         <button
                           onClick={handleUnlinkFromParent}

--- a/src/renderer/src/store/fileStore.ts
+++ b/src/renderer/src/store/fileStore.ts
@@ -57,8 +57,8 @@ export const useFileStore = create<FileStore>((set, get) => ({
     // Extract filename from path locally (works cross-platform)
     const parts = currentFilePath.replace(/\\/g, '/').split('/');
     const filename = parts[parts.length - 1];
-    // Remove any ShowStack extension (.ssp, .ssm, .ssd, or legacy .showstack)
-    return filename.replace(/\.(ssp|ssm|ssd|showstack)$/, '');
+    // Remove any ShowStack extension (.ss, or legacy .ssp, .ssm, .ssd, .showstack)
+    return filename.replace(/\.(ss|ssp|ssm|ssd|showstack)$/, '');
   },
 
   // Open file
@@ -267,8 +267,8 @@ export const useFileStore = create<FileStore>((set, get) => ({
       // Extract new filename and update project name in database
       const parts = filePath.replace(/\\/g, '/').split('/');
       const filename = parts[parts.length - 1];
-      // Remove any ShowStack extension (.ssp, .ssm, .ssd, or legacy .showstack)
-      const newProjectName = filename.replace(/\.(ssp|ssm|ssd|showstack)$/, '');
+      // Remove any ShowStack extension (.ss, or legacy .ssp, .ssm, .ssd, .showstack)
+      const newProjectName = filename.replace(/\.(ss|ssp|ssm|ssd|showstack)$/, '');
 
       // Update project name in database
       if (window.api?.projects) {

--- a/src/renderer/src/store/prepFileStore.ts
+++ b/src/renderer/src/store/prepFileStore.ts
@@ -53,7 +53,7 @@ export const usePrepFileStore = create<PrepFileStore>((set, get) => ({
       // Extract filename from path
       const parts = currentFilePath.replace(/\\/g, '/').split('/');
       const filename = parts[parts.length - 1];
-      return filename.replace(/\.ssd$/, '');
+      return filename.replace(/\.(ss|ssd)$/, '');
     }
     return currentFileName;
   },

--- a/src/renderer/src/utils/recentFiles.ts
+++ b/src/renderer/src/utils/recentFiles.ts
@@ -109,9 +109,13 @@ export async function clearRecentFiles(moduleType?: ModuleType): Promise<void> {
 }
 
 /**
- * Determine module type from file extension
+ * Determine module type from file extension (supports both .ss and legacy extensions)
  */
 export function getModuleTypeFromPath(filePath: string): ModuleType | undefined {
+  // New unified format - module type will be determined from database contents
+  if (filePath.endsWith('.ss')) return undefined;
+
+  // Legacy formats
   if (filePath.endsWith('.ssp')) return 'production';
   if (filePath.endsWith('.ssm')) return 'manager';
   if (filePath.endsWith('.ssd')) return 'design';


### PR DESCRIPTION
## Summary

This PR addresses three major issues in the prep module and implements significant improvements to the file system and navigation:

### 1. 🎯 Unified File Extension (.ss)
- **Changed from module-specific extensions** (`.ssp`, `.ssm`, `.ssd`) to a **single `.ss` extension** for all ShowStack files
- **Backward compatibility maintained** - all legacy formats can still be opened
- **Updated services:**
  - `fileService.ts` - Main file operations
  - `prepFileService.ts` - Prep-specific file operations
  - `fileStore.ts` & `prepFileStore.ts` - Frontend stores
  - `recentFiles.ts` - File extension detection

### 2. 🐛 Fixed "Unknown Project" Bug
- **Root cause:** File validation was only querying `projects` table, but prep files use `prep_projects` table
- **Solution:** Added table detection logic:
  - Prep files: Query `prep_projects.production_name`
  - Production/Manager files: Query `projects.name`
- **Fixed in:**
  - `fileService.ts` - `validateFile()`, `importProject()`, `exportProject()`
  - `Prep.tsx` - Parent project name display (line 714)

### 3. 🚀 Streamlined Navigation
- **Removed redundant "Modules" section** from landing page
- **Eliminated ModuleLanding** intermediate page
- **Direct routing** from projects to module tools
- **Reduced click paths:**
  - Before: Home → Modules → Module Type → Project List → Project → Work (4-5 clicks)
  - After: Home → Project → Work (1-2 clicks)
- **Added route redirects:**
  - `/project/:projectId/module/production` → `system-docs`
  - `/project/:projectId/module/design` → `prep`

### 4. ✅ Additional Fixes
- Fixed Production module routing from ProjectPage
- Fixed parent project display showing "Unknown Project"
- Merged all recent features from develop branch

## Files Changed

**Backend Services:**
- `src/main/services/fileService.ts` - Unified extension & table detection
- `src/main/services/prepFileService.ts` - Updated for .ss extension

**Frontend:**
- `src/renderer/src/App.tsx` - Streamlined routing
- `src/renderer/src/pages/LandingPage.tsx` - Removed Modules section
- `src/renderer/src/pages/modules/Prep.tsx` - Fixed parent project display
- `src/renderer/src/store/fileStore.ts` - Extension pattern updates
- `src/renderer/src/store/prepFileStore.ts` - Extension pattern updates
- `src/renderer/src/utils/recentFiles.ts` - Added .ss support

## Testing

- ✅ Legacy .ssp, .ssm, .ssd files can be opened
- ✅ New files save as .ss
- ✅ Linked prep projects display correct parent name
- ✅ Navigation from ProjectPage to Production module works
- ✅ Direct module access works
- ✅ File validation correctly identifies prep vs production files

## Breaking Changes

None - full backward compatibility maintained for legacy file formats.

## Commits

- `07829d3` feat: Unify file extensions and streamline navigation
- `ad88252` Merge remote-tracking branch 'origin/develop'
- `8910a64` fix: Update prepFileService to use unified .ss extension
- `f8e9a66` fix: Fix 'Unknown Project' display and Production module routing