### PR TITLE
feat: Cross-Platform Keyboard Shortcuts & PR Review Improvements

### DIFF
--- a/src/renderer/src/components/prep/layout/CommandPalette.tsx
+++ b/src/renderer/src/components/prep/layout/CommandPalette.tsx
@@ -1,11 +1,12 @@
 import { useState, useEffect, useRef, useMemo } from 'react';
+import { formatShortcut } from '../../../hooks/usePlatform';
 
 export interface Command {
   id: string;
   label: string;
   description?: string;
   category: string;
-  shortcut?: string;
+  shortcut?: string; // Use "Mod" for modifier key (e.g., "Mod+S")
   action: () => void;
   icon?: string;
 }
@@ -246,7 +247,7 @@ export function CommandPalette({ isOpen, onClose, commands }: CommandPaletteProp
                                 ? 'bg-blue-700 text-blue-100'
                                 : 'bg-gray-700 text-gray-400'
                             }`}>
-                              {command.shortcut}
+                              {formatShortcut(command.shortcut)}
                             </div>
                           )}
                         </button>

--- a/src/renderer/src/components/prep/layout/KeyboardShortcutsHelp.tsx
+++ b/src/renderer/src/components/prep/layout/KeyboardShortcutsHelp.tsx
@@ -155,7 +155,7 @@ export function KeyboardShortcutsHelp({ isOpen, onClose }: KeyboardShortcutsHelp
         {/* Footer */}
         <div className="p-4 border-t border-gray-700 flex items-center justify-between">
           <div className="text-xs text-gray-500">
-            Press <kbd className="px-2 py-0.5 bg-gray-700 border border-gray-600 rounded text-xs font-mono">Cmd+/</kbd> anytime to view this help
+            Press <kbd className="px-2 py-0.5 bg-gray-700 border border-gray-600 rounded text-xs font-mono">{formatShortcut('Mod+/')}</kbd> anytime to view this help
           </div>
           <button
             onClick={onClose}

--- a/src/renderer/src/components/prep/layout/KeyboardShortcutsHelp.tsx
+++ b/src/renderer/src/components/prep/layout/KeyboardShortcutsHelp.tsx
@@ -1,7 +1,9 @@
+import { formatShortcut } from '../../../hooks/usePlatform';
+
 interface ShortcutGroup {
   category: string;
   shortcuts: {
-    keys: string;
+    keys: string; // Use "Mod" for modifier key (e.g., "Mod+S")
     description: string;
   }[];
 }
@@ -10,19 +12,19 @@ const shortcutGroups: ShortcutGroup[] = [
   {
     category: 'General',
     shortcuts: [
-      { keys: 'Cmd+K', description: 'Open command palette' },
-      { keys: 'Cmd+/', description: 'Show keyboard shortcuts' },
-      { keys: 'Cmd+S', description: 'Save template' },
-      { keys: 'Cmd+P', description: 'Toggle preview mode' },
+      { keys: 'Mod+K', description: 'Open command palette' },
+      { keys: 'Mod+/', description: 'Show keyboard shortcuts' },
+      { keys: 'Mod+S', description: 'Save template' },
+      { keys: 'Mod+P', description: 'Toggle preview mode' },
       { keys: 'ESC', description: 'Deselect / Close' }
     ]
   },
   {
     category: 'Editing',
     shortcuts: [
-      { keys: 'Cmd+Z', description: 'Undo' },
-      { keys: 'Cmd+Shift+Z', description: 'Redo' },
-      { keys: 'Cmd+D', description: 'Duplicate element' },
+      { keys: 'Mod+Z', description: 'Undo' },
+      { keys: 'Mod+Shift+Z', description: 'Redo' },
+      { keys: 'Mod+D', description: 'Duplicate element' },
       { keys: 'Delete', description: 'Delete selected element' },
       { keys: 'Backspace', description: 'Delete selected element' }
     ]
@@ -30,22 +32,22 @@ const shortcutGroups: ShortcutGroup[] = [
   {
     category: 'Text Formatting',
     shortcuts: [
-      { keys: 'Cmd+B', description: 'Bold' },
-      { keys: 'Cmd+I', description: 'Italic' },
-      { keys: 'Cmd+U', description: 'Underline' },
-      { keys: 'Cmd+Shift+L', description: 'Align left' },
-      { keys: 'Cmd+Shift+E', description: 'Align center' },
-      { keys: 'Cmd+Shift+R', description: 'Align right' }
+      { keys: 'Mod+B', description: 'Bold' },
+      { keys: 'Mod+I', description: 'Italic' },
+      { keys: 'Mod+U', description: 'Underline' },
+      { keys: 'Mod+Shift+L', description: 'Align left' },
+      { keys: 'Mod+Shift+E', description: 'Align center' },
+      { keys: 'Mod+Shift+R', description: 'Align right' }
     ]
   },
   {
     category: 'Canvas',
     shortcuts: [
-      { keys: 'Cmd++', description: 'Zoom in' },
-      { keys: 'Cmd+-', description: 'Zoom out' },
-      { keys: 'Cmd+0', description: 'Reset zoom to 100%' },
-      { keys: 'Cmd+G', description: 'Toggle grid' },
-      { keys: 'Cmd+Shift+G', description: 'Toggle snap guides' }
+      { keys: 'Mod++', description: 'Zoom in' },
+      { keys: 'Mod+-', description: 'Zoom out' },
+      { keys: 'Mod+0', description: 'Reset zoom to 100%' },
+      { keys: 'Mod+G', description: 'Toggle grid' },
+      { keys: 'Mod+Shift+G', description: 'Toggle snap guides' }
     ]
   },
   {
@@ -131,7 +133,7 @@ export function KeyboardShortcutsHelp({ isOpen, onClose }: KeyboardShortcutsHelp
                         {shortcut.description}
                       </span>
                       <div className="flex items-center gap-1">
-                        {shortcut.keys.split('+').map((key, keyIndex) => (
+                        {formatShortcut(shortcut.keys).split('+').map((key, keyIndex) => (
                           <span key={keyIndex} className="flex items-center gap-1">
                             {keyIndex > 0 && (
                               <span className="text-gray-500 text-xs">+</span>

--- a/src/renderer/src/components/prep/layout/LayoutDesigner.tsx
+++ b/src/renderer/src/components/prep/layout/LayoutDesigner.tsx
@@ -67,7 +67,7 @@ export function LayoutDesigner({
   });
 
   // Platform detection for keyboard shortcuts
-  const { modifierKey } = usePlatform();
+  const { modifierKey, isMac } = usePlatform();
 
   const [selectedElementId, setSelectedElementId] = useState<string | null>(null);
   const [draggedPaletteElement, setDraggedPaletteElement] = useState<any>(null);
@@ -384,7 +384,6 @@ export function LayoutDesigner({
   // Keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
       const modifier = isMac ? e.metaKey : e.ctrlKey;
 
       // Command Palette: Cmd+K
@@ -566,6 +565,7 @@ export function LayoutDesigner({
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [
+    isMac,
     hasChanges,
     handleSave,
     previewMode,

--- a/src/renderer/src/components/prep/layout/LayoutDesigner.tsx
+++ b/src/renderer/src/components/prep/layout/LayoutDesigner.tsx
@@ -382,6 +382,7 @@ export function LayoutDesigner({
   }, [template.elements, template.updated_at]);
 
   // Keyboard shortcuts
+  // Note: isMac is not in dependency array as it never changes during runtime (cached in usePlatform hook)
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       const modifier = isMac ? e.metaKey : e.ctrlKey;
@@ -565,7 +566,6 @@ export function LayoutDesigner({
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [
-    isMac,
     hasChanges,
     handleSave,
     previewMode,

--- a/src/renderer/src/components/prep/layout/LayoutDesigner.tsx
+++ b/src/renderer/src/components/prep/layout/LayoutDesigner.tsx
@@ -5,6 +5,7 @@ import { LayoutCanvas } from './LayoutCanvas';
 import { ElementInspector } from './ElementInspector';
 import { CommandPalette, type Command } from './CommandPalette';
 import { KeyboardShortcutsHelp } from './KeyboardShortcutsHelp';
+import { usePlatform } from '../../../hooks/usePlatform';
 import type {
   PageLayoutTemplate,
   LayoutElement,
@@ -64,6 +65,9 @@ export function LayoutDesigner({
       updated_at: now
     };
   });
+
+  // Platform detection for keyboard shortcuts
+  const { modifierKey } = usePlatform();
 
   const [selectedElementId, setSelectedElementId] = useState<string | null>(null);
   const [draggedPaletteElement, setDraggedPaletteElement] = useState<any>(null);
@@ -583,7 +587,7 @@ export function LayoutDesigner({
       label: 'Save Template',
       description: 'Save the current layout template',
       category: 'General',
-      shortcut: 'Cmd+S',
+      shortcut: 'Mod+S',
       icon: '💾',
       action: () => hasChanges && handleSave()
     },
@@ -592,7 +596,7 @@ export function LayoutDesigner({
       label: previewMode ? 'Exit Preview Mode' : 'Enter Preview Mode',
       description: 'Toggle between edit and preview modes',
       category: 'General',
-      shortcut: 'Cmd+P',
+      shortcut: 'Mod+P',
       icon: '👁️',
       action: () => setPreviewMode(!previewMode)
     },
@@ -601,7 +605,7 @@ export function LayoutDesigner({
       label: 'Show Keyboard Shortcuts',
       description: 'View all available keyboard shortcuts',
       category: 'General',
-      shortcut: 'Cmd+/',
+      shortcut: 'Mod+/',
       icon: '⌨️',
       action: () => setShowShortcutsHelp(true)
     },
@@ -620,7 +624,7 @@ export function LayoutDesigner({
       label: 'Undo',
       description: 'Undo the last change',
       category: 'Editing',
-      shortcut: 'Cmd+Z',
+      shortcut: 'Mod+Z',
       icon: '↶',
       action: handleUndo
     },
@@ -629,7 +633,7 @@ export function LayoutDesigner({
       label: 'Redo',
       description: 'Redo the last undone change',
       category: 'Editing',
-      shortcut: 'Cmd+Shift+Z',
+      shortcut: 'Mod+Shift+Z',
       icon: '↷',
       action: handleRedo
     },
@@ -638,7 +642,7 @@ export function LayoutDesigner({
       label: 'Duplicate Element',
       description: 'Duplicate the selected element',
       category: 'Editing',
-      shortcut: 'Cmd+D',
+      shortcut: 'Mod+D',
       icon: '📋',
       action: () => {
         if (selectedElementId) {
@@ -680,7 +684,7 @@ export function LayoutDesigner({
       label: 'Zoom In',
       description: 'Increase canvas zoom',
       category: 'Canvas',
-      shortcut: 'Cmd++',
+      shortcut: 'Mod++',
       icon: '🔍',
       action: () => setZoom(Math.min(200, zoom + 10))
     },
@@ -689,7 +693,7 @@ export function LayoutDesigner({
       label: 'Zoom Out',
       description: 'Decrease canvas zoom',
       category: 'Canvas',
-      shortcut: 'Cmd+-',
+      shortcut: 'Mod+-',
       icon: '🔍',
       action: () => setZoom(Math.max(50, zoom - 10))
     },
@@ -698,7 +702,7 @@ export function LayoutDesigner({
       label: 'Reset Zoom',
       description: 'Reset zoom to 100%',
       category: 'Canvas',
-      shortcut: 'Cmd+0',
+      shortcut: 'Mod+0',
       icon: '🔍',
       action: () => setZoom(100)
     },
@@ -707,7 +711,7 @@ export function LayoutDesigner({
       label: showGrid ? 'Hide Grid' : 'Show Grid',
       description: 'Toggle grid visibility',
       category: 'Canvas',
-      shortcut: 'Cmd+G',
+      shortcut: 'Mod+G',
       icon: '⊞',
       action: () => setShowGrid(!showGrid)
     },
@@ -716,7 +720,7 @@ export function LayoutDesigner({
       label: snapEnabled ? 'Disable Snap Guides' : 'Enable Snap Guides',
       description: 'Toggle snap-to-element guides',
       category: 'Canvas',
-      shortcut: 'Cmd+Shift+G',
+      shortcut: 'Mod+Shift+G',
       icon: '📍',
       action: () => setSnapEnabled(!snapEnabled)
     },
@@ -1130,11 +1134,11 @@ export function LayoutDesigner({
         <div className="text-sm text-gray-400">
           {previewMode ? (
             <>
-              <span className="font-medium text-green-400">Preview Mode</span> • Press <kbd className="px-2 py-0.5 bg-gray-700 border border-gray-600 rounded text-xs font-mono">Cmd+P</kbd> to exit
+              <span className="font-medium text-green-400">Preview Mode</span> • Press <kbd className="px-2 py-0.5 bg-gray-700 border border-gray-600 rounded text-xs font-mono">{modifierKey}+P</kbd> to exit
             </>
           ) : (
             <>
-              <span className="font-medium">Tip:</span> Press <kbd className="px-2 py-0.5 bg-gray-700 border border-gray-600 rounded text-xs font-mono">Cmd+K</kbd> for commands or <kbd className="px-2 py-0.5 bg-gray-700 border border-gray-600 rounded text-xs font-mono">Cmd+/</kbd> for shortcuts
+              <span className="font-medium">Tip:</span> Press <kbd className="px-2 py-0.5 bg-gray-700 border border-gray-600 rounded text-xs font-mono">{modifierKey}+K</kbd> for commands or <kbd className="px-2 py-0.5 bg-gray-700 border border-gray-600 rounded text-xs font-mono">{modifierKey}+/</kbd> for shortcuts
             </>
           )}
         </div>

--- a/src/renderer/src/components/prep/layout/LayoutDesigner.tsx
+++ b/src/renderer/src/components/prep/layout/LayoutDesigner.tsx
@@ -382,7 +382,6 @@ export function LayoutDesigner({
   }, [template.elements, template.updated_at]);
 
   // Keyboard shortcuts
-  // Note: isMac is not in dependency array as it never changes during runtime (cached in usePlatform hook)
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       const modifier = isMac ? e.metaKey : e.ctrlKey;
@@ -566,6 +565,7 @@ export function LayoutDesigner({
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [
+    isMac,
     hasChanges,
     handleSave,
     previewMode,

--- a/src/renderer/src/components/prep/layout/LayoutDesigner.tsx
+++ b/src/renderer/src/components/prep/layout/LayoutDesigner.tsx
@@ -412,7 +412,7 @@ export function LayoutDesigner({
       // Preview Mode: Cmd+P
       if (modifier && e.key === 'p') {
         e.preventDefault();
-        setPreviewMode(!previewMode);
+        setPreviewMode(prev => !prev);
         return;
       }
 
@@ -460,14 +460,14 @@ export function LayoutDesigner({
       // Zoom In: Cmd++
       if (modifier && (e.key === '+' || e.key === '=')) {
         e.preventDefault();
-        setZoom(Math.min(200, zoom + 10));
+        setZoom(prev => Math.min(200, prev + 10));
         return;
       }
 
       // Zoom Out: Cmd+-
       if (modifier && e.key === '-') {
         e.preventDefault();
-        setZoom(Math.max(50, zoom - 10));
+        setZoom(prev => Math.max(50, prev - 10));
         return;
       }
 
@@ -481,14 +481,14 @@ export function LayoutDesigner({
       // Toggle Grid: Cmd+G
       if (modifier && e.key === 'g' && !e.shiftKey) {
         e.preventDefault();
-        setShowGrid(!showGrid);
+        setShowGrid(prev => !prev);
         return;
       }
 
       // Toggle Snap Guides: Cmd+Shift+G
       if (modifier && e.shiftKey && e.key === 'g') {
         e.preventDefault();
-        setSnapEnabled(!snapEnabled);
+        setSnapEnabled(prev => !prev);
         return;
       }
 
@@ -568,14 +568,10 @@ export function LayoutDesigner({
     isMac,
     hasChanges,
     handleSave,
-    previewMode,
     handleUndo,
     handleRedo,
     selectedElementId,
     template,
-    zoom,
-    showGrid,
-    snapEnabled,
     handleElementUpdate
   ]);
 

--- a/src/renderer/src/hooks/usePlatform.ts
+++ b/src/renderer/src/hooks/usePlatform.ts
@@ -9,6 +9,26 @@ export interface PlatformInfo {
 }
 
 /**
+ * Internal helper to detect the current platform.
+ * Uses modern userAgentData API when available, with fallback to deprecated APIs.
+ *
+ * Note: Platform detection is cached per session as the platform won't change during runtime.
+ */
+function detectPlatform() {
+  // @ts-expect-error - userAgentData is experimental and not yet in TS DOM types
+  const userAgentData = navigator.userAgentData;
+  const platformString = userAgentData?.platform || navigator.platform || '';
+  const platform = platformString.toUpperCase();
+  const userAgent = (navigator.userAgent || '').toUpperCase();
+
+  const isMac = platform.includes('MAC') || userAgent.includes('MAC');
+  const isWindows = platform.includes('WIN') || userAgent.includes('WIN');
+  const isLinux = platform.includes('LINUX') || userAgent.includes('LINUX');
+
+  return { isMac, isWindows, isLinux };
+}
+
+/**
  * Hook to detect the current platform and provide platform-specific information.
  * Useful for displaying correct keyboard shortcuts across different operating systems.
  *
@@ -20,16 +40,8 @@ export interface PlatformInfo {
  */
 export function usePlatform(): PlatformInfo {
   return useMemo(() => {
-    // Use modern userAgentData API if available, otherwise fall back to deprecated platform/userAgent
-    // @ts-ignore - userAgentData is not yet in TypeScript DOM types
-    const userAgentData = navigator.userAgentData;
-    const platformString = userAgentData?.platform || navigator.platform;
-    const platform = platformString.toUpperCase();
-    const userAgent = navigator.userAgent.toUpperCase();
-
-    const isMac = platform.includes('MAC') || userAgent.includes('MAC');
-    const isWindows = platform.includes('WIN') || userAgent.includes('WIN');
-    const isLinux = platform.includes('LINUX') || userAgent.includes('LINUX');
+    // Platform won't change during session, so empty dependency array is safe
+    const { isMac, isWindows, isLinux } = detectPlatform();
 
     return {
       isMac,
@@ -53,12 +65,7 @@ export function usePlatform(): PlatformInfo {
  * formatShortcut("Mod+S", true) // Returns "⌘+S" on Mac, "Ctrl+S" on Windows
  */
 export function formatShortcut(shortcut: string, useSymbol = false): string {
-  // Use modern userAgentData API if available, otherwise fall back to deprecated platform
-  // @ts-ignore - userAgentData is not yet in TypeScript DOM types
-  const userAgentData = navigator.userAgentData;
-  const platformString = userAgentData?.platform || navigator.platform;
-  const platform = platformString.toUpperCase();
-  const isMac = platform.includes('MAC');
+  const { isMac } = detectPlatform();
   const modifier = useSymbol && isMac ? '⌘' : (isMac ? 'Cmd' : 'Ctrl');
 
   return shortcut.replace(/Mod/g, modifier);

--- a/src/renderer/src/hooks/usePlatform.ts
+++ b/src/renderer/src/hooks/usePlatform.ts
@@ -5,10 +5,15 @@ export interface PlatformInfo {
   isWindows: boolean;
   isLinux: boolean;
   modifierKey: 'Cmd' | 'Ctrl';
-  modifierSymbol: '⌘' | 'Ctrl';
+  modifierSymbol: '⌘' | 'Ctrl'; // Note: Symbol version available for UI that prefers visual clarity
 }
 
 type PlatformFlags = Pick<PlatformInfo, 'isMac' | 'isWindows' | 'isLinux'>;
+
+// Platform identifier constants for consistent detection
+const MAC_IDENTIFIERS = ['MAC'];
+const WINDOWS_IDENTIFIERS = ['WIN'];
+const LINUX_IDENTIFIERS = ['LINUX'];
 
 // Module-level cache for platform detection
 // Platform won't change during runtime, so we can safely cache this
@@ -24,15 +29,15 @@ let cachedPlatform: PlatformFlags | null = null;
 function detectPlatform(): PlatformFlags {
   if (cachedPlatform) return cachedPlatform;
 
-  // @ts-expect-error - userAgentData is experimental and not yet in TS DOM types
+  // @ts-expect-error - userAgentData is experimental; remove when added to TS DOM lib types
   const userAgentData = navigator.userAgentData;
   const platformString = userAgentData?.platform || navigator.platform || '';
   const platform = platformString.toUpperCase();
   const userAgent = (navigator.userAgent || '').toUpperCase();
 
-  const isMac = platform.includes('MAC') || userAgent.includes('MAC');
-  const isWindows = platform.includes('WIN') || userAgent.includes('WIN');
-  const isLinux = platform.includes('LINUX') || userAgent.includes('LINUX');
+  const isMac = MAC_IDENTIFIERS.some(id => platform.includes(id) || userAgent.includes(id));
+  const isWindows = WINDOWS_IDENTIFIERS.some(id => platform.includes(id) || userAgent.includes(id));
+  const isLinux = LINUX_IDENTIFIERS.some(id => platform.includes(id) || userAgent.includes(id));
 
   cachedPlatform = { isMac, isWindows, isLinux };
   return cachedPlatform;
@@ -74,6 +79,7 @@ export function usePlatform(): PlatformInfo {
  * @example
  * formatShortcut("Mod+S") // Returns "Cmd+S" on Mac, "Ctrl+S" on Windows
  * formatShortcut("Mod+S", true) // Returns "⌘+S" on Mac, "Ctrl+S" on Windows
+ * formatShortcut("mod+s") // Also works (case-insensitive)
  */
 export function formatShortcut(shortcut: string | undefined, useSymbol = false): string {
   if (!shortcut) return '';
@@ -83,5 +89,6 @@ export function formatShortcut(shortcut: string | undefined, useSymbol = false):
     ? (useSymbol ? '⌘' : 'Cmd')
     : 'Ctrl';
 
-  return shortcut.replace(/Mod/g, modifier);
+  // Use case-insensitive regex for robustness
+  return shortcut.replace(/Mod/gi, modifier);
 }

--- a/src/renderer/src/hooks/usePlatform.ts
+++ b/src/renderer/src/hooks/usePlatform.ts
@@ -69,15 +69,19 @@ export function usePlatform(): PlatformInfo {
  *
  * @param shortcut - Shortcut string with generic "Mod" prefix (e.g., "Mod+S", "Mod+Shift+Z")
  * @param useSymbol - Whether to use symbol (⌘) or text (Cmd) for Mac modifier
- * @returns Formatted shortcut string (e.g., "Cmd+S" on Mac, "Ctrl+S" on Windows)
+ * @returns Formatted shortcut string (e.g., "Cmd+S" on Mac, "Ctrl+S" on Windows), or empty string if input is invalid
  *
  * @example
  * formatShortcut("Mod+S") // Returns "Cmd+S" on Mac, "Ctrl+S" on Windows
  * formatShortcut("Mod+S", true) // Returns "⌘+S" on Mac, "Ctrl+S" on Windows
  */
-export function formatShortcut(shortcut: string, useSymbol = false): string {
+export function formatShortcut(shortcut: string | undefined, useSymbol = false): string {
+  if (!shortcut) return '';
+
   const { isMac } = detectPlatform();
-  const modifier = useSymbol && isMac ? '⌘' : (isMac ? 'Cmd' : 'Ctrl');
+  const modifier = isMac
+    ? (useSymbol ? '⌘' : 'Cmd')
+    : 'Ctrl';
 
   return shortcut.replace(/Mod/g, modifier);
 }

--- a/src/renderer/src/hooks/usePlatform.ts
+++ b/src/renderer/src/hooks/usePlatform.ts
@@ -1,0 +1,57 @@
+import { useMemo } from 'react';
+
+export interface PlatformInfo {
+  isMac: boolean;
+  isWindows: boolean;
+  isLinux: boolean;
+  modifierKey: 'Cmd' | 'Ctrl';
+  modifierSymbol: '⌘' | 'Ctrl';
+}
+
+/**
+ * Hook to detect the current platform and provide platform-specific information.
+ * Useful for displaying correct keyboard shortcuts across different operating systems.
+ *
+ * @returns PlatformInfo object with platform detection flags and modifier key information
+ *
+ * @example
+ * const { isMac, modifierKey } = usePlatform();
+ * return <kbd>{modifierKey}+S</kbd>; // Shows "Cmd+S" on Mac, "Ctrl+S" on Windows/Linux
+ */
+export function usePlatform(): PlatformInfo {
+  return useMemo(() => {
+    const platform = navigator.platform.toUpperCase();
+    const userAgent = navigator.userAgent.toUpperCase();
+
+    const isMac = platform.includes('MAC') || userAgent.includes('MAC');
+    const isWindows = platform.includes('WIN') || userAgent.includes('WIN');
+    const isLinux = platform.includes('LINUX') || userAgent.includes('LINUX');
+
+    return {
+      isMac,
+      isWindows,
+      isLinux,
+      modifierKey: isMac ? 'Cmd' : 'Ctrl',
+      modifierSymbol: isMac ? '⌘' : 'Ctrl'
+    };
+  }, []);
+}
+
+/**
+ * Utility function to format a keyboard shortcut for the current platform.
+ *
+ * @param shortcut - Shortcut string with generic "Mod" prefix (e.g., "Mod+S", "Mod+Shift+Z")
+ * @param useSymbol - Whether to use symbol (⌘) or text (Cmd) for Mac modifier
+ * @returns Formatted shortcut string (e.g., "Cmd+S" on Mac, "Ctrl+S" on Windows)
+ *
+ * @example
+ * formatShortcut("Mod+S") // Returns "Cmd+S" on Mac, "Ctrl+S" on Windows
+ * formatShortcut("Mod+S", true) // Returns "⌘+S" on Mac, "Ctrl+S" on Windows
+ */
+export function formatShortcut(shortcut: string, useSymbol = false): string {
+  const platform = navigator.platform.toUpperCase();
+  const isMac = platform.includes('MAC');
+  const modifier = useSymbol && isMac ? '⌘' : (isMac ? 'Cmd' : 'Ctrl');
+
+  return shortcut.replace(/Mod/g, modifier);
+}

--- a/src/renderer/src/hooks/usePlatform.ts
+++ b/src/renderer/src/hooks/usePlatform.ts
@@ -8,13 +8,22 @@ export interface PlatformInfo {
   modifierSymbol: '⌘' | 'Ctrl';
 }
 
+type PlatformFlags = Pick<PlatformInfo, 'isMac' | 'isWindows' | 'isLinux'>;
+
+// Module-level cache for platform detection
+// Platform won't change during runtime, so we can safely cache this
+let cachedPlatform: PlatformFlags | null = null;
+
 /**
  * Internal helper to detect the current platform.
  * Uses modern userAgentData API when available, with fallback to deprecated APIs.
  *
- * Note: Platform detection is cached per session as the platform won't change during runtime.
+ * Note: Platform detection is cached at module level as the platform won't change during runtime.
+ * This improves performance when formatShortcut() is called frequently.
  */
-function detectPlatform() {
+function detectPlatform(): PlatformFlags {
+  if (cachedPlatform) return cachedPlatform;
+
   // @ts-expect-error - userAgentData is experimental and not yet in TS DOM types
   const userAgentData = navigator.userAgentData;
   const platformString = userAgentData?.platform || navigator.platform || '';
@@ -25,7 +34,8 @@ function detectPlatform() {
   const isWindows = platform.includes('WIN') || userAgent.includes('WIN');
   const isLinux = platform.includes('LINUX') || userAgent.includes('LINUX');
 
-  return { isMac, isWindows, isLinux };
+  cachedPlatform = { isMac, isWindows, isLinux };
+  return cachedPlatform;
 }
 
 /**
@@ -33,6 +43,7 @@ function detectPlatform() {
  * Useful for displaying correct keyboard shortcuts across different operating systems.
  *
  * @returns PlatformInfo object with platform detection flags and modifier key information
+ * @note For unrecognized platforms (FreeBSD, ChromeOS, etc.), defaults to 'Ctrl' as the modifier key
  *
  * @example
  * const { isMac, modifierKey } = usePlatform();

--- a/src/renderer/src/hooks/usePlatform.ts
+++ b/src/renderer/src/hooks/usePlatform.ts
@@ -20,7 +20,11 @@ export interface PlatformInfo {
  */
 export function usePlatform(): PlatformInfo {
   return useMemo(() => {
-    const platform = navigator.platform.toUpperCase();
+    // Use modern userAgentData API if available, otherwise fall back to deprecated platform/userAgent
+    // @ts-ignore - userAgentData is not yet in TypeScript DOM types
+    const userAgentData = navigator.userAgentData;
+    const platformString = userAgentData?.platform || navigator.platform;
+    const platform = platformString.toUpperCase();
     const userAgent = navigator.userAgent.toUpperCase();
 
     const isMac = platform.includes('MAC') || userAgent.includes('MAC');
@@ -49,7 +53,11 @@ export function usePlatform(): PlatformInfo {
  * formatShortcut("Mod+S", true) // Returns "⌘+S" on Mac, "Ctrl+S" on Windows
  */
 export function formatShortcut(shortcut: string, useSymbol = false): string {
-  const platform = navigator.platform.toUpperCase();
+  // Use modern userAgentData API if available, otherwise fall back to deprecated platform
+  // @ts-ignore - userAgentData is not yet in TypeScript DOM types
+  const userAgentData = navigator.userAgentData;
+  const platformString = userAgentData?.platform || navigator.platform;
+  const platform = platformString.toUpperCase();
   const isMac = platform.includes('MAC');
   const modifier = useSymbol && isMac ? '⌘' : (isMac ? 'Cmd' : 'Ctrl');
 


### PR DESCRIPTION
## Overview
Addresses remaining feedback from PR #57 review by adding cross-platform keyboard shortcut support and other improvements.

## Changes

### Platform Detection (✅ High Priority)
- Created `usePlatform` hook for detecting Mac/Windows/Linux
- Added `formatShortcut` utility to convert "Mod" → "Cmd"/"Ctrl"
- Updated all shortcut displays to show correct modifier key

**Before:**
- All users saw "Cmd+K" (confusing for Windows/Linux users)

**After:**
- Mac users see: "Cmd+K" or "⌘+K"
- Windows/Linux users see: "Ctrl+K"

### Components Updated
- ✅ **CommandPalette**: Now formats shortcuts dynamically
- ✅ **KeyboardShortcutsHelp**: Shows platform-appropriate keys
- ✅ **LayoutDesigner**: Footer hints use dynamic modifier key

### Shortcut Definitions
- Replaced all "Cmd" with "Mod" in command definitions
- Single source of truth that works across platforms
- Examples:
  - `Mod+S` → Save
  - `Mod+Shift+Z` → Redo
  - `Mod+/` → Show shortcuts

## Files Changed
- **New**: `src/renderer/src/hooks/usePlatform.ts`
- **Modified**: `CommandPalette.tsx`, `KeyboardShortcutsHelp.tsx`, `LayoutDesigner.tsx`

## Testing
✅ Build passes successfully
✅ No TypeScript errors
✅ Platform detection works correctly

## Benefits
- Consistent UX across Mac, Windows, and Linux
- Less confusion for Windows/Linux users
- Professional multi-platform support
- Follows industry standards (VS Code, Figma, etc.)

## Addresses PR #57 Review
- ✅ Platform detection for shortcut display
- ✅ Missing from earlier PR review fixes

## Follow-up Work
Event listener optimization with useCallback can be done in a future PR if needed (current implementation is correct, just not perfectly optimized for re-renders).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>