### PR TITLE
feat: user accounts, licensing & demo mode

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -1,35 +1,54 @@
 # Next Steps - ShowStack Development
 
-**Branch:** `develop`
-**Last Updated:** February 11, 2026
-**Status:** Renovation ~90% complete (Phases 0-7.2 done), Phase 7.3 in progress
+**Branch:** `feature/user-accounts-licensing`
+**Last Updated:** February 13, 2026
+**Status:** Renovation ~95% complete (Phases 0-7.2 done), Phase 7.3 in progress
 
 ---
 
 ## Quick Start (Resuming Work)
 
 ```bash
-# 1. Ensure you're on develop branch
-git checkout develop
+# 1. Ensure you're on the correct branch
+git checkout feature/user-accounts-licensing
 
 # 2. Pull latest changes
-git pull origin develop
+git pull origin feature/user-accounts-licensing
 
 # 3. Install dependencies (sets up Husky hooks)
 npm install
 
-# 4. Start dev server
+# 4. Rebuild better-sqlite3 for Electron
+npx electron-rebuild -f -w better-sqlite3
+
+# 5. Start dev server
 npm run dev
 
-# 5. Run tests
+# 6. Run tests
 npm run test:run
 
-# 6. Run linter
+# 7. Run linter
 npm run lint
 
-# 7. Check formatting
+# 8. Check formatting
 npm run format:check
 ```
+
+---
+
+## Recently Completed
+
+### User Accounts, Licensing & Demo Mode (February 2026)
+
+- Supabase Auth integration (sign in, sign up, sign out, password reset)
+- Email-based license auto-claim (no manual key entry)
+- Perpetual fallback licensing model
+- Demo mode for unauthenticated users (25 fixtures, no cloud sync, no exports)
+- First-launch auth prompt with "Continue in Demo Mode" option
+- Account page shows auth status with demo badge and upgrade prompts
+- `maxFixtures` feature limit per tier
+- Cloud sync flag on Supabase licenses table
+- 5 new test cases for demo mode licensing
 
 ---
 
@@ -41,13 +60,12 @@ npm run format:check
 - **Phase 1: Database Migration** - better-sqlite3 with WAL mode, transactions
 - **Phase 2: Validation & Services** - Zod validation, service layer
 - **Phase 3: Cloud Collaboration** - PowerSync + Supabase, offline-first sync
-- **Phase 4: Testing & QA** - 1,520+ tests, 70%+ coverage, Vitest + RTL
+- **Phase 4: Testing & QA** - 1,576+ tests, 70%+ coverage, Vitest + RTL
 - **Phase 5: CI/CD & DevOps** - ESLint 9, Prettier, Husky, GitHub Actions
 
 ### Completed: Phase 6 - Security & Monitoring
 
 - [x] Code quality hardening (PR #76 review items)
-  - `no-explicit-any`: warn, ESLint caching, `--max-warnings`, CodeQL/SAST
 - [x] Logger utility (replace ~1,000 console statements)
 - [x] Sentry integration
 - [x] Health check system
@@ -90,6 +108,7 @@ See `docs/archive/renovation/README.md` for the full renovation plan.
 - `docs/archive/renovation/README.md` - Renovation plan overview
 - `docs/archive/renovation/Phase-6-Security-Monitoring.md` - Phase 6 details
 - `docs/archive/renovation/Phase-7-Disaster-Recovery.md` - Phase 7 disaster recovery details
+- `docs/user/LICENSING_SYSTEM_README.md` - Licensing system documentation
 - `PROJECT_STATUS.md` - Overall project status
 - `CONTRIBUTING.md` - Contribution guidelines and code standards
 - `docs/development/ARCHITECTURE.md` - Architecture guide
@@ -102,8 +121,9 @@ See `docs/archive/renovation/README.md` for the full renovation plan.
 2. **Review renovation status** - See `docs/archive/renovation/README.md`
 3. **Run test suite** - Ensure all tests passing: `npm run test:run`
 4. **Run lint** - Ensure no errors: `npm run lint`
-5. **Check CI** - Ensure GitHub Actions are green on develop
+5. **Check CI** - Ensure GitHub Actions are green
+6. **Rebuild native modules** - `npx electron-rebuild -f -w better-sqlite3` for Electron, `npm rebuild better-sqlite3` for vitest
 
 ---
 
-**Current Focus:** Phase 7.3 - Documentation updates (renovation ~90% complete)
+**Current Focus:** Phase 7.3 - Documentation updates, then merge feature branch to main

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -1,10 +1,10 @@
 # ShowStack Project Status
 
 **Created:** December 18, 2025
-**Last Updated:** February 11, 2026
+**Last Updated:** February 13, 2026
 **Current Version:** 0.1.0-alpha
 **Development Phase:** Alpha (Renovation ~90% complete)
-**Active Branch:** `develop`
+**Active Branch:** `feature/user-accounts-licensing`
 
 This document tracks the development status of all ShowStack feature domains and editions. It serves as the central source of truth for what's completed, in progress, and planned.
 
@@ -26,9 +26,22 @@ This document tracks the development status of all ShowStack feature domains and
 
 ## 🎯 Current Development Priorities
 
-### ✅ Recently Completed (December 2025 - January 2026)
+### ✅ Recently Completed (December 2025 - February 2026)
 
-**Latest (January 2026):** 9. ✅ Shop Order Table Migration (PR #63) - COMPLETED (January 20, 2026)
+**Latest (February 2026):** 10. ✅ User Accounts, Licensing & Demo Mode (PR on feature/user-accounts-licensing) - COMPLETED (February 13, 2026)
+
+- Supabase Auth integration (sign in, sign up, sign out, password reset)
+- Email-based license auto-claim (no manual key entry)
+- Perpetual fallback licensing model (app works if built before maintenance end)
+- Demo mode for unauthenticated users (25 fixtures, no cloud sync, no exports)
+- First-launch auth prompt with "Continue in Demo Mode" option
+- Account page shows auth status, demo badge, and upgrade prompts
+- License verification via Supabase with auto-claim flow
+- Cloud sync flag (`cloud_sync` column) on Supabase licenses table
+- `maxFixtures` feature limit per tier (demo: 25, student: 100, pro/institutional: unlimited)
+- Comprehensive test coverage (5 new test cases for demo mode)
+
+9. ✅ Shop Order Table Migration (PR #63) - COMPLETED (January 20, 2026)
 
 - Migrated from dialog-based to spreadsheet-like table interface
 - Inline cell editing (double-click to edit, single-click to select)
@@ -1322,6 +1335,7 @@ Privacy-first telemetry system with full PostHog SDK integration.
   - Tier-based features (Professional, Student, Institutional)
   - Background verification (non-blocking)
   - Graceful degradation (read-only on expiration)
+  - Demo mode for unauthenticated users (restricted local-only license)
 
 - ✅ **License Database** - `src/main/database/appSchema.ts:licenses`
   - License storage in app database
@@ -1332,6 +1346,8 @@ Privacy-first telemetry system with full PostHog SDK integration.
   - License status banners
   - Edition selector
   - Upgrade prompts
+  - First-launch auth prompt with demo mode fallback
+  - Auth status section on Account page (signed in / demo / not signed in)
   - Account dialog with license section
 
 - ✅ **License Hooks** - `src/renderer/src/hooks/`
@@ -1559,21 +1575,18 @@ Full developer mode implementation with DevTools integration.
 
 ### User Authentication
 
-**Status:** UI placeholder only (2% complete) - Login page bypasses auth
+**Status:** ✅ Complete (Supabase Auth)
 
-- ⬜ **JWT Authentication** - jsonwebtoken package not installed
-- ⬜ **Authentication Service** - No auth backend
-- ⬜ **Session Management** - No session tracking
-- ⬜ **Password Hashing** - For user credentials (bcryptjs only used for admin password)
-- ⬜ **User Registration** - No registration flow
-- ⬜ **Password Reset** - No reset functionality
+- ✅ **Supabase Auth** - Email/password authentication via Supabase
+- ✅ **Sign In / Sign Up / Sign Out** - Full auth flows via IPC
+- ✅ **Password Reset** - Email-based password reset
+- ✅ **Auth State Management** - Zustand authStore with IPC bridge
+- ✅ **Auth Modal** - Login, signup, and password reset forms
+- ✅ **First-Launch Prompt** - Auth modal on first launch with demo mode fallback
+- ✅ **Demo Mode** - Restricted local-only license for unauthenticated users
+- ✅ **License Auto-Link** - Email-based auto-claim when signing in
 
-**Existing UI (Non-functional):**
-
-- `Login.tsx` - Login form with "Skip login (development)" that bypasses everything
-- handleLogin() just navigates to /modules without validation
-
-**Note:** License system (LicenseService.ts) handles feature access control but is NOT user authentication
+**Architecture:** Supabase Auth (managed service) — no custom JWT or session management needed
 
 ---
 
@@ -1816,7 +1829,7 @@ Incorporated into **Lighting Edition → Planned** section above.
 - **Team collaboration**: Multi-user permissions not yet implemented (sync is device-level)
 - **E2E tests**: Playwright tests not yet implemented
 - **Fixture management**: ~80% complete, some advanced features remaining
-- **ESLint warnings**: ~826 warnings (0 errors) - gradual reduction planned
+- **ESLint warnings**: ~821 warnings (0 errors) - gradual reduction planned
 
 ### Breaking Changes Log
 
@@ -1843,4 +1856,4 @@ Incorporated into **Lighting Edition → Planned** section above.
 
 ---
 
-**Last Updated:** February 11, 2026
+**Last Updated:** February 13, 2026

--- a/apps/desktop/src/main/database/appSchema.ts
+++ b/apps/desktop/src/main/database/appSchema.ts
@@ -28,7 +28,7 @@ export const APP_SCHEMA = `
     email TEXT NOT NULL,
     name TEXT,
     license_key TEXT UNIQUE NOT NULL,
-    tier TEXT NOT NULL CHECK(tier IN ('professional', 'student', 'institutional')),
+    tier TEXT NOT NULL CHECK(tier IN ('professional', 'student', 'institutional', 'demo')),
     status TEXT NOT NULL CHECK(status IN ('active', 'expired', 'suspended', 'deleted')),
     modules TEXT NOT NULL, -- JSON stringified ModuleAccess[]
     expiration_date INTEGER NOT NULL,

--- a/apps/desktop/src/main/database/appSchema.ts
+++ b/apps/desktop/src/main/database/appSchema.ts
@@ -32,6 +32,8 @@ export const APP_SCHEMA = `
     status TEXT NOT NULL CHECK(status IN ('active', 'expired', 'suspended', 'deleted')),
     modules TEXT NOT NULL, -- JSON stringified ModuleAccess[]
     expiration_date INTEGER NOT NULL,
+    maintenance_end_date INTEGER, -- Unix timestamp, defaults to expiration_date if null
+    user_id TEXT,
     last_verified INTEGER NOT NULL,
     created_at INTEGER NOT NULL,
     updated_at INTEGER NOT NULL

--- a/apps/desktop/src/main/database/appSchema.ts
+++ b/apps/desktop/src/main/database/appSchema.ts
@@ -34,6 +34,7 @@ export const APP_SCHEMA = `
     expiration_date INTEGER NOT NULL,
     maintenance_end_date INTEGER, -- Unix timestamp, defaults to expiration_date if null
     user_id TEXT,
+    cloud_sync INTEGER NOT NULL DEFAULT 1, -- 1=enabled, 0=disabled; default true for backwards compat
     last_verified INTEGER NOT NULL,
     created_at INTEGER NOT NULL,
     updated_at INTEGER NOT NULL

--- a/apps/desktop/src/main/database/core/MigrationRunner.ts
+++ b/apps/desktop/src/main/database/core/MigrationRunner.ts
@@ -56,6 +56,9 @@ export class MigrationRunner {
     logger.info('Running app database migrations');
 
     try {
+      // Migration: Add cloud_sync column to licenses table
+      this.migrateLicensesTable();
+
       // Seed default page layouts if none exist
       const layoutResult = this.db
         .prepare('SELECT COUNT(*) as count FROM page_layout_templates')
@@ -171,6 +174,23 @@ export class MigrationRunner {
         error instanceof Error ? error : new Error(String(error)),
       );
       // Continue anyway - don't block app startup
+    }
+  }
+
+  /**
+   * Migrate licenses table schema
+   */
+  private migrateLicensesTable(): void {
+    const tableInfo = this.db.prepare('PRAGMA table_info(licenses)').all() as Array<{
+      name: string;
+    }>;
+    const columns = tableInfo.map((row) => row.name);
+
+    if (!columns.includes('cloud_sync')) {
+      logger.info('Running migration: Adding cloud_sync to licenses');
+      this.db
+        .prepare('ALTER TABLE licenses ADD COLUMN cloud_sync INTEGER NOT NULL DEFAULT 1')
+        .run();
     }
   }
 

--- a/apps/desktop/src/main/database/queries/license.ts
+++ b/apps/desktop/src/main/database/queries/license.ts
@@ -122,6 +122,19 @@ export function createLicense(data: {
   return getLicenseById(id)!;
 }
 
+/** Allowed column mappings for license updates — prevents SQL injection */
+const LICENSE_UPDATE_COLUMNS: Record<string, string> = {
+  email: 'email',
+  name: 'name',
+  tier: 'tier',
+  status: 'status',
+  modules: 'modules',
+  expirationDate: 'expiration_date',
+  maintenanceEndDate: 'maintenance_end_date',
+  userId: 'user_id',
+  lastVerified: 'last_verified',
+};
+
 /**
  * Update license
  */
@@ -143,43 +156,14 @@ export function updateLicense(
   const now = Date.now();
 
   const fields: string[] = [];
-  const values: any[] = [];
+  const values: (string | number | null)[] = [];
 
-  if (updates.email !== undefined) {
-    fields.push('email = ?');
-    values.push(updates.email);
-  }
-  if (updates.name !== undefined) {
-    fields.push('name = ?');
-    values.push(updates.name);
-  }
-  if (updates.tier !== undefined) {
-    fields.push('tier = ?');
-    values.push(updates.tier);
-  }
-  if (updates.status !== undefined) {
-    fields.push('status = ?');
-    values.push(updates.status);
-  }
-  if (updates.modules !== undefined) {
-    fields.push('modules = ?');
-    values.push(JSON.stringify(updates.modules));
-  }
-  if (updates.expirationDate !== undefined) {
-    fields.push('expiration_date = ?');
-    values.push(updates.expirationDate);
-  }
-  if (updates.maintenanceEndDate !== undefined) {
-    fields.push('maintenance_end_date = ?');
-    values.push(updates.maintenanceEndDate);
-  }
-  if (updates.userId !== undefined) {
-    fields.push('user_id = ?');
-    values.push(updates.userId);
-  }
-  if (updates.lastVerified !== undefined) {
-    fields.push('last_verified = ?');
-    values.push(updates.lastVerified);
+  for (const [key, value] of Object.entries(updates)) {
+    if (value === undefined) continue;
+    const column = LICENSE_UPDATE_COLUMNS[key];
+    if (!column) continue; // Skip unknown keys — whitelist only
+    fields.push(`${column} = ?`);
+    values.push(key === 'modules' ? JSON.stringify(value) : (value as string | number | null));
   }
 
   fields.push('updated_at = ?');

--- a/apps/desktop/src/main/database/queries/license.ts
+++ b/apps/desktop/src/main/database/queries/license.ts
@@ -85,18 +85,21 @@ export function createLicense(data: {
   tier: LicenseTier;
   modules: ModuleAccess[];
   expirationDate: number;
+  maintenanceEndDate?: number;
+  userId?: string;
 }): UserLicense {
   const db = getAppDatabase();
   const now = Date.now();
   const id = uuidv4();
+  const maintenanceEndDate = data.maintenanceEndDate ?? data.expirationDate;
 
   db.prepare(
     `
     INSERT INTO licenses (
       id, email, name, license_key, tier, status, modules,
-      expiration_date, last_verified, created_at, updated_at
+      expiration_date, maintenance_end_date, user_id, last_verified, created_at, updated_at
     )
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `,
   ).run(
     id,
@@ -107,6 +110,8 @@ export function createLicense(data: {
     'active',
     JSON.stringify(data.modules),
     data.expirationDate,
+    maintenanceEndDate,
+    data.userId || null,
     now,
     now,
     now,
@@ -129,6 +134,8 @@ export function updateLicense(
     status: 'active' | 'expired' | 'suspended';
     modules: ModuleAccess[];
     expirationDate: number;
+    maintenanceEndDate: number;
+    userId: string;
     lastVerified: number;
   }>,
 ): UserLicense {
@@ -161,6 +168,14 @@ export function updateLicense(
   if (updates.expirationDate !== undefined) {
     fields.push('expiration_date = ?');
     values.push(updates.expirationDate);
+  }
+  if (updates.maintenanceEndDate !== undefined) {
+    fields.push('maintenance_end_date = ?');
+    values.push(updates.maintenanceEndDate);
+  }
+  if (updates.userId !== undefined) {
+    fields.push('user_id = ?');
+    values.push(updates.userId);
   }
   if (updates.lastVerified !== undefined) {
     fields.push('last_verified = ?');
@@ -205,6 +220,8 @@ export function deleteLicense(id: string): void {
  * Helper function to convert database row object to UserLicense
  */
 function rowObjectToLicense(obj: Record<string, unknown>): UserLicense {
+  const expirationDate = obj.expiration_date as number;
+  const maintenanceEndDate = (obj.maintenance_end_date as number) ?? expirationDate;
   return {
     id: obj.id as string,
     email: obj.email as string,
@@ -212,8 +229,10 @@ function rowObjectToLicense(obj: Record<string, unknown>): UserLicense {
     licenseKey: obj.license_key as string,
     tier: obj.tier as LicenseTier,
     status: obj.status as 'active' | 'expired' | 'suspended',
+    userId: (obj.user_id as string) || undefined,
     modules: JSON.parse(obj.modules as string) as ModuleAccess[],
-    expirationDate: obj.expiration_date as number,
+    expirationDate,
+    maintenanceEndDate,
     lastVerified: obj.last_verified as number,
     createdAt: obj.created_at as number,
     updatedAt: obj.updated_at as number,

--- a/apps/desktop/src/main/database/queries/license.ts
+++ b/apps/desktop/src/main/database/queries/license.ts
@@ -87,6 +87,7 @@ export function createLicense(data: {
   expirationDate: number;
   maintenanceEndDate?: number;
   userId?: string;
+  cloudSync?: boolean;
 }): UserLicense {
   const db = getAppDatabase();
   const now = Date.now();
@@ -97,9 +98,9 @@ export function createLicense(data: {
     `
     INSERT INTO licenses (
       id, email, name, license_key, tier, status, modules,
-      expiration_date, maintenance_end_date, user_id, last_verified, created_at, updated_at
+      expiration_date, maintenance_end_date, user_id, cloud_sync, last_verified, created_at, updated_at
     )
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `,
   ).run(
     id,
@@ -112,6 +113,7 @@ export function createLicense(data: {
     data.expirationDate,
     maintenanceEndDate,
     data.userId || null,
+    data.cloudSync === false ? 0 : 1,
     now,
     now,
     now,
@@ -132,6 +134,7 @@ const LICENSE_UPDATE_COLUMNS: Record<string, string> = {
   expirationDate: 'expiration_date',
   maintenanceEndDate: 'maintenance_end_date',
   userId: 'user_id',
+  cloudSync: 'cloud_sync',
   lastVerified: 'last_verified',
 };
 
@@ -149,6 +152,7 @@ export function updateLicense(
     expirationDate: number;
     maintenanceEndDate: number;
     userId: string;
+    cloudSync: boolean;
     lastVerified: number;
   }>,
 ): UserLicense {
@@ -163,7 +167,13 @@ export function updateLicense(
     const column = LICENSE_UPDATE_COLUMNS[key];
     if (!column) continue; // Skip unknown keys — whitelist only
     fields.push(`${column} = ?`);
-    values.push(key === 'modules' ? JSON.stringify(value) : (value as string | number | null));
+    if (key === 'modules') {
+      values.push(JSON.stringify(value));
+    } else if (key === 'cloudSync') {
+      values.push(value ? 1 : 0);
+    } else {
+      values.push(value as string | number | null);
+    }
   }
 
   fields.push('updated_at = ?');
@@ -223,6 +233,7 @@ function rowObjectToLicense(obj: Record<string, unknown>): UserLicense {
     tier: obj.tier as LicenseTier,
     status: obj.status as 'active' | 'expired' | 'suspended',
     userId: (obj.user_id as string) || undefined,
+    cloudSync: obj.cloud_sync !== 0, // Default true for backwards compat (column DEFAULT 1)
     modules: parseModules(obj.modules),
     expirationDate,
     maintenanceEndDate,

--- a/apps/desktop/src/main/database/queries/license.ts
+++ b/apps/desktop/src/main/database/queries/license.ts
@@ -203,6 +203,15 @@ export function deleteLicense(id: string): void {
 /**
  * Helper function to convert database row object to UserLicense
  */
+function parseModules(raw: unknown): ModuleAccess[] {
+  try {
+    const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
 function rowObjectToLicense(obj: Record<string, unknown>): UserLicense {
   const expirationDate = obj.expiration_date as number;
   const maintenanceEndDate = (obj.maintenance_end_date as number) ?? expirationDate;
@@ -214,7 +223,7 @@ function rowObjectToLicense(obj: Record<string, unknown>): UserLicense {
     tier: obj.tier as LicenseTier,
     status: obj.status as 'active' | 'expired' | 'suspended',
     userId: (obj.user_id as string) || undefined,
-    modules: JSON.parse(obj.modules as string) as ModuleAccess[],
+    modules: parseModules(obj.modules),
     expirationDate,
     maintenanceEndDate,
     lastVerified: obj.last_verified as number,

--- a/apps/desktop/src/main/ipc/license.ts
+++ b/apps/desktop/src/main/ipc/license.ts
@@ -140,40 +140,52 @@ export function registerLicenseHandlers(): void {
   });
 
   /**
-   * Activate a new license
+   * Activate a license key (user comes from Supabase session)
    */
-  ipcMain.handle(
-    'license:activate',
-    async (_, licenseKey: string, email: string, modules: ShowStackModule[]) => {
-      try {
-        // Validation
-        if (!licenseKey || licenseKey.trim().length === 0) {
-          throw new ValidationError('License key is required', 'licenseKey', licenseKey);
-        }
-        if (!email || email.trim().length === 0) {
-          throw new ValidationError('Email is required', 'email', email);
-        }
-
-        return await errorHandler.executeWithRetry(
-          async () => licenseService.activateLicense(licenseKey, email, modules),
-          'license:activate',
-        );
-      } catch (error) {
-        logger.error('Failed to activate license:', {
-          operation: 'license:activate',
-          email,
-          error: error instanceof Error ? error.message : error,
-        });
-
-        if (error instanceof ValidationError) {
-          throw new Error(error.toUserMessage());
-        }
-        throw new Error(
-          `Unable to activate license: ${error instanceof Error ? error.message : 'Unknown error'}`,
-        );
+  ipcMain.handle('license:activate', async (_, licenseKey: string) => {
+    try {
+      if (!licenseKey || licenseKey.trim().length === 0) {
+        throw new ValidationError('License key is required', 'licenseKey', licenseKey);
       }
-    },
-  );
+
+      return await errorHandler.executeWithRetry(
+        async () => licenseService.activateLicenseKey(licenseKey),
+        'license:activate',
+      );
+    } catch (error) {
+      logger.error('Failed to activate license:', {
+        operation: 'license:activate',
+        error: error instanceof Error ? error.message : error,
+      });
+
+      if (error instanceof ValidationError) {
+        throw new Error(error.toUserMessage());
+      }
+      throw new Error(
+        `Unable to activate license: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+    }
+  });
+
+  /**
+   * Refresh license from Supabase
+   */
+  ipcMain.handle('license:refresh', async () => {
+    try {
+      return await errorHandler.executeWithRetry(async () => {
+        const success = await licenseService.verifyLicenseViaSupabase();
+        return { success, license: licenseService.getCurrentLicense() };
+      }, 'license:refresh');
+    } catch (error) {
+      logger.error('Failed to refresh license:', {
+        operation: 'license:refresh',
+        error: error instanceof Error ? error.message : error,
+      });
+      throw new Error(
+        `Unable to refresh license: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+    }
+  });
 
   /**
    * Verify license online (manual trigger)
@@ -181,9 +193,7 @@ export function registerLicenseHandlers(): void {
   ipcMain.handle('license:verifyOnline', async () => {
     try {
       return await errorHandler.executeWithRetry(async () => {
-        const license = licenseService.getCurrentLicense();
-        if (!license) return false;
-        return await licenseService.verifyLicenseOnline(license.licenseKey);
+        return await licenseService.verifyLicenseViaSupabase();
       }, 'license:verifyOnline');
     } catch (error) {
       logger.error('Failed to verify license online:', {

--- a/apps/desktop/src/main/ipc/license.ts
+++ b/apps/desktop/src/main/ipc/license.ts
@@ -4,7 +4,6 @@ import { settingsService } from '../services/SettingsService';
 import type { ShowStackModule } from '../../shared/types/license.types';
 import type { AppSettings } from '../../shared/types/settings.types';
 import { errorHandler } from '../errors';
-import { ValidationError } from '../errors';
 import { logger } from '../utils/logger';
 
 /**
@@ -135,34 +134,6 @@ export function registerLicenseHandlers(): void {
       });
       throw new Error(
         `Unable to check feature access: ${error instanceof Error ? error.message : 'Unknown error'}`,
-      );
-    }
-  });
-
-  /**
-   * Activate a license key (user comes from Supabase session)
-   */
-  ipcMain.handle('license:activate', async (_, licenseKey: string) => {
-    try {
-      if (!licenseKey || licenseKey.trim().length === 0) {
-        throw new ValidationError('License key is required', 'licenseKey', licenseKey);
-      }
-
-      return await errorHandler.executeWithRetry(
-        async () => licenseService.activateLicenseKey(licenseKey),
-        'license:activate',
-      );
-    } catch (error) {
-      logger.error('Failed to activate license:', {
-        operation: 'license:activate',
-        error: error instanceof Error ? error.message : error,
-      });
-
-      if (error instanceof ValidationError) {
-        throw new Error(error.toUserMessage());
-      }
-      throw new Error(
-        `Unable to activate license: ${error instanceof Error ? error.message : 'Unknown error'}`,
       );
     }
   });

--- a/apps/desktop/src/main/ipc/license.ts
+++ b/apps/desktop/src/main/ipc/license.ts
@@ -159,6 +159,26 @@ export function registerLicenseHandlers(): void {
   });
 
   /**
+   * Create a demo license (for first-launch skip)
+   */
+  ipcMain.handle('license:createDemo', async () => {
+    try {
+      return await errorHandler.executeWithRetry(async () => {
+        const license = licenseService.createDemoLicense();
+        return { success: true, license };
+      }, 'license:createDemo');
+    } catch (error) {
+      logger.error('Failed to create demo license', {
+        operation: 'license:createDemo',
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw new Error(
+        `Unable to create demo license: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+    }
+  });
+
+  /**
    * Verify license online (manual trigger)
    */
   ipcMain.handle('license:verifyOnline', async () => {

--- a/apps/desktop/src/main/ipc/license.ts
+++ b/apps/desktop/src/main/ipc/license.ts
@@ -1,7 +1,7 @@
 import { ipcMain } from 'electron';
 import { licenseService } from '../services/LicenseService';
 import { settingsService } from '../services/SettingsService';
-import type { ShowStackModule } from '../../shared/types/license.types';
+import type { ShowStackModule, ModuleFeatures } from '../../shared/types/license.types';
 import type { AppSettings } from '../../shared/types/settings.types';
 import { errorHandler } from '../errors';
 import { logger } from '../utils/logger';
@@ -119,24 +119,27 @@ export function registerLicenseHandlers(): void {
   /**
    * Check if user can use a specific feature
    */
-  ipcMain.handle('license:canUseFeature', async (_, module: ShowStackModule, feature: string) => {
-    try {
-      return await errorHandler.executeWithRetry(
-        async () => licenseService.canUseFeature(module, feature),
-        'license:canUseFeature',
-      );
-    } catch (error) {
-      logger.error('Failed to check feature access:', {
-        operation: 'license:canUseFeature',
-        module,
-        feature,
-        error: error instanceof Error ? error.message : error,
-      });
-      throw new Error(
-        `Unable to check feature access: ${error instanceof Error ? error.message : 'Unknown error'}`,
-      );
-    }
-  });
+  ipcMain.handle(
+    'license:canUseFeature',
+    async (_, module: ShowStackModule, feature: keyof ModuleFeatures) => {
+      try {
+        return await errorHandler.executeWithRetry(
+          async () => licenseService.canUseFeature(module, feature),
+          'license:canUseFeature',
+        );
+      } catch (error) {
+        logger.error('Failed to check feature access:', {
+          operation: 'license:canUseFeature',
+          module,
+          feature,
+          error: error instanceof Error ? error.message : error,
+        });
+        throw new Error(
+          `Unable to check feature access: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        );
+      }
+    },
+  );
 
   /**
    * Refresh license from Supabase

--- a/apps/desktop/src/main/ipc/sync.ts
+++ b/apps/desktop/src/main/ipc/sync.ts
@@ -19,7 +19,13 @@ function isValidEmail(email: string): boolean {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim());
 }
 
-/** Simple rate limiter — tracks last call time per action */
+/**
+ * Simple in-memory rate limiter — tracks last call time per action.
+ * This is a client-side courtesy limit only. The authoritative rate limiting
+ * is enforced server-side by Supabase (e.g., email rate limits for password reset,
+ * auth attempt limits for sign-in). This resets on app restart by design —
+ * Supabase's persistent server-side limits are the security boundary.
+ */
 const rateLimitTimestamps = new Map<string, number>();
 const RATE_LIMIT_MS = 10_000; // 10 seconds between calls
 

--- a/apps/desktop/src/main/ipc/sync.ts
+++ b/apps/desktop/src/main/ipc/sync.ts
@@ -102,8 +102,9 @@ export function registerSyncHandlers(): void {
 
       if (result.success) {
         // Refresh license data from Supabase after sign-in
+        let licenseVerified = false;
         try {
-          await licenseService.verifyLicenseViaSupabase();
+          licenseVerified = await licenseService.verifyLicenseViaSupabase();
         } catch (licenseError) {
           logger.warn('[Sync] License refresh after sign-in failed (non-fatal)', {
             error: licenseError instanceof Error ? licenseError.message : 'Unknown',
@@ -115,6 +116,8 @@ export function registerSyncHandlers(): void {
         if (service.isReady()) {
           await service.connect();
         }
+
+        return { ...result, licenseVerified };
       }
 
       return result;

--- a/apps/desktop/src/main/ipc/sync.ts
+++ b/apps/desktop/src/main/ipc/sync.ts
@@ -14,6 +14,11 @@ import {
 import { licenseService } from '../services/LicenseService';
 import { logger } from '../utils/logger';
 
+/** Basic email format validation */
+function isValidEmail(email: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim());
+}
+
 /**
  * Register all sync-related IPC handlers
  */
@@ -63,9 +68,17 @@ export function registerSyncHandlers(): void {
    * Sign in with email and password
    */
   ipcMain.handle('auth:signIn', async (_, email: string, password: string) => {
+    // Input validation
+    if (!email || typeof email !== 'string' || !isValidEmail(email)) {
+      return { success: false, error: 'Invalid email address' };
+    }
+    if (!password || typeof password !== 'string' || password.length < 8) {
+      return { success: false, error: 'Password must be at least 8 characters' };
+    }
+
     try {
       const connector = getSupabaseConnector();
-      const result = await connector.signIn(email, password);
+      const result = await connector.signIn(email.trim(), password);
 
       if (result.success) {
         // Refresh license data from Supabase after sign-in
@@ -97,9 +110,17 @@ export function registerSyncHandlers(): void {
    * Sign up with email and password
    */
   ipcMain.handle('auth:signUp', async (_, email: string, password: string) => {
+    // Input validation
+    if (!email || typeof email !== 'string' || !isValidEmail(email)) {
+      return { success: false, error: 'Invalid email address' };
+    }
+    if (!password || typeof password !== 'string' || password.length < 8) {
+      return { success: false, error: 'Password must be at least 8 characters' };
+    }
+
     try {
       const connector = getSupabaseConnector();
-      return await connector.signUp(email, password);
+      return await connector.signUp(email.trim(), password);
     } catch (error) {
       return {
         success: false,
@@ -134,9 +155,13 @@ export function registerSyncHandlers(): void {
    * Request password reset
    */
   ipcMain.handle('auth:resetPassword', async (_, email: string) => {
+    if (!email || typeof email !== 'string' || !isValidEmail(email)) {
+      return { success: false, error: 'Invalid email address' };
+    }
+
     try {
       const connector = getSupabaseConnector();
-      return await connector.resetPassword(email);
+      return await connector.resetPassword(email.trim());
     } catch (error) {
       return {
         success: false,
@@ -158,7 +183,10 @@ export function registerSyncHandlers(): void {
         userId: connector.getUserId(),
         email: session?.user?.email ?? null,
       };
-    } catch {
+    } catch (error) {
+      logger.warn('Failed to get auth state', {
+        error: error instanceof Error ? error.message : String(error),
+      });
       return {
         isAuthenticated: false,
         userId: null,

--- a/apps/desktop/src/main/ipc/sync.ts
+++ b/apps/desktop/src/main/ipc/sync.ts
@@ -11,6 +11,7 @@ import {
   getSupabaseConnector,
   type ShowStackSyncStatus,
 } from '../services/sync';
+import { licenseService } from '../services/LicenseService';
 import { logger } from '../utils/logger';
 
 /**
@@ -67,6 +68,15 @@ export function registerSyncHandlers(): void {
       const result = await connector.signIn(email, password);
 
       if (result.success) {
+        // Refresh license data from Supabase after sign-in
+        try {
+          await licenseService.verifyLicenseViaSupabase();
+        } catch (licenseError) {
+          logger.info('[Sync] License refresh after sign-in failed (non-fatal)', {
+            error: licenseError instanceof Error ? licenseError.message : 'Unknown',
+          });
+        }
+
         // Start syncing after successful sign in
         const service = getPowerSyncService();
         if (service.isReady()) {

--- a/apps/desktop/src/main/ipc/sync.ts
+++ b/apps/desktop/src/main/ipc/sync.ts
@@ -19,6 +19,20 @@ function isValidEmail(email: string): boolean {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim());
 }
 
+/** Simple rate limiter — tracks last call time per action */
+const rateLimitTimestamps = new Map<string, number>();
+const RATE_LIMIT_MS = 10_000; // 10 seconds between calls
+
+function isRateLimited(action: string): boolean {
+  const now = Date.now();
+  const lastCall = rateLimitTimestamps.get(action);
+  if (lastCall && now - lastCall < RATE_LIMIT_MS) {
+    return true;
+  }
+  rateLimitTimestamps.set(action, now);
+  return false;
+}
+
 /**
  * Register all sync-related IPC handlers
  */
@@ -157,6 +171,9 @@ export function registerSyncHandlers(): void {
   ipcMain.handle('auth:resetPassword', async (_, email: string) => {
     if (!email || typeof email !== 'string' || !isValidEmail(email)) {
       return { success: false, error: 'Invalid email address' };
+    }
+    if (isRateLimited('resetPassword')) {
+      return { success: false, error: 'Please wait before requesting another reset' };
     }
 
     try {

--- a/apps/desktop/src/main/ipc/sync.ts
+++ b/apps/desktop/src/main/ipc/sync.ts
@@ -101,7 +101,7 @@ export function registerSyncHandlers(): void {
 
     try {
       const connector = getSupabaseConnector();
-      const result = await connector.signIn(email.trim(), password);
+      const result = await connector.signIn(email.trim().toLowerCase(), password);
 
       if (result.success) {
         // Refresh license data from Supabase after sign-in
@@ -149,7 +149,7 @@ export function registerSyncHandlers(): void {
 
     try {
       const connector = getSupabaseConnector();
-      return await connector.signUp(email.trim(), password);
+      return await connector.signUp(email.trim().toLowerCase(), password);
     } catch (error) {
       return {
         success: false,
@@ -193,7 +193,7 @@ export function registerSyncHandlers(): void {
 
     try {
       const connector = getSupabaseConnector();
-      return await connector.resetPassword(email.trim());
+      return await connector.resetPassword(email.trim().toLowerCase());
     } catch (error) {
       return {
         success: false,

--- a/apps/desktop/src/main/ipc/sync.ts
+++ b/apps/desktop/src/main/ipc/sync.ts
@@ -105,7 +105,7 @@ export function registerSyncHandlers(): void {
         try {
           await licenseService.verifyLicenseViaSupabase();
         } catch (licenseError) {
-          logger.info('[Sync] License refresh after sign-in failed (non-fatal)', {
+          logger.warn('[Sync] License refresh after sign-in failed (non-fatal)', {
             error: licenseError instanceof Error ? licenseError.message : 'Unknown',
           });
         }

--- a/apps/desktop/src/main/ipc/sync.ts
+++ b/apps/desktop/src/main/ipc/sync.ts
@@ -88,6 +88,9 @@ export function registerSyncHandlers(): void {
    * Sign in with email and password
    */
   ipcMain.handle('auth:signIn', async (_, email: string, password: string) => {
+    if (isRateLimited('signIn')) {
+      return { success: false, error: 'Too many attempts. Please wait.' };
+    }
     // Input validation
     if (!email || typeof email !== 'string' || !isValidEmail(email)) {
       return { success: false, error: 'Invalid email address' };
@@ -133,6 +136,9 @@ export function registerSyncHandlers(): void {
    * Sign up with email and password
    */
   ipcMain.handle('auth:signUp', async (_, email: string, password: string) => {
+    if (isRateLimited('signUp')) {
+      return { success: false, error: 'Too many attempts. Please wait.' };
+    }
     // Input validation
     if (!email || typeof email !== 'string' || !isValidEmail(email)) {
       return { success: false, error: 'Invalid email address' };

--- a/apps/desktop/src/main/services/LicenseService.ts
+++ b/apps/desktop/src/main/services/LicenseService.ts
@@ -5,6 +5,7 @@ import {
   deleteLicense,
 } from '../database/queries/license';
 import { getAppDatabase } from '../database';
+import { v4 as uuidv4 } from 'uuid';
 import { logger } from '../utils/logger';
 import type {
   UserLicense,
@@ -74,6 +75,7 @@ export class LicenseService {
     if (!license) {
       return {
         status: 'expired',
+        tier: null,
         message: 'No license found. Please activate.',
         canView: false,
         canEdit: false,
@@ -85,6 +87,7 @@ export class LicenseService {
     if (license.tier === 'demo') {
       return {
         status: 'active',
+        tier: 'demo',
         message: 'Demo mode — sign in for full access',
         canView: true,
         canEdit: true,
@@ -98,10 +101,14 @@ export class LicenseService {
     const daysSinceVerification = this.daysBetween(license.lastVerified, now);
     const daysUntilMaintenance = this.daysBetween(now, maintenanceEnd);
 
+    // Cloud sync requires both active maintenance AND the cloud_sync flag from Supabase
+    const cloudSyncEnabled = license.cloudSync;
+
     // Suspended license — no access
     if (license.status === 'suspended') {
       return {
         status: 'suspended',
+        tier: license.tier,
         message: 'License suspended. Please contact support.',
         canView: false,
         canEdit: false,
@@ -113,6 +120,7 @@ export class LicenseService {
     if (daysSinceVerification > this.OFFLINE_GRACE_DAYS) {
       return {
         status: 'grace',
+        tier: license.tier,
         message: `License verification needed. Please connect to internet. (${daysSinceVerification} days offline)`,
         canView: true,
         canEdit: true,
@@ -130,6 +138,7 @@ export class LicenseService {
       if (canRun) {
         return {
           status: 'maintenance_expired',
+          tier: license.tier,
           message:
             'Maintenance expired. App continues to work, but cloud sync is disabled. Renew to get updates and sync.',
           canView: true,
@@ -141,6 +150,7 @@ export class LicenseService {
       // Build is newer than maintenance end — cannot run
       return {
         status: 'expired',
+        tier: license.tier,
         message:
           'This version of ShowStack requires an active maintenance plan. Please renew your license.',
         canView: true,
@@ -153,10 +163,11 @@ export class LicenseService {
     if (daysUntilMaintenance <= this.EXPIRATION_WARNING_DAYS) {
       return {
         status: 'active',
+        tier: license.tier,
         message: `Maintenance expires in ${daysUntilMaintenance} days. Renew to continue receiving updates and cloud sync.`,
         canView: true,
         canEdit: true,
-        canSync: true,
+        canSync: cloudSyncEnabled,
         warningLevel: 'low',
         daysUntilExpiration: daysUntilMaintenance,
       };
@@ -165,10 +176,11 @@ export class LicenseService {
     // Fully active
     return {
       status: 'active',
+      tier: license.tier,
       message: 'License active',
       canView: true,
       canEdit: true,
-      canSync: true,
+      canSync: cloudSyncEnabled,
     };
   }
 
@@ -207,26 +219,44 @@ export class LicenseService {
 
       // Update local SQLite with server data
       const localLicense = getCurrentLicense();
+      const maintenanceEndDate = new Date(serverLicense.maintenance_end_date).getTime();
 
-      // If existing license is a demo, atomically replace it with the real license.
-      // Note: createLicense/deleteLicense call saveAppDatabase() internally, but that's
-      // a no-op under WAL mode, so it doesn't break transaction atomicity.
       if (localLicense && localLicense.tier === 'demo') {
+        // Atomically replace demo license with real license using raw SQL.
+        // Raw SQL avoids calling saveAppDatabase() inside the transaction body,
+        // keeping the transaction purely database operations.
         const demoId = localLicense.id;
         try {
           const db = getAppDatabase();
+          const now = Date.now();
+          const newId = uuidv4();
           const replaceLicense = db.transaction(() => {
-            createLicense({
-              email: serverLicense.email,
-              name: serverLicense.name || '',
-              licenseKey: serverLicense.license_key,
-              tier: serverLicense.tier,
-              modules: serverLicense.modules,
-              expirationDate: new Date(serverLicense.maintenance_end_date).getTime(),
-              maintenanceEndDate: new Date(serverLicense.maintenance_end_date).getTime(),
-              userId: serverLicense.user_id ?? undefined,
-            });
-            deleteLicense(demoId);
+            db.prepare(
+              `INSERT INTO licenses (
+                id, email, name, license_key, tier, status, modules,
+                expiration_date, maintenance_end_date, user_id, cloud_sync,
+                last_verified, created_at, updated_at
+              ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+            ).run(
+              newId,
+              serverLicense.email,
+              serverLicense.name || '',
+              serverLicense.license_key,
+              serverLicense.tier,
+              'active',
+              JSON.stringify(serverLicense.modules),
+              maintenanceEndDate,
+              maintenanceEndDate,
+              serverLicense.user_id ?? null,
+              serverLicense.cloud_sync ? 1 : 0,
+              now,
+              now,
+              now,
+            );
+            db.prepare(`UPDATE licenses SET status = 'deleted', updated_at = ? WHERE id = ?`).run(
+              now,
+              demoId,
+            );
           });
           replaceLicense();
         } catch (replaceError) {
@@ -240,10 +270,11 @@ export class LicenseService {
         updateLicense(localLicense.id, {
           status: serverLicense.status === 'revoked' ? 'suspended' : serverLicense.status,
           name: serverLicense.name || localLicense.name,
-          maintenanceEndDate: new Date(serverLicense.maintenance_end_date).getTime(),
-          expirationDate: new Date(serverLicense.maintenance_end_date).getTime(),
+          maintenanceEndDate,
+          expirationDate: maintenanceEndDate,
           modules: serverLicense.modules,
           tier: serverLicense.tier,
+          cloudSync: serverLicense.cloud_sync,
           lastVerified: Date.now(),
         });
       } else {
@@ -254,9 +285,10 @@ export class LicenseService {
           licenseKey: serverLicense.license_key,
           tier: serverLicense.tier,
           modules: serverLicense.modules,
-          expirationDate: new Date(serverLicense.maintenance_end_date).getTime(),
-          maintenanceEndDate: new Date(serverLicense.maintenance_end_date).getTime(),
+          expirationDate: maintenanceEndDate,
+          maintenanceEndDate,
           userId: serverLicense.user_id ?? undefined,
+          cloudSync: serverLicense.cloud_sync,
         });
       }
 

--- a/apps/desktop/src/main/services/LicenseService.ts
+++ b/apps/desktop/src/main/services/LicenseService.ts
@@ -17,8 +17,24 @@ import type {
 /**
  * Build date used for perpetual fallback licensing.
  * If the app was built before maintenance_end_date, it can still run.
+ * In production, BUILD_DATE must be set at build time. In development,
+ * we fall back to the current date so the app can run without a build step.
  */
-const APP_BUILD_DATE = new Date(process.env.BUILD_DATE || new Date().toISOString());
+function getAppBuildDate(): Date {
+  if (process.env.BUILD_DATE) {
+    return new Date(process.env.BUILD_DATE);
+  }
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error(
+      'BUILD_DATE environment variable must be set in production builds. ' +
+        'This is required for perpetual fallback licensing.',
+    );
+  }
+  // Development fallback — current date means maintenance checks behave as "just built"
+  return new Date();
+}
+
+const APP_BUILD_DATE = getAppBuildDate();
 
 /**
  * License Service
@@ -175,23 +191,24 @@ export class LicenseService {
       // Update local SQLite with server data
       const localLicense = getCurrentLicense();
 
-      // If existing license is a demo, delete it so we create a fresh real one
+      // If existing license is a demo, create real license first, then delete demo
+      // (create-before-delete avoids a window where no license exists)
       if (localLicense && localLicense.tier === 'demo') {
-        deleteLicense(localLicense.id);
-        // Create local license from server data
+        const demoId = localLicense.id;
         createLicense({
           email: serverLicense.email,
           name: serverLicense.name || '',
           licenseKey: serverLicense.license_key,
-          tier: serverLicense.tier as LicenseTier,
+          tier: serverLicense.tier,
           modules: serverLicense.modules,
           expirationDate: new Date(serverLicense.maintenance_end_date).getTime(),
           maintenanceEndDate: new Date(serverLicense.maintenance_end_date).getTime(),
-          userId: serverLicense.user_id,
+          userId: serverLicense.user_id ?? undefined,
         });
+        deleteLicense(demoId);
       } else if (localLicense) {
         updateLicense(localLicense.id, {
-          status: serverLicense.status as 'active' | 'expired' | 'suspended',
+          status: serverLicense.status === 'revoked' ? 'suspended' : serverLicense.status,
           name: serverLicense.name || localLicense.name,
           maintenanceEndDate: new Date(serverLicense.maintenance_end_date).getTime(),
           expirationDate: new Date(serverLicense.maintenance_end_date).getTime(),
@@ -205,11 +222,11 @@ export class LicenseService {
           email: serverLicense.email,
           name: serverLicense.name || '',
           licenseKey: serverLicense.license_key,
-          tier: serverLicense.tier as LicenseTier,
+          tier: serverLicense.tier,
           modules: serverLicense.modules,
           expirationDate: new Date(serverLicense.maintenance_end_date).getTime(),
           maintenanceEndDate: new Date(serverLicense.maintenance_end_date).getTime(),
-          userId: serverLicense.user_id,
+          userId: serverLicense.user_id ?? undefined,
         });
       }
 

--- a/apps/desktop/src/main/services/LicenseService.ts
+++ b/apps/desktop/src/main/services/LicenseService.ts
@@ -195,17 +195,25 @@ export class LicenseService {
       // (create-before-delete avoids a window where no license exists)
       if (localLicense && localLicense.tier === 'demo') {
         const demoId = localLicense.id;
-        createLicense({
-          email: serverLicense.email,
-          name: serverLicense.name || '',
-          licenseKey: serverLicense.license_key,
-          tier: serverLicense.tier,
-          modules: serverLicense.modules,
-          expirationDate: new Date(serverLicense.maintenance_end_date).getTime(),
-          maintenanceEndDate: new Date(serverLicense.maintenance_end_date).getTime(),
-          userId: serverLicense.user_id ?? undefined,
-        });
-        deleteLicense(demoId);
+        try {
+          createLicense({
+            email: serverLicense.email,
+            name: serverLicense.name || '',
+            licenseKey: serverLicense.license_key,
+            tier: serverLicense.tier,
+            modules: serverLicense.modules,
+            expirationDate: new Date(serverLicense.maintenance_end_date).getTime(),
+            maintenanceEndDate: new Date(serverLicense.maintenance_end_date).getTime(),
+            userId: serverLicense.user_id ?? undefined,
+          });
+          deleteLicense(demoId);
+        } catch (replaceError) {
+          logger.error('Failed to replace demo license with real license', {
+            error: replaceError instanceof Error ? replaceError.message : String(replaceError),
+          });
+          // Demo license remains — user still has access, verification will retry
+          return false;
+        }
       } else if (localLicense) {
         updateLicense(localLicense.id, {
           status: serverLicense.status === 'revoked' ? 'suspended' : serverLicense.status,
@@ -295,16 +303,11 @@ export class LicenseService {
   /**
    * Check if user can use a specific feature
    */
-  canUseFeature(module: ShowStackModule, feature: string): boolean {
+  canUseFeature(module: ShowStackModule, feature: keyof ModuleFeatures): boolean {
     const features = this.getModuleFeatures(module);
     if (!features) return false;
 
-    if (feature in features) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return !!(features as any)[feature];
-    }
-
-    return false;
+    return !!features[feature];
   }
 
   /**

--- a/apps/desktop/src/main/services/LicenseService.ts
+++ b/apps/desktop/src/main/services/LicenseService.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import {
   getCurrentLicense,
   getLicenseByKey,
@@ -16,19 +15,25 @@ import type {
 } from '../../shared/types/license.types';
 
 /**
+ * Build date used for perpetual fallback licensing.
+ * If the app was built before maintenance_end_date, it can still run.
+ */
+const APP_BUILD_DATE = new Date(process.env.BUILD_DATE || new Date().toISOString());
+
+/**
  * License Service
  *
  * Handles license validation, verification, and feature access control.
- * Uses offline-first approach with 14-day grace period.
+ * Uses perpetual fallback model: app runs if built before maintenance_end_date.
+ * Cloud sync requires active maintenance.
  */
 export class LicenseService {
-  // Grace period constants
   private readonly OFFLINE_GRACE_DAYS = 14;
   private readonly EXPIRATION_WARNING_DAYS = 7;
   private readonly VERIFICATION_INTERVAL_HOURS = 24;
 
   /**
-   * Get current license validation status
+   * Get current license validation status with perpetual fallback model
    */
   getLicenseStatus(): LicenseValidation {
     const license = getCurrentLicense();
@@ -39,97 +44,198 @@ export class LicenseService {
         message: 'No license found. Please activate.',
         canView: false,
         canEdit: false,
+        canSync: false,
       };
     }
 
     const now = Date.now();
+    const maintenanceEnd = license.maintenanceEndDate;
+    const buildTime = APP_BUILD_DATE.getTime();
     const daysSinceVerification = this.daysBetween(license.lastVerified, now);
-    const daysUntilExpiration = this.daysBetween(now, license.expirationDate);
+    const daysUntilMaintenance = this.daysBetween(now, maintenanceEnd);
 
-    // Check if subscription is expired
-    if (now > license.expirationDate) {
-      if (daysSinceVerification <= this.OFFLINE_GRACE_DAYS) {
-        return {
-          status: 'expired',
-          message: 'Subscription expired. Please renew to continue editing.',
-          canView: true,
-          canEdit: false,
-        };
-      }
-
+    // Suspended license — no access
+    if (license.status === 'suspended') {
       return {
-        status: 'grace',
-        message: `Unable to verify license. Please connect to internet. (${daysSinceVerification} days offline)`,
-        canView: true,
-        canEdit: true,
-        warningLevel: 'high',
-        daysSinceVerification,
+        status: 'suspended',
+        message: 'License suspended. Please contact support.',
+        canView: false,
+        canEdit: false,
+        canSync: false,
       };
     }
 
-    // Check if verification is stale
+    // Check verification staleness (offline grace period)
     if (daysSinceVerification > this.OFFLINE_GRACE_DAYS) {
       return {
         status: 'grace',
         message: `License verification needed. Please connect to internet. (${daysSinceVerification} days offline)`,
         canView: true,
         canEdit: true,
-        warningLevel: 'medium',
+        canSync: false,
+        warningLevel: daysSinceVerification > this.OFFLINE_GRACE_DAYS * 2 ? 'high' : 'medium',
         daysSinceVerification,
       };
     }
 
-    // Check if approaching expiration
-    if (daysUntilExpiration <= this.EXPIRATION_WARNING_DAYS) {
+    // Maintenance expired
+    if (now > maintenanceEnd) {
+      // Perpetual fallback: app built before maintenance end can still run
+      const canRun = buildTime <= maintenanceEnd;
+
+      if (canRun) {
+        return {
+          status: 'maintenance_expired',
+          message:
+            'Maintenance expired. App continues to work, but cloud sync is disabled. Renew to get updates and sync.',
+          canView: true,
+          canEdit: true,
+          canSync: false,
+        };
+      }
+
+      // Build is newer than maintenance end — cannot run
       return {
-        status: 'active',
-        message: `License expires in ${daysUntilExpiration} days. Please renew soon.`,
+        status: 'expired',
+        message:
+          'This version of ShowStack requires an active maintenance plan. Please renew your license.',
         canView: true,
-        canEdit: true,
-        warningLevel: 'low',
-        daysUntilExpiration,
+        canEdit: false,
+        canSync: false,
       };
     }
 
+    // Active maintenance — approaching expiration warning
+    if (daysUntilMaintenance <= this.EXPIRATION_WARNING_DAYS) {
+      return {
+        status: 'active',
+        message: `Maintenance expires in ${daysUntilMaintenance} days. Renew to continue receiving updates and cloud sync.`,
+        canView: true,
+        canEdit: true,
+        canSync: true,
+        warningLevel: 'low',
+        daysUntilExpiration: daysUntilMaintenance,
+      };
+    }
+
+    // Fully active
     return {
       status: 'active',
       message: 'License active',
       canView: true,
       canEdit: true,
+      canSync: true,
     };
   }
 
   /**
-   * Verify license against online server
+   * Verify license via Supabase (replaces old API endpoint verification)
    */
-  async verifyLicenseOnline(licenseKey: string): Promise<boolean> {
+  async verifyLicenseViaSupabase(): Promise<boolean> {
     try {
-      // TODO: Replace with your actual API endpoint
-      const response = await fetch('https://api.showstack.app/verify-license', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ licenseKey }),
-        signal: AbortSignal.timeout(5000), // 5 second timeout
-      });
+      const { getSupabaseConnector } = await import('../services/sync/SupabaseConnector');
+      const connector = getSupabaseConnector();
 
-      if (!response.ok) return false;
+      if (!connector.isAuthenticated()) {
+        logger.info('License verification skipped: not authenticated');
+        return false;
+      }
 
-      const data = await response.json();
+      const serverLicense = await connector.fetchUserLicense();
+      if (!serverLicense) {
+        logger.info('No license found on server for current user');
+        return false;
+      }
 
-      const license = getLicenseByKey(licenseKey);
-      if (!license) return false;
+      // Update local SQLite with server data
+      const localLicense = getCurrentLicense();
+      if (localLicense) {
+        updateLicense(localLicense.id, {
+          status: serverLicense.status as 'active' | 'expired' | 'suspended',
+          maintenanceEndDate: new Date(serverLicense.maintenance_end_date).getTime(),
+          expirationDate: new Date(serverLicense.maintenance_end_date).getTime(),
+          modules: serverLicense.modules,
+          tier: serverLicense.tier,
+          lastVerified: Date.now(),
+        });
+      } else {
+        // Create local license from server data
+        createLicense({
+          email: serverLicense.email,
+          licenseKey: serverLicense.license_key,
+          tier: serverLicense.tier as LicenseTier,
+          modules: serverLicense.modules,
+          expirationDate: new Date(serverLicense.maintenance_end_date).getTime(),
+          maintenanceEndDate: new Date(serverLicense.maintenance_end_date).getTime(),
+          userId: serverLicense.user_id,
+        });
+      }
 
-      updateLicense(license.id, {
-        status: data.status,
-        expirationDate: new Date(data.expirationDate).getTime(),
-        lastVerified: Date.now(),
-        modules: data.modules,
-      });
-
-      return data.status === 'active';
+      return serverLicense.status === 'active';
     } catch (error) {
-      logger.error('License verification failed (offline):', error);
+      logger.error('License verification via Supabase failed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
       return false;
+    }
+  }
+
+  /**
+   * Activate a license key via Supabase RPC
+   */
+  async activateLicenseKey(
+    licenseKey: string,
+  ): Promise<{ success: boolean; error?: string; license?: UserLicense }> {
+    try {
+      const { getSupabaseConnector } = await import('../services/sync/SupabaseConnector');
+      const connector = getSupabaseConnector();
+
+      if (!connector.isAuthenticated()) {
+        return { success: false, error: 'You must be signed in to activate a license' };
+      }
+
+      const result = await connector.activateLicense(licenseKey);
+
+      if (!result.success) {
+        return { success: false, error: result.error };
+      }
+
+      const serverLicense = result.license;
+
+      // Store license locally in SQLite
+      const existing = getLicenseByKey(licenseKey);
+      if (existing) {
+        const updated = updateLicense(existing.id, {
+          userId: connector.getUserId() || undefined,
+          tier: serverLicense.tier as LicenseTier,
+          modules: serverLicense.modules,
+          maintenanceEndDate: new Date(serverLicense.maintenanceEndDate).getTime(),
+          expirationDate: new Date(serverLicense.maintenanceEndDate).getTime(),
+          status: serverLicense.status as 'active' | 'expired' | 'suspended',
+          lastVerified: Date.now(),
+        });
+        return { success: true, license: updated };
+      }
+
+      const newLicense = createLicense({
+        email: connector.getSession()?.user?.email || '',
+        licenseKey: serverLicense.licenseKey,
+        tier: serverLicense.tier as LicenseTier,
+        modules: serverLicense.modules || [],
+        expirationDate: new Date(serverLicense.maintenanceEndDate).getTime(),
+        maintenanceEndDate: new Date(serverLicense.maintenanceEndDate).getTime(),
+        userId: connector.getUserId() || undefined,
+      });
+
+      return { success: true, license: newLicense };
+    } catch (error) {
+      logger.error('License activation failed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Activation failed',
+      };
     }
   }
 
@@ -143,7 +249,7 @@ export class LicenseService {
     const hoursSinceCheck = this.hoursBetween(license.lastVerified, Date.now());
 
     if (hoursSinceCheck >= this.VERIFICATION_INTERVAL_HOURS) {
-      await this.verifyLicenseOnline(license.licenseKey);
+      await this.verifyLicenseViaSupabase();
     }
   }
 
@@ -159,7 +265,7 @@ export class LicenseService {
       return false;
     }
 
-    const moduleAccess = license.modules.find((m) => m.module === module);
+    const moduleAccess = license.modules.find((m: ModuleAccess) => m.module === module);
     return moduleAccess?.enabled ?? false;
   }
 
@@ -170,7 +276,7 @@ export class LicenseService {
     const license = getCurrentLicense();
     if (!license) return null;
 
-    const moduleAccess = license.modules.find((m) => m.module === module);
+    const moduleAccess = license.modules.find((m: ModuleAccess) => m.module === module);
     return moduleAccess?.features ?? null;
   }
 
@@ -181,7 +287,9 @@ export class LicenseService {
     const license = getCurrentLicense();
     if (!license) return [];
 
-    return license.modules.filter((m) => m.enabled).map((m) => m.module);
+    return license.modules
+      .filter((m: ModuleAccess) => m.enabled)
+      .map((m: ModuleAccess) => m.module);
   }
 
   /**
@@ -191,19 +299,21 @@ export class LicenseService {
     const features = this.getModuleFeatures(module);
     if (!features) return false;
 
-    // Check universal features
     if (feature in features) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       return !!(features as any)[feature];
     }
 
-    // Check module-specific features
     if (module === 'prep' && features.prepFeatures) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       return !!(features.prepFeatures as any)[feature];
     }
     if (module === 'production' && features.productionFeatures) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       return !!(features.productionFeatures as any)[feature];
     }
     if (module === 'manager' && features.managerFeatures) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       return !!(features.managerFeatures as any)[feature];
     }
 
@@ -218,9 +328,10 @@ export class LicenseService {
   }
 
   /**
-   * Activate a new license
+   * Legacy: activate a license locally without Supabase
+   * Kept for backwards compatibility and offline-first scenarios
    */
-  activateLicense(
+  activateLicenseLocally(
     licenseKey: string,
     email: string,
     purchasedModules: ShowStackModule[],
@@ -233,19 +344,19 @@ export class LicenseService {
       features: this.getDefaultFeaturesForTier(tier, module),
     }));
 
+    const maintenanceEndDate = Date.now() + 365 * 24 * 60 * 60 * 1000; // 1 year
+
     return createLicense({
       email,
       name: '',
       licenseKey,
       tier,
       modules,
-      expirationDate: Date.now() + 365 * 24 * 60 * 60 * 1000, // 1 year
+      expirationDate: maintenanceEndDate,
+      maintenanceEndDate,
     });
   }
 
-  /**
-   * Get default features for a tier and module
-   */
   private getDefaultFeaturesForTier(tier: LicenseTier, module: ShowStackModule): ModuleFeatures {
     const tierFeatures = {
       professional: {
@@ -307,24 +418,15 @@ export class LicenseService {
     return moduleFeatures;
   }
 
-  /**
-   * Determine tier from purchased modules
-   */
   private determineTierFromModules(modules: ShowStackModule[]): LicenseTier {
     if (modules.includes('student')) return 'student';
     return 'professional';
   }
 
-  /**
-   * Calculate days between two timestamps
-   */
   private daysBetween(timestamp1: number, timestamp2: number): number {
     return Math.floor((timestamp2 - timestamp1) / (1000 * 60 * 60 * 24));
   }
 
-  /**
-   * Calculate hours between two timestamps
-   */
   private hoursBetween(timestamp1: number, timestamp2: number): number {
     return Math.floor((timestamp2 - timestamp1) / (1000 * 60 * 60));
   }

--- a/apps/desktop/src/main/services/LicenseService.ts
+++ b/apps/desktop/src/main/services/LicenseService.ts
@@ -1,4 +1,9 @@
-import { getCurrentLicense, createLicense, updateLicense } from '../database/queries/license';
+import {
+  getCurrentLicense,
+  createLicense,
+  updateLicense,
+  deleteLicense,
+} from '../database/queries/license';
 import { logger } from '../utils/logger';
 import type {
   UserLicense,
@@ -39,6 +44,17 @@ export class LicenseService {
         message: 'No license found. Please activate.',
         canView: false,
         canEdit: false,
+        canSync: false,
+      };
+    }
+
+    // Demo tier — local-only with restrictions
+    if (license.tier === 'demo') {
+      return {
+        status: 'active',
+        message: 'Demo mode — sign in for full access',
+        canView: true,
+        canEdit: true,
         canSync: false,
       };
     }
@@ -158,9 +174,25 @@ export class LicenseService {
 
       // Update local SQLite with server data
       const localLicense = getCurrentLicense();
-      if (localLicense) {
+
+      // If existing license is a demo, delete it so we create a fresh real one
+      if (localLicense && localLicense.tier === 'demo') {
+        deleteLicense(localLicense.id);
+        // Create local license from server data
+        createLicense({
+          email: serverLicense.email,
+          name: serverLicense.name || '',
+          licenseKey: serverLicense.license_key,
+          tier: serverLicense.tier as LicenseTier,
+          modules: serverLicense.modules,
+          expirationDate: new Date(serverLicense.maintenance_end_date).getTime(),
+          maintenanceEndDate: new Date(serverLicense.maintenance_end_date).getTime(),
+          userId: serverLicense.user_id,
+        });
+      } else if (localLicense) {
         updateLicense(localLicense.id, {
           status: serverLicense.status as 'active' | 'expired' | 'suspended',
+          name: serverLicense.name || localLicense.name,
           maintenanceEndDate: new Date(serverLicense.maintenance_end_date).getTime(),
           expirationDate: new Date(serverLicense.maintenance_end_date).getTime(),
           modules: serverLicense.modules,
@@ -171,6 +203,7 @@ export class LicenseService {
         // Create local license from server data
         createLicense({
           email: serverLicense.email,
+          name: serverLicense.name || '',
           licenseKey: serverLicense.license_key,
           tier: serverLicense.tier as LicenseTier,
           modules: serverLicense.modules,
@@ -265,6 +298,46 @@ export class LicenseService {
   }
 
   /**
+   * Create a demo license with restricted features.
+   * All 6 modules enabled at demo tier.
+   */
+  createDemoLicense(): UserLicense {
+    // Remove any existing demo license first
+    const existing = getCurrentLicense();
+    if (existing && existing.tier === 'demo') {
+      deleteLicense(existing.id);
+    }
+
+    const allModules: ShowStackModule[] = [
+      'lighting',
+      'sound',
+      'video',
+      'production_management',
+      'touring',
+      'producer',
+    ];
+
+    const modules: ModuleAccess[] = allModules.map((module) => ({
+      module,
+      enabled: true,
+      features: this.getDefaultFeaturesForTier('demo', module),
+    }));
+
+    // Demo licenses don't expire — they're replaced when a real license is found
+    const farFuture = Date.now() + 100 * 365 * 24 * 60 * 60 * 1000;
+
+    return createLicense({
+      email: 'demo@local',
+      name: 'Demo User',
+      licenseKey: `DEMO-${Date.now()}`,
+      tier: 'demo',
+      modules,
+      expirationDate: farFuture,
+      maintenanceEndDate: farFuture,
+    });
+  }
+
+  /**
    * Legacy: activate a license locally without Supabase
    * Kept for backwards compatibility and offline-first scenarios
    */
@@ -295,9 +368,10 @@ export class LicenseService {
   }
 
   private getDefaultFeaturesForTier(tier: LicenseTier, _module: ShowStackModule): ModuleFeatures {
-    const tierFeatures = {
+    const tierFeatures: Record<LicenseTier, ModuleFeatures> = {
       professional: {
         maxRevisions: 5,
+        maxFixtures: -1,
         multiDiscipline: true,
         advancedExport: true,
         cloudSync: true,
@@ -305,6 +379,7 @@ export class LicenseService {
       },
       student: {
         maxRevisions: 2,
+        maxFixtures: 100,
         multiDiscipline: false,
         advancedExport: false,
         cloudSync: false,
@@ -312,10 +387,19 @@ export class LicenseService {
       },
       institutional: {
         maxRevisions: 3,
+        maxFixtures: -1,
         multiDiscipline: true,
         advancedExport: true,
         cloudSync: true,
         prioritySupport: true,
+      },
+      demo: {
+        maxRevisions: 0,
+        maxFixtures: 25,
+        multiDiscipline: false,
+        advancedExport: false,
+        cloudSync: false,
+        prioritySupport: false,
       },
     };
 

--- a/apps/desktop/src/main/services/LicenseService.ts
+++ b/apps/desktop/src/main/services/LicenseService.ts
@@ -56,7 +56,9 @@ const APP_BUILD_DATE = getAppBuildDate();
  */
 /** Time constants */
 const ONE_YEAR_MS = 365 * 24 * 60 * 60 * 1000;
-const DEMO_EXPIRY_MS = 100 * ONE_YEAR_MS; // effectively never
+// Demo licenses never expire on their own — they're replaced when a real license is found.
+// 100 years is a sentinel value that ensures demo licenses never hit expiration logic.
+const DEMO_EXPIRY_MS = 100 * ONE_YEAR_MS;
 
 /** Demo tier feature limits */
 export const DEMO_FIXTURE_LIMIT = 25;
@@ -217,6 +219,17 @@ export class LicenseService {
 
       if (!serverLicense) {
         logger.info('No license found on server for current user');
+        return false;
+      }
+
+      // Validate server license data before writing to local database
+      if (
+        !serverLicense.email ||
+        !serverLicense.license_key ||
+        !serverLicense.tier ||
+        !serverLicense.maintenance_end_date
+      ) {
+        logger.warn('Server license missing required fields, skipping update');
         return false;
       }
 

--- a/apps/desktop/src/main/services/LicenseService.ts
+++ b/apps/desktop/src/main/services/LicenseService.ts
@@ -209,6 +209,9 @@ export class LicenseService {
           serverLicense = await connector.fetchUserLicense();
         } else {
           logger.warn(`Auto-claim failed: ${claimResult.error}`);
+          // Don't proceed with an unclaimed license — would create a local record
+          // with null user_id. The claim can be retried on next verification cycle.
+          return false;
         }
       }
 
@@ -228,9 +231,9 @@ export class LicenseService {
         const demoId = localLicense.id;
         try {
           const db = getAppDatabase();
-          const now = Date.now();
-          const newId = uuidv4();
           const replaceLicense = db.transaction(() => {
+            const now = Date.now();
+            const newId = uuidv4();
             db.prepare(
               `INSERT INTO licenses (
                 id, email, name, license_key, tier, status, modules,

--- a/apps/desktop/src/main/services/LicenseService.ts
+++ b/apps/desktop/src/main/services/LicenseService.ts
@@ -1,9 +1,4 @@
-import {
-  getCurrentLicense,
-  getLicenseByKey,
-  createLicense,
-  updateLicense,
-} from '../database/queries/license';
+import { getCurrentLicense, createLicense, updateLicense } from '../database/queries/license';
 import { logger } from '../utils/logger';
 import type {
   UserLicense,
@@ -129,7 +124,8 @@ export class LicenseService {
   }
 
   /**
-   * Verify license via Supabase (replaces old API endpoint verification)
+   * Verify license via Supabase.
+   * First tries fetching by user_id (already claimed), then auto-claims by email.
    */
   async verifyLicenseViaSupabase(): Promise<boolean> {
     try {
@@ -141,7 +137,20 @@ export class LicenseService {
         return false;
       }
 
-      const serverLicense = await connector.fetchUserLicense();
+      let serverLicense = await connector.fetchUserLicense();
+
+      // If fetchUserLicense found an unclaimed email match, try to claim it
+      if (serverLicense && !serverLicense.user_id) {
+        logger.info('Found unclaimed license matching email, attempting auto-claim');
+        const claimResult = await connector.claimLicenseByEmail();
+        if (claimResult.success) {
+          // Re-fetch to get the updated record with user_id set
+          serverLicense = await connector.fetchUserLicense();
+        } else {
+          logger.warn(`Auto-claim failed: ${claimResult.error}`);
+        }
+      }
+
       if (!serverLicense) {
         logger.info('No license found on server for current user');
         return false;
@@ -177,65 +186,6 @@ export class LicenseService {
         error: error instanceof Error ? error.message : String(error),
       });
       return false;
-    }
-  }
-
-  /**
-   * Activate a license key via Supabase RPC
-   */
-  async activateLicenseKey(
-    licenseKey: string,
-  ): Promise<{ success: boolean; error?: string; license?: UserLicense }> {
-    try {
-      const { getSupabaseConnector } = await import('../services/sync/SupabaseConnector');
-      const connector = getSupabaseConnector();
-
-      if (!connector.isAuthenticated()) {
-        return { success: false, error: 'You must be signed in to activate a license' };
-      }
-
-      const result = await connector.activateLicense(licenseKey);
-
-      if (!result.success) {
-        return { success: false, error: result.error };
-      }
-
-      const serverLicense = result.license;
-
-      // Store license locally in SQLite
-      const existing = getLicenseByKey(licenseKey);
-      if (existing) {
-        const updated = updateLicense(existing.id, {
-          userId: connector.getUserId() || undefined,
-          tier: serverLicense.tier as LicenseTier,
-          modules: serverLicense.modules,
-          maintenanceEndDate: new Date(serverLicense.maintenanceEndDate).getTime(),
-          expirationDate: new Date(serverLicense.maintenanceEndDate).getTime(),
-          status: serverLicense.status as 'active' | 'expired' | 'suspended',
-          lastVerified: Date.now(),
-        });
-        return { success: true, license: updated };
-      }
-
-      const newLicense = createLicense({
-        email: connector.getSession()?.user?.email || '',
-        licenseKey: serverLicense.licenseKey,
-        tier: serverLicense.tier as LicenseTier,
-        modules: serverLicense.modules || [],
-        expirationDate: new Date(serverLicense.maintenanceEndDate).getTime(),
-        maintenanceEndDate: new Date(serverLicense.maintenanceEndDate).getTime(),
-        userId: connector.getUserId() || undefined,
-      });
-
-      return { success: true, license: newLicense };
-    } catch (error) {
-      logger.error('License activation failed', {
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Activation failed',
-      };
     }
   }
 

--- a/apps/desktop/src/main/services/LicenseService.ts
+++ b/apps/desktop/src/main/services/LicenseService.ts
@@ -254,19 +254,6 @@ export class LicenseService {
       return !!(features as any)[feature];
     }
 
-    if (module === 'prep' && features.prepFeatures) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return !!(features.prepFeatures as any)[feature];
-    }
-    if (module === 'production' && features.productionFeatures) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return !!(features.productionFeatures as any)[feature];
-    }
-    if (module === 'manager' && features.managerFeatures) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return !!(features.managerFeatures as any)[feature];
-    }
-
     return false;
   }
 
@@ -307,7 +294,7 @@ export class LicenseService {
     });
   }
 
-  private getDefaultFeaturesForTier(tier: LicenseTier, module: ShowStackModule): ModuleFeatures {
+  private getDefaultFeaturesForTier(tier: LicenseTier, _module: ShowStackModule): ModuleFeatures {
     const tierFeatures = {
       professional: {
         maxRevisions: 5,
@@ -332,44 +319,10 @@ export class LicenseService {
       },
     };
 
-    const baseFeatures = tierFeatures[tier] || tierFeatures.student;
-    const moduleFeatures: ModuleFeatures = { ...baseFeatures };
-
-    if (module === 'prep') {
-      moduleFeatures.prepFeatures = {
-        maxProjects: tier === 'professional' ? -1 : 3,
-        logoIntegration: tier !== 'student',
-        vendorTemplates: tier !== 'student',
-        equipmentDatabase: true,
-        bulkOperations: tier !== 'student',
-      };
-    }
-
-    if (module === 'production') {
-      moduleFeatures.productionFeatures = {
-        vectorworksIntegration: tier !== 'student',
-        etcEosIntegration: tier !== 'student',
-        paperworkGeneration: true,
-        labelSystem: true,
-        powerManagement: tier !== 'student',
-      };
-    }
-
-    if (module === 'manager') {
-      moduleFeatures.managerFeatures = {
-        plaidIntegration: tier === 'professional',
-        multiShowManagement: true,
-        budgetTracking: true,
-        perDiemCalculation: tier !== 'student',
-        tourLogistics: tier !== 'student',
-      };
-    }
-
-    return moduleFeatures;
+    return tierFeatures[tier] || tierFeatures.student;
   }
 
-  private determineTierFromModules(modules: ShowStackModule[]): LicenseTier {
-    if (modules.includes('student')) return 'student';
+  private determineTierFromModules(_modules: ShowStackModule[]): LicenseTier {
     return 'professional';
   }
 

--- a/apps/desktop/src/main/services/LicenseService.ts
+++ b/apps/desktop/src/main/services/LicenseService.ts
@@ -26,7 +26,13 @@ import type {
  */
 function getAppBuildDate(): Date {
   if (process.env.BUILD_DATE) {
-    return new Date(process.env.BUILD_DATE);
+    const date = new Date(process.env.BUILD_DATE);
+    if (isNaN(date.getTime())) {
+      throw new Error(
+        `BUILD_DATE environment variable is not a valid date: "${process.env.BUILD_DATE}"`,
+      );
+    }
+    return date;
   }
   if (process.env.NODE_ENV === 'production') {
     throw new Error(
@@ -47,6 +53,13 @@ const APP_BUILD_DATE = getAppBuildDate();
  * Uses perpetual fallback model: app runs if built before maintenance_end_date.
  * Cloud sync requires active maintenance.
  */
+/** Time constants */
+const ONE_YEAR_MS = 365 * 24 * 60 * 60 * 1000;
+const DEMO_EXPIRY_MS = 100 * ONE_YEAR_MS; // effectively never
+
+/** Demo tier feature limits */
+export const DEMO_FIXTURE_LIMIT = 25;
+
 export class LicenseService {
   private readonly OFFLINE_GRACE_DAYS = 14;
   private readonly EXPIRATION_WARNING_DAYS = 7;
@@ -195,7 +208,9 @@ export class LicenseService {
       // Update local SQLite with server data
       const localLicense = getCurrentLicense();
 
-      // If existing license is a demo, atomically replace it with the real license
+      // If existing license is a demo, atomically replace it with the real license.
+      // Note: createLicense/deleteLicense call saveAppDatabase() internally, but that's
+      // a no-op under WAL mode, so it doesn't break transaction atomicity.
       if (localLicense && localLicense.tier === 'demo') {
         const demoId = localLicense.id;
         try {
@@ -329,8 +344,13 @@ export class LicenseService {
    * All 6 modules enabled at demo tier.
    */
   createDemoLicense(): UserLicense {
-    // Remove any existing demo license first
     const existing = getCurrentLicense();
+    // Never downgrade a real license to demo
+    if (existing && existing.tier !== 'demo') {
+      logger.warn('Cannot create demo license: user already has a real license');
+      return existing;
+    }
+    // Remove any existing demo license first
     if (existing && existing.tier === 'demo') {
       deleteLicense(existing.id);
     }
@@ -351,7 +371,7 @@ export class LicenseService {
     }));
 
     // Demo licenses don't expire — they're replaced when a real license is found
-    const farFuture = Date.now() + 100 * 365 * 24 * 60 * 60 * 1000;
+    const farFuture = Date.now() + DEMO_EXPIRY_MS;
 
     return createLicense({
       email: 'demo@local',
@@ -381,7 +401,7 @@ export class LicenseService {
       features: this.getDefaultFeaturesForTier(tier, module),
     }));
 
-    const maintenanceEndDate = Date.now() + 365 * 24 * 60 * 60 * 1000; // 1 year
+    const maintenanceEndDate = Date.now() + ONE_YEAR_MS;
 
     return createLicense({
       email,
@@ -422,7 +442,7 @@ export class LicenseService {
       },
       demo: {
         maxRevisions: 0,
-        maxFixtures: 25,
+        maxFixtures: DEMO_FIXTURE_LIMIT,
         multiDiscipline: false,
         advancedExport: false,
         cloudSync: false,

--- a/apps/desktop/src/main/services/LicenseService.ts
+++ b/apps/desktop/src/main/services/LicenseService.ts
@@ -4,6 +4,7 @@ import {
   updateLicense,
   deleteLicense,
 } from '../database/queries/license';
+import { getAppDatabase } from '../database';
 import { logger } from '../utils/logger';
 import type {
   UserLicense,
@@ -19,6 +20,9 @@ import type {
  * If the app was built before maintenance_end_date, it can still run.
  * In production, BUILD_DATE must be set at build time. In development,
  * we fall back to the current date so the app can run without a build step.
+ *
+ * To test expired maintenance scenarios in development, set:
+ *   BUILD_DATE=2020-01-01 npm run dev
  */
 function getAppBuildDate(): Date {
   if (process.env.BUILD_DATE) {
@@ -191,27 +195,30 @@ export class LicenseService {
       // Update local SQLite with server data
       const localLicense = getCurrentLicense();
 
-      // If existing license is a demo, create real license first, then delete demo
-      // (create-before-delete avoids a window where no license exists)
+      // If existing license is a demo, atomically replace it with the real license
       if (localLicense && localLicense.tier === 'demo') {
         const demoId = localLicense.id;
         try {
-          createLicense({
-            email: serverLicense.email,
-            name: serverLicense.name || '',
-            licenseKey: serverLicense.license_key,
-            tier: serverLicense.tier,
-            modules: serverLicense.modules,
-            expirationDate: new Date(serverLicense.maintenance_end_date).getTime(),
-            maintenanceEndDate: new Date(serverLicense.maintenance_end_date).getTime(),
-            userId: serverLicense.user_id ?? undefined,
+          const db = getAppDatabase();
+          const replaceLicense = db.transaction(() => {
+            createLicense({
+              email: serverLicense.email,
+              name: serverLicense.name || '',
+              licenseKey: serverLicense.license_key,
+              tier: serverLicense.tier,
+              modules: serverLicense.modules,
+              expirationDate: new Date(serverLicense.maintenance_end_date).getTime(),
+              maintenanceEndDate: new Date(serverLicense.maintenance_end_date).getTime(),
+              userId: serverLicense.user_id ?? undefined,
+            });
+            deleteLicense(demoId);
           });
-          deleteLicense(demoId);
+          replaceLicense();
         } catch (replaceError) {
           logger.error('Failed to replace demo license with real license', {
             error: replaceError instanceof Error ? replaceError.message : String(replaceError),
           });
-          // Demo license remains — user still has access, verification will retry
+          // Transaction rolled back — demo license remains, verification will retry
           return false;
         }
       } else if (localLicense) {
@@ -240,9 +247,9 @@ export class LicenseService {
 
       return serverLicense.status === 'active';
     } catch (error) {
-      logger.error('License verification via Supabase failed', {
-        error: error instanceof Error ? error.message : String(error),
-      });
+      // Only log error message — avoid leaking license keys or user IDs
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      logger.error('License verification via Supabase failed', { error: message });
       return false;
     }
   }

--- a/apps/desktop/src/main/services/__tests__/LicenseService.test.ts
+++ b/apps/desktop/src/main/services/__tests__/LicenseService.test.ts
@@ -20,13 +20,15 @@ vi.mock('../../database/queries/license', () => ({
   deleteLicense: vi.fn(),
 }));
 
-// Mock getAppDatabase for transaction support
+// Mock getAppDatabase for transaction support and raw SQL
+const mockPrepare = vi.fn(() => ({ run: vi.fn() }));
 vi.mock('../../database', () => ({
   getAppDatabase: () => ({
     transaction: (fn: () => void) => {
       // Return a callable that executes the callback (mimics better-sqlite3 transaction)
       return () => fn();
     },
+    prepare: mockPrepare,
   }),
 }));
 
@@ -92,6 +94,7 @@ function buildLicense(overrides: Partial<UserLicense> = {}): UserLicense {
     licenseKey: 'TEST-KEY-1234',
     tier: 'professional',
     status: 'active',
+    cloudSync: true,
     modules: defaultModules,
     expirationDate: now + oneYear,
     maintenanceEndDate: now + oneYear,
@@ -107,16 +110,18 @@ describe('LicenseService', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockPrepare.mockReturnValue({ run: vi.fn() });
     service = new LicenseService();
   });
 
   describe('getLicenseStatus', () => {
-    it('returns expired with no license', () => {
+    it('returns expired with no license and null tier', () => {
       mockedGetCurrentLicense.mockReturnValue(null);
 
       const status = service.getLicenseStatus();
 
       expect(status.status).toBe('expired');
+      expect(status.tier).toBeNull();
       expect(status.canView).toBe(false);
       expect(status.canEdit).toBe(false);
       expect(status.canSync).toBe(false);
@@ -129,9 +134,22 @@ describe('LicenseService', () => {
       const status = service.getLicenseStatus();
 
       expect(status.status).toBe('active');
+      expect(status.tier).toBe('professional');
       expect(status.canView).toBe(true);
       expect(status.canEdit).toBe(true);
       expect(status.canSync).toBe(true);
+    });
+
+    it('returns canSync false when cloud_sync is disabled on license', () => {
+      const license = buildLicense({ cloudSync: false });
+      mockedGetCurrentLicense.mockReturnValue(license);
+
+      const status = service.getLicenseStatus();
+
+      expect(status.status).toBe('active');
+      expect(status.canView).toBe(true);
+      expect(status.canEdit).toBe(true);
+      expect(status.canSync).toBe(false);
     });
 
     it('returns active with warning when approaching expiration', () => {
@@ -331,6 +349,7 @@ describe('LicenseService', () => {
         modules: [],
         maintenance_end_date: '2027-06-01T00:00:00Z',
         status: 'active',
+        cloud_sync: true,
       });
 
       const localLicense = buildLicense({ id: 'local-id' });
@@ -361,6 +380,7 @@ describe('LicenseService', () => {
         modules: [],
         maintenance_end_date: '2027-06-01T00:00:00Z',
         status: 'active',
+        cloud_sync: false,
       });
 
       mockedGetCurrentLicense.mockReturnValue(null);
@@ -374,6 +394,7 @@ describe('LicenseService', () => {
           email: 'new@example.com',
           licenseKey: 'NEW-KEY',
           tier: 'student',
+          cloudSync: false,
         }),
       );
     });
@@ -391,6 +412,7 @@ describe('LicenseService', () => {
         modules: [],
         maintenance_end_date: '2027-06-01T00:00:00Z',
         status: 'active',
+        cloud_sync: true,
       };
 
       // After claim, returns the same license with user_id set
@@ -436,6 +458,7 @@ describe('LicenseService', () => {
         modules: [],
         maintenance_end_date: '2027-06-01T00:00:00Z',
         status: 'active',
+        cloud_sync: true,
       };
 
       // fetchUserLicense returns unclaimed license
@@ -564,13 +587,14 @@ describe('LicenseService', () => {
   });
 
   describe('getLicenseStatus — demo tier', () => {
-    it('returns active with demo message for demo license', () => {
+    it('returns active with demo tier for demo license', () => {
       const license = buildLicense({ tier: 'demo' });
       mockedGetCurrentLicense.mockReturnValue(license);
 
       const status = service.getLicenseStatus();
 
       expect(status.status).toBe('active');
+      expect(status.tier).toBe('demo');
       expect(status.message).toContain('Demo mode');
       expect(status.canView).toBe(true);
       expect(status.canEdit).toBe(true);
@@ -579,7 +603,7 @@ describe('LicenseService', () => {
   });
 
   describe('verifyLicenseViaSupabase — demo replacement', () => {
-    it('replaces demo license with server license', async () => {
+    it('replaces demo license with server license via raw SQL transaction', async () => {
       mockConnector.isAuthenticated.mockReturnValue(true);
       mockConnector.fetchUserLicense.mockResolvedValue({
         id: 'srv-id',
@@ -591,30 +615,25 @@ describe('LicenseService', () => {
         modules: [],
         maintenance_end_date: '2027-06-01T00:00:00Z',
         status: 'active',
+        cloud_sync: true,
       });
 
       const demoLicense = buildLicense({ id: 'demo-id', tier: 'demo' });
       mockedGetCurrentLicense.mockReturnValue(demoLicense);
-      mockedCreateLicense.mockReturnValue(buildLicense());
 
       const result = await service.verifyLicenseViaSupabase();
 
       expect(result).toBe(true);
-      expect(mockedDeleteLicense).toHaveBeenCalledWith('demo-id');
-      expect(mockedCreateLicense).toHaveBeenCalledWith(
-        expect.objectContaining({
-          email: 'real@example.com',
-          name: 'Real User',
-          licenseKey: 'REAL-KEY',
-          tier: 'professional',
-          userId: 'user-123',
-        }),
+      // Uses raw SQL in transaction, not wrapper functions
+      expect(mockPrepare).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO licenses'));
+      expect(mockPrepare).toHaveBeenCalledWith(
+        expect.stringContaining("UPDATE licenses SET status = 'deleted'"),
       );
     });
   });
 
   describe('verifyLicenseViaSupabase — edge cases', () => {
-    it('creates real license before deleting demo (no gap)', async () => {
+    it('uses raw SQL in transaction for demo replacement (no wrapper side effects)', async () => {
       mockConnector.isAuthenticated.mockReturnValue(true);
       mockConnector.fetchUserLicense.mockResolvedValue({
         id: 'srv-id',
@@ -626,18 +645,22 @@ describe('LicenseService', () => {
         modules: [],
         maintenance_end_date: '2027-06-01T00:00:00Z',
         status: 'active',
+        cloud_sync: true,
       });
 
       const demoLicense = buildLicense({ id: 'demo-id', tier: 'demo' });
       mockedGetCurrentLicense.mockReturnValue(demoLicense);
-      mockedCreateLicense.mockReturnValue(buildLicense());
 
       await service.verifyLicenseViaSupabase();
 
-      // Verify create happens before delete (create-before-delete pattern)
-      const createCallOrder = mockedCreateLicense.mock.invocationCallOrder[0];
-      const deleteCallOrder = mockedDeleteLicense.mock.invocationCallOrder[0];
-      expect(createCallOrder).toBeLessThan(deleteCallOrder);
+      // Transaction uses raw db.prepare() — NOT createLicense/deleteLicense wrappers
+      expect(mockedCreateLicense).not.toHaveBeenCalled();
+      expect(mockedDeleteLicense).not.toHaveBeenCalled();
+      // Raw SQL was used via db.prepare()
+      expect(mockPrepare).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO licenses'));
+      expect(mockPrepare).toHaveBeenCalledWith(
+        expect.stringContaining("UPDATE licenses SET status = 'deleted'"),
+      );
     });
 
     it('handles network error during verification gracefully', async () => {
@@ -660,6 +683,7 @@ describe('LicenseService', () => {
         modules: [],
         maintenance_end_date: '2027-06-01T00:00:00Z',
         status: 'active',
+        cloud_sync: true,
       });
 
       const professionalLicense = buildLicense({ id: 'pro-id', tier: 'professional' });

--- a/apps/desktop/src/main/services/__tests__/LicenseService.test.ts
+++ b/apps/desktop/src/main/services/__tests__/LicenseService.test.ts
@@ -603,6 +603,81 @@ describe('LicenseService', () => {
     });
   });
 
+  describe('verifyLicenseViaSupabase — edge cases', () => {
+    it('creates real license before deleting demo (no gap)', async () => {
+      mockConnector.isAuthenticated.mockReturnValue(true);
+      mockConnector.fetchUserLicense.mockResolvedValue({
+        id: 'srv-id',
+        license_key: 'REAL-KEY',
+        user_id: 'user-123',
+        email: 'real@example.com',
+        name: 'Real User',
+        tier: 'professional',
+        modules: [],
+        maintenance_end_date: '2027-06-01T00:00:00Z',
+        status: 'active',
+      });
+
+      const demoLicense = buildLicense({ id: 'demo-id', tier: 'demo' });
+      mockedGetCurrentLicense.mockReturnValue(demoLicense);
+      mockedCreateLicense.mockReturnValue(buildLicense());
+
+      await service.verifyLicenseViaSupabase();
+
+      // Verify create happens before delete (create-before-delete pattern)
+      const createCallOrder = mockedCreateLicense.mock.invocationCallOrder[0];
+      const deleteCallOrder = mockedDeleteLicense.mock.invocationCallOrder[0];
+      expect(createCallOrder).toBeLessThan(deleteCallOrder);
+    });
+
+    it('handles network error during verification gracefully', async () => {
+      mockConnector.isAuthenticated.mockReturnValue(true);
+      mockConnector.fetchUserLicense.mockRejectedValue(new Error('Network timeout'));
+
+      const result = await service.verifyLicenseViaSupabase();
+
+      expect(result).toBe(false);
+    });
+
+    it('does not replace non-demo license with demo-like server data', async () => {
+      mockConnector.isAuthenticated.mockReturnValue(true);
+      mockConnector.fetchUserLicense.mockResolvedValue({
+        id: 'srv-id',
+        license_key: 'SRV-KEY',
+        user_id: 'user-123',
+        email: 'test@example.com',
+        tier: 'professional',
+        modules: [],
+        maintenance_end_date: '2027-06-01T00:00:00Z',
+        status: 'active',
+      });
+
+      const professionalLicense = buildLicense({ id: 'pro-id', tier: 'professional' });
+      mockedGetCurrentLicense.mockReturnValue(professionalLicense);
+      mockedUpdateLicense.mockReturnValue(professionalLicense);
+
+      await service.verifyLicenseViaSupabase();
+
+      // Should update, not delete+create
+      expect(mockedDeleteLicense).not.toHaveBeenCalled();
+      expect(mockedUpdateLicense).toHaveBeenCalled();
+    });
+  });
+
+  describe('createDemoLicense — edge cases', () => {
+    it('does not delete non-demo existing license', () => {
+      const existingPro = buildLicense({ id: 'pro-id', tier: 'professional' });
+      mockedGetCurrentLicense.mockReturnValue(existingPro);
+      mockedCreateLicense.mockReturnValue(buildLicense({ tier: 'demo' }));
+
+      service.createDemoLicense();
+
+      // Should not delete a professional license
+      expect(mockedDeleteLicense).not.toHaveBeenCalled();
+      expect(mockedCreateLicense).toHaveBeenCalled();
+    });
+  });
+
   describe('checkAndVerifyIfNeeded', () => {
     it('skips verification when no license exists', async () => {
       mockedGetCurrentLicense.mockReturnValue(null);

--- a/apps/desktop/src/main/services/__tests__/LicenseService.test.ts
+++ b/apps/desktop/src/main/services/__tests__/LicenseService.test.ts
@@ -20,6 +20,16 @@ vi.mock('../../database/queries/license', () => ({
   deleteLicense: vi.fn(),
 }));
 
+// Mock getAppDatabase for transaction support
+vi.mock('../../database', () => ({
+  getAppDatabase: () => ({
+    transaction: (fn: () => void) => {
+      // Return a callable that executes the callback (mimics better-sqlite3 transaction)
+      return () => fn();
+    },
+  }),
+}));
+
 // Mock the logger
 vi.mock('../../utils/logger', () => ({
   logger: {

--- a/apps/desktop/src/main/services/__tests__/LicenseService.test.ts
+++ b/apps/desktop/src/main/services/__tests__/LicenseService.test.ts
@@ -1,0 +1,531 @@
+/**
+ * Tests for LicenseService
+ *
+ * Tests the perpetual fallback licensing model:
+ * - Build date before maintenance end → canRunApp true, canSync true
+ * - Build date after maintenance end → canRunApp false (canEdit false)
+ * - Maintenance expired but build date valid → canRunApp true, canSync false
+ * - Offline grace period
+ * - activateLicenseKey with mocked Supabase RPC
+ * - verifyLicenseViaSupabase updates local SQLite
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { UserLicense, ModuleAccess } from '../../../shared/types/license.types';
+
+// Mock the database queries
+vi.mock('../../database/queries/license', () => ({
+  getCurrentLicense: vi.fn(),
+  getLicenseByKey: vi.fn(),
+  createLicense: vi.fn(),
+  updateLicense: vi.fn(),
+}));
+
+// Mock the logger
+vi.mock('../../utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// Mock SupabaseConnector
+const mockConnector = {
+  isAuthenticated: vi.fn(),
+  getUserId: vi.fn(),
+  getSession: vi.fn(),
+  activateLicense: vi.fn(),
+  fetchUserLicense: vi.fn(),
+};
+
+vi.mock('../../services/sync/SupabaseConnector', () => ({
+  getSupabaseConnector: () => mockConnector,
+}));
+
+import {
+  getCurrentLicense,
+  getLicenseByKey,
+  createLicense,
+  updateLicense,
+} from '../../database/queries/license';
+import { LicenseService } from '../LicenseService';
+
+const mockedGetCurrentLicense = vi.mocked(getCurrentLicense);
+const mockedGetLicenseByKey = vi.mocked(getLicenseByKey);
+const mockedCreateLicense = vi.mocked(createLicense);
+const mockedUpdateLicense = vi.mocked(updateLicense);
+
+function buildLicense(overrides: Partial<UserLicense> = {}): UserLicense {
+  const now = Date.now();
+  const oneYear = 365 * 24 * 60 * 60 * 1000;
+
+  const defaultModules: ModuleAccess[] = [
+    {
+      module: 'prep',
+      enabled: true,
+      features: {
+        maxRevisions: 5,
+        multiDiscipline: true,
+        advancedExport: true,
+        cloudSync: true,
+        prioritySupport: true,
+      },
+    },
+  ];
+
+  return {
+    id: 'test-id',
+    email: 'test@example.com',
+    name: 'Test User',
+    licenseKey: 'TEST-KEY-1234',
+    tier: 'professional',
+    status: 'active',
+    modules: defaultModules,
+    expirationDate: now + oneYear,
+    maintenanceEndDate: now + oneYear,
+    lastVerified: now,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+describe('LicenseService', () => {
+  let service: LicenseService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new LicenseService();
+  });
+
+  describe('getLicenseStatus', () => {
+    it('returns expired with no license', () => {
+      mockedGetCurrentLicense.mockReturnValue(null);
+
+      const status = service.getLicenseStatus();
+
+      expect(status.status).toBe('expired');
+      expect(status.canView).toBe(false);
+      expect(status.canEdit).toBe(false);
+      expect(status.canSync).toBe(false);
+    });
+
+    it('returns active when maintenance is current', () => {
+      const license = buildLicense();
+      mockedGetCurrentLicense.mockReturnValue(license);
+
+      const status = service.getLicenseStatus();
+
+      expect(status.status).toBe('active');
+      expect(status.canView).toBe(true);
+      expect(status.canEdit).toBe(true);
+      expect(status.canSync).toBe(true);
+    });
+
+    it('returns active with warning when approaching expiration', () => {
+      const license = buildLicense({
+        maintenanceEndDate: Date.now() + 3 * 24 * 60 * 60 * 1000, // 3 days
+      });
+      mockedGetCurrentLicense.mockReturnValue(license);
+
+      const status = service.getLicenseStatus();
+
+      expect(status.status).toBe('active');
+      expect(status.warningLevel).toBe('low');
+      expect(status.canSync).toBe(true);
+    });
+
+    it('returns maintenance_expired when maintenance expired but build date is valid', () => {
+      // Maintenance ended yesterday, but the build date (mocked as "now") is before that
+      // We need the build to have happened BEFORE maintenanceEndDate
+      // Since APP_BUILD_DATE defaults to new Date() at module load time, and we can't easily
+      // control it, we test with maintenance far in the past
+      const pastDate = Date.now() - 30 * 24 * 60 * 60 * 1000; // 30 days ago
+
+      // The APP_BUILD_DATE was set at module import time — it's approximately "now"
+      // So for the perpetual fallback to work, maintenanceEndDate must be >= build time
+      // Since we can't control APP_BUILD_DATE in tests, we test the expired-but-can-view path
+      const license = buildLicense({
+        maintenanceEndDate: pastDate,
+        expirationDate: pastDate,
+      });
+      mockedGetCurrentLicense.mockReturnValue(license);
+
+      const status = service.getLicenseStatus();
+
+      // Build date is "now" which is after the maintenance end, so canEdit should be false
+      expect(status.status).toBe('expired');
+      expect(status.canView).toBe(true);
+      expect(status.canEdit).toBe(false);
+      expect(status.canSync).toBe(false);
+    });
+
+    it('returns suspended for suspended licenses', () => {
+      const license = buildLicense({ status: 'suspended' });
+      mockedGetCurrentLicense.mockReturnValue(license);
+
+      const status = service.getLicenseStatus();
+
+      expect(status.status).toBe('suspended');
+      expect(status.canView).toBe(false);
+      expect(status.canEdit).toBe(false);
+      expect(status.canSync).toBe(false);
+    });
+
+    it('returns grace when verification is stale', () => {
+      const license = buildLicense({
+        lastVerified: Date.now() - 20 * 24 * 60 * 60 * 1000, // 20 days ago
+      });
+      mockedGetCurrentLicense.mockReturnValue(license);
+
+      const status = service.getLicenseStatus();
+
+      expect(status.status).toBe('grace');
+      expect(status.canView).toBe(true);
+      expect(status.canEdit).toBe(true);
+      expect(status.canSync).toBe(false);
+      expect(status.warningLevel).toBe('medium');
+    });
+
+    it('returns high warning when very stale verification', () => {
+      const license = buildLicense({
+        lastVerified: Date.now() - 35 * 24 * 60 * 60 * 1000, // 35 days ago
+      });
+      mockedGetCurrentLicense.mockReturnValue(license);
+
+      const status = service.getLicenseStatus();
+
+      expect(status.status).toBe('grace');
+      expect(status.warningLevel).toBe('high');
+    });
+  });
+
+  describe('hasModuleAccess', () => {
+    it('returns false with no license', () => {
+      mockedGetCurrentLicense.mockReturnValue(null);
+      expect(service.hasModuleAccess('prep')).toBe(false);
+    });
+
+    it('returns true for enabled module', () => {
+      const license = buildLicense();
+      mockedGetCurrentLicense.mockReturnValue(license);
+      expect(service.hasModuleAccess('prep')).toBe(true);
+    });
+
+    it('returns false for disabled module', () => {
+      const license = buildLicense({
+        modules: [
+          {
+            module: 'prep',
+            enabled: false,
+            features: {
+              maxRevisions: 5,
+              multiDiscipline: true,
+              advancedExport: true,
+              cloudSync: true,
+              prioritySupport: true,
+            },
+          },
+        ],
+      });
+      mockedGetCurrentLicense.mockReturnValue(license);
+      expect(service.hasModuleAccess('prep')).toBe(false);
+    });
+
+    it('returns false for suspended license', () => {
+      const license = buildLicense({ status: 'suspended' });
+      mockedGetCurrentLicense.mockReturnValue(license);
+      expect(service.hasModuleAccess('prep')).toBe(false);
+    });
+  });
+
+  describe('getModuleFeatures', () => {
+    it('returns null with no license', () => {
+      mockedGetCurrentLicense.mockReturnValue(null);
+      expect(service.getModuleFeatures('prep')).toBeNull();
+    });
+
+    it('returns features for available module', () => {
+      const license = buildLicense();
+      mockedGetCurrentLicense.mockReturnValue(license);
+
+      const features = service.getModuleFeatures('prep');
+      expect(features).not.toBeNull();
+      expect(features!.maxRevisions).toBe(5);
+    });
+  });
+
+  describe('getAvailableModules', () => {
+    it('returns empty array with no license', () => {
+      mockedGetCurrentLicense.mockReturnValue(null);
+      expect(service.getAvailableModules()).toEqual([]);
+    });
+
+    it('returns only enabled modules', () => {
+      const license = buildLicense({
+        modules: [
+          {
+            module: 'prep',
+            enabled: true,
+            features: {
+              maxRevisions: 5,
+              multiDiscipline: true,
+              advancedExport: true,
+              cloudSync: true,
+              prioritySupport: true,
+            },
+          },
+          {
+            module: 'production',
+            enabled: false,
+            features: {
+              maxRevisions: 5,
+              multiDiscipline: true,
+              advancedExport: true,
+              cloudSync: true,
+              prioritySupport: true,
+            },
+          },
+        ],
+      });
+      mockedGetCurrentLicense.mockReturnValue(license);
+
+      expect(service.getAvailableModules()).toEqual(['prep']);
+    });
+  });
+
+  describe('activateLicenseKey', () => {
+    it('returns error if not authenticated', async () => {
+      mockConnector.isAuthenticated.mockReturnValue(false);
+
+      const result = await service.activateLicenseKey('TEST-KEY');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('signed in');
+    });
+
+    it('returns error if Supabase RPC fails', async () => {
+      mockConnector.isAuthenticated.mockReturnValue(true);
+      mockConnector.activateLicense.mockResolvedValue({
+        success: false,
+        error: 'Invalid or inactive license key',
+      });
+
+      const result = await service.activateLicenseKey('BAD-KEY');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Invalid or inactive license key');
+    });
+
+    it('creates local license on successful activation', async () => {
+      mockConnector.isAuthenticated.mockReturnValue(true);
+      mockConnector.getUserId.mockReturnValue('user-123');
+      mockConnector.getSession.mockReturnValue({
+        user: { email: 'test@example.com' },
+      });
+
+      const serverLicense = {
+        id: 'srv-id',
+        licenseKey: 'VALID-KEY',
+        tier: 'professional',
+        modules: [],
+        maintenanceEndDate: '2027-01-01T00:00:00Z',
+        status: 'active',
+      };
+
+      mockConnector.activateLicense.mockResolvedValue({
+        success: true,
+        license: serverLicense,
+      });
+
+      mockedGetLicenseByKey.mockReturnValue(null);
+      mockedCreateLicense.mockReturnValue(buildLicense({ licenseKey: 'VALID-KEY' }));
+
+      const result = await service.activateLicenseKey('VALID-KEY');
+
+      expect(result.success).toBe(true);
+      expect(result.license).toBeDefined();
+      expect(mockedCreateLicense).toHaveBeenCalled();
+    });
+
+    it('updates existing local license on re-activation', async () => {
+      mockConnector.isAuthenticated.mockReturnValue(true);
+      mockConnector.getUserId.mockReturnValue('user-123');
+
+      const serverLicense = {
+        id: 'srv-id',
+        licenseKey: 'EXISTING-KEY',
+        tier: 'professional',
+        modules: [],
+        maintenanceEndDate: '2027-01-01T00:00:00Z',
+        status: 'active',
+      };
+
+      mockConnector.activateLicense.mockResolvedValue({
+        success: true,
+        license: serverLicense,
+      });
+
+      const existing = buildLicense({ id: 'local-id', licenseKey: 'EXISTING-KEY' });
+      mockedGetLicenseByKey.mockReturnValue(existing);
+      mockedUpdateLicense.mockReturnValue(existing);
+
+      const result = await service.activateLicenseKey('EXISTING-KEY');
+
+      expect(result.success).toBe(true);
+      expect(mockedUpdateLicense).toHaveBeenCalledWith(
+        'local-id',
+        expect.objectContaining({
+          userId: 'user-123',
+          tier: 'professional',
+        }),
+      );
+    });
+  });
+
+  describe('verifyLicenseViaSupabase', () => {
+    it('returns false if not authenticated', async () => {
+      mockConnector.isAuthenticated.mockReturnValue(false);
+
+      const result = await service.verifyLicenseViaSupabase();
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false if no server license found', async () => {
+      mockConnector.isAuthenticated.mockReturnValue(true);
+      mockConnector.fetchUserLicense.mockResolvedValue(null);
+
+      const result = await service.verifyLicenseViaSupabase();
+
+      expect(result).toBe(false);
+    });
+
+    it('updates local license with server data', async () => {
+      mockConnector.isAuthenticated.mockReturnValue(true);
+      mockConnector.fetchUserLicense.mockResolvedValue({
+        id: 'srv-id',
+        license_key: 'SRV-KEY',
+        user_id: 'user-123',
+        email: 'test@example.com',
+        tier: 'professional',
+        modules: [],
+        maintenance_end_date: '2027-06-01T00:00:00Z',
+        status: 'active',
+      });
+
+      const localLicense = buildLicense({ id: 'local-id' });
+      mockedGetCurrentLicense.mockReturnValue(localLicense);
+      mockedUpdateLicense.mockReturnValue(localLicense);
+
+      const result = await service.verifyLicenseViaSupabase();
+
+      expect(result).toBe(true);
+      expect(mockedUpdateLicense).toHaveBeenCalledWith(
+        'local-id',
+        expect.objectContaining({
+          status: 'active',
+          tier: 'professional',
+          lastVerified: expect.any(Number),
+        }),
+      );
+    });
+
+    it('creates local license if none exists', async () => {
+      mockConnector.isAuthenticated.mockReturnValue(true);
+      mockConnector.fetchUserLicense.mockResolvedValue({
+        id: 'srv-id',
+        license_key: 'NEW-KEY',
+        user_id: 'user-123',
+        email: 'new@example.com',
+        tier: 'student',
+        modules: [],
+        maintenance_end_date: '2027-06-01T00:00:00Z',
+        status: 'active',
+      });
+
+      mockedGetCurrentLicense.mockReturnValue(null);
+      mockedCreateLicense.mockReturnValue(buildLicense());
+
+      const result = await service.verifyLicenseViaSupabase();
+
+      expect(result).toBe(true);
+      expect(mockedCreateLicense).toHaveBeenCalledWith(
+        expect.objectContaining({
+          email: 'new@example.com',
+          licenseKey: 'NEW-KEY',
+          tier: 'student',
+        }),
+      );
+    });
+  });
+
+  describe('canUseFeature', () => {
+    it('returns false with no license', () => {
+      mockedGetCurrentLicense.mockReturnValue(null);
+      expect(service.canUseFeature('prep', 'cloudSync')).toBe(false);
+    });
+
+    it('checks universal features', () => {
+      const license = buildLicense();
+      mockedGetCurrentLicense.mockReturnValue(license);
+      expect(service.canUseFeature('prep', 'cloudSync')).toBe(true);
+      expect(service.canUseFeature('prep', 'multiDiscipline')).toBe(true);
+    });
+  });
+
+  describe('activateLicenseLocally (legacy)', () => {
+    it('creates a license with correct defaults', () => {
+      const newLicense = buildLicense();
+      mockedCreateLicense.mockReturnValue(newLicense);
+
+      const result = service.activateLicenseLocally('KEY', 'test@test.com', ['prep']);
+
+      expect(mockedCreateLicense).toHaveBeenCalledWith(
+        expect.objectContaining({
+          email: 'test@test.com',
+          licenseKey: 'KEY',
+          tier: 'professional',
+        }),
+      );
+      expect(result).toEqual(newLicense);
+    });
+
+    it('uses student tier for student module', () => {
+      const newLicense = buildLicense({ tier: 'student' });
+      mockedCreateLicense.mockReturnValue(newLicense);
+
+      service.activateLicenseLocally('KEY', 'student@test.com', ['student']);
+
+      expect(mockedCreateLicense).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tier: 'student',
+        }),
+      );
+    });
+  });
+
+  describe('checkAndVerifyIfNeeded', () => {
+    it('skips verification when no license exists', async () => {
+      mockedGetCurrentLicense.mockReturnValue(null);
+
+      await service.checkAndVerifyIfNeeded();
+
+      expect(mockConnector.isAuthenticated).not.toHaveBeenCalled();
+    });
+
+    it('skips verification when recently verified', async () => {
+      const license = buildLicense({
+        lastVerified: Date.now() - 1 * 60 * 60 * 1000, // 1 hour ago
+      });
+      mockedGetCurrentLicense.mockReturnValue(license);
+
+      await service.checkAndVerifyIfNeeded();
+
+      // Should not attempt Supabase verification
+      expect(mockConnector.isAuthenticated).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/desktop/src/main/services/__tests__/LicenseService.test.ts
+++ b/apps/desktop/src/main/services/__tests__/LicenseService.test.ts
@@ -55,7 +55,7 @@ function buildLicense(overrides: Partial<UserLicense> = {}): UserLicense {
 
   const defaultModules: ModuleAccess[] = [
     {
-      module: 'prep',
+      module: 'lighting',
       enabled: true,
       features: {
         maxRevisions: 5,
@@ -190,20 +190,20 @@ describe('LicenseService', () => {
   describe('hasModuleAccess', () => {
     it('returns false with no license', () => {
       mockedGetCurrentLicense.mockReturnValue(null);
-      expect(service.hasModuleAccess('prep')).toBe(false);
+      expect(service.hasModuleAccess('lighting')).toBe(false);
     });
 
     it('returns true for enabled module', () => {
       const license = buildLicense();
       mockedGetCurrentLicense.mockReturnValue(license);
-      expect(service.hasModuleAccess('prep')).toBe(true);
+      expect(service.hasModuleAccess('lighting')).toBe(true);
     });
 
     it('returns false for disabled module', () => {
       const license = buildLicense({
         modules: [
           {
-            module: 'prep',
+            module: 'lighting',
             enabled: false,
             features: {
               maxRevisions: 5,
@@ -216,27 +216,27 @@ describe('LicenseService', () => {
         ],
       });
       mockedGetCurrentLicense.mockReturnValue(license);
-      expect(service.hasModuleAccess('prep')).toBe(false);
+      expect(service.hasModuleAccess('lighting')).toBe(false);
     });
 
     it('returns false for suspended license', () => {
       const license = buildLicense({ status: 'suspended' });
       mockedGetCurrentLicense.mockReturnValue(license);
-      expect(service.hasModuleAccess('prep')).toBe(false);
+      expect(service.hasModuleAccess('lighting')).toBe(false);
     });
   });
 
   describe('getModuleFeatures', () => {
     it('returns null with no license', () => {
       mockedGetCurrentLicense.mockReturnValue(null);
-      expect(service.getModuleFeatures('prep')).toBeNull();
+      expect(service.getModuleFeatures('lighting')).toBeNull();
     });
 
     it('returns features for available module', () => {
       const license = buildLicense();
       mockedGetCurrentLicense.mockReturnValue(license);
 
-      const features = service.getModuleFeatures('prep');
+      const features = service.getModuleFeatures('lighting');
       expect(features).not.toBeNull();
       expect(features!.maxRevisions).toBe(5);
     });
@@ -252,7 +252,7 @@ describe('LicenseService', () => {
       const license = buildLicense({
         modules: [
           {
-            module: 'prep',
+            module: 'lighting',
             enabled: true,
             features: {
               maxRevisions: 5,
@@ -263,7 +263,7 @@ describe('LicenseService', () => {
             },
           },
           {
-            module: 'production',
+            module: 'sound',
             enabled: false,
             features: {
               maxRevisions: 5,
@@ -277,7 +277,7 @@ describe('LicenseService', () => {
       });
       mockedGetCurrentLicense.mockReturnValue(license);
 
-      expect(service.getAvailableModules()).toEqual(['prep']);
+      expect(service.getAvailableModules()).toEqual(['lighting']);
     });
   });
 
@@ -445,14 +445,14 @@ describe('LicenseService', () => {
   describe('canUseFeature', () => {
     it('returns false with no license', () => {
       mockedGetCurrentLicense.mockReturnValue(null);
-      expect(service.canUseFeature('prep', 'cloudSync')).toBe(false);
+      expect(service.canUseFeature('lighting', 'cloudSync')).toBe(false);
     });
 
     it('checks universal features', () => {
       const license = buildLicense();
       mockedGetCurrentLicense.mockReturnValue(license);
-      expect(service.canUseFeature('prep', 'cloudSync')).toBe(true);
-      expect(service.canUseFeature('prep', 'multiDiscipline')).toBe(true);
+      expect(service.canUseFeature('lighting', 'cloudSync')).toBe(true);
+      expect(service.canUseFeature('lighting', 'multiDiscipline')).toBe(true);
     });
   });
 
@@ -461,7 +461,7 @@ describe('LicenseService', () => {
       const newLicense = buildLicense();
       mockedCreateLicense.mockReturnValue(newLicense);
 
-      const result = service.activateLicenseLocally('KEY', 'test@test.com', ['prep']);
+      const result = service.activateLicenseLocally('KEY', 'test@test.com', ['lighting']);
 
       expect(mockedCreateLicense).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -473,15 +473,15 @@ describe('LicenseService', () => {
       expect(result).toEqual(newLicense);
     });
 
-    it('uses student tier for student module', () => {
-      const newLicense = buildLicense({ tier: 'student' });
+    it('creates license with multiple modules', () => {
+      const newLicense = buildLicense();
       mockedCreateLicense.mockReturnValue(newLicense);
 
-      service.activateLicenseLocally('KEY', 'student@test.com', ['student']);
+      service.activateLicenseLocally('KEY', 'test@test.com', ['lighting', 'sound']);
 
       expect(mockedCreateLicense).toHaveBeenCalledWith(
         expect.objectContaining({
-          tier: 'student',
+          tier: 'professional',
         }),
       );
     });

--- a/apps/desktop/src/main/services/__tests__/LicenseService.test.ts
+++ b/apps/desktop/src/main/services/__tests__/LicenseService.test.ts
@@ -17,6 +17,7 @@ vi.mock('../../database/queries/license', () => ({
   getCurrentLicense: vi.fn(),
   createLicense: vi.fn(),
   updateLicense: vi.fn(),
+  deleteLicense: vi.fn(),
 }));
 
 // Mock the logger
@@ -42,12 +43,18 @@ vi.mock('../../services/sync/SupabaseConnector', () => ({
   getSupabaseConnector: () => mockConnector,
 }));
 
-import { getCurrentLicense, createLicense, updateLicense } from '../../database/queries/license';
+import {
+  getCurrentLicense,
+  createLicense,
+  updateLicense,
+  deleteLicense,
+} from '../../database/queries/license';
 import { LicenseService } from '../LicenseService';
 
 const mockedGetCurrentLicense = vi.mocked(getCurrentLicense);
 const mockedCreateLicense = vi.mocked(createLicense);
 const mockedUpdateLicense = vi.mocked(updateLicense);
+const mockedDeleteLicense = vi.mocked(deleteLicense);
 
 function buildLicense(overrides: Partial<UserLicense> = {}): UserLicense {
   const now = Date.now();
@@ -59,6 +66,7 @@ function buildLicense(overrides: Partial<UserLicense> = {}): UserLicense {
       enabled: true,
       features: {
         maxRevisions: 5,
+        maxFixtures: -1,
         multiDiscipline: true,
         advancedExport: true,
         cloudSync: true,
@@ -207,6 +215,7 @@ describe('LicenseService', () => {
             enabled: false,
             features: {
               maxRevisions: 5,
+              maxFixtures: -1,
               multiDiscipline: true,
               advancedExport: true,
               cloudSync: true,
@@ -256,6 +265,7 @@ describe('LicenseService', () => {
             enabled: true,
             features: {
               maxRevisions: 5,
+              maxFixtures: -1,
               multiDiscipline: true,
               advancedExport: true,
               cloudSync: true,
@@ -267,6 +277,7 @@ describe('LicenseService', () => {
             enabled: false,
             features: {
               maxRevisions: 5,
+              maxFixtures: -1,
               multiDiscipline: true,
               advancedExport: true,
               cloudSync: true,
@@ -482,6 +493,111 @@ describe('LicenseService', () => {
       expect(mockedCreateLicense).toHaveBeenCalledWith(
         expect.objectContaining({
           tier: 'professional',
+        }),
+      );
+    });
+  });
+
+  describe('createDemoLicense', () => {
+    it('creates a demo license with all 6 modules enabled', () => {
+      mockedGetCurrentLicense.mockReturnValue(null);
+      const demoLicense = buildLicense({ tier: 'demo' });
+      mockedCreateLicense.mockReturnValue(demoLicense);
+
+      service.createDemoLicense();
+
+      expect(mockedCreateLicense).toHaveBeenCalledWith(
+        expect.objectContaining({
+          email: 'demo@local',
+          tier: 'demo',
+          modules: expect.arrayContaining([
+            expect.objectContaining({ module: 'lighting', enabled: true }),
+            expect.objectContaining({ module: 'sound', enabled: true }),
+            expect.objectContaining({ module: 'video', enabled: true }),
+            expect.objectContaining({ module: 'production_management', enabled: true }),
+            expect.objectContaining({ module: 'touring', enabled: true }),
+            expect.objectContaining({ module: 'producer', enabled: true }),
+          ]),
+        }),
+      );
+    });
+
+    it('creates demo license with correct feature restrictions', () => {
+      mockedGetCurrentLicense.mockReturnValue(null);
+      const demoLicense = buildLicense({ tier: 'demo' });
+      mockedCreateLicense.mockReturnValue(demoLicense);
+
+      service.createDemoLicense();
+
+      const createCall = mockedCreateLicense.mock.calls[0][0];
+      const lightingModule = createCall.modules.find((m: ModuleAccess) => m.module === 'lighting');
+      expect(lightingModule?.features).toEqual({
+        maxRevisions: 0,
+        maxFixtures: 25,
+        multiDiscipline: false,
+        advancedExport: false,
+        cloudSync: false,
+        prioritySupport: false,
+      });
+    });
+
+    it('deletes existing demo license before creating new one', () => {
+      const existingDemo = buildLicense({ id: 'old-demo', tier: 'demo' });
+      mockedGetCurrentLicense.mockReturnValue(existingDemo);
+      mockedCreateLicense.mockReturnValue(buildLicense({ tier: 'demo' }));
+
+      service.createDemoLicense();
+
+      expect(mockedDeleteLicense).toHaveBeenCalledWith('old-demo');
+      expect(mockedCreateLicense).toHaveBeenCalled();
+    });
+  });
+
+  describe('getLicenseStatus — demo tier', () => {
+    it('returns active with demo message for demo license', () => {
+      const license = buildLicense({ tier: 'demo' });
+      mockedGetCurrentLicense.mockReturnValue(license);
+
+      const status = service.getLicenseStatus();
+
+      expect(status.status).toBe('active');
+      expect(status.message).toContain('Demo mode');
+      expect(status.canView).toBe(true);
+      expect(status.canEdit).toBe(true);
+      expect(status.canSync).toBe(false);
+    });
+  });
+
+  describe('verifyLicenseViaSupabase — demo replacement', () => {
+    it('replaces demo license with server license', async () => {
+      mockConnector.isAuthenticated.mockReturnValue(true);
+      mockConnector.fetchUserLicense.mockResolvedValue({
+        id: 'srv-id',
+        license_key: 'REAL-KEY',
+        user_id: 'user-123',
+        email: 'real@example.com',
+        name: 'Real User',
+        tier: 'professional',
+        modules: [],
+        maintenance_end_date: '2027-06-01T00:00:00Z',
+        status: 'active',
+      });
+
+      const demoLicense = buildLicense({ id: 'demo-id', tier: 'demo' });
+      mockedGetCurrentLicense.mockReturnValue(demoLicense);
+      mockedCreateLicense.mockReturnValue(buildLicense());
+
+      const result = await service.verifyLicenseViaSupabase();
+
+      expect(result).toBe(true);
+      expect(mockedDeleteLicense).toHaveBeenCalledWith('demo-id');
+      expect(mockedCreateLicense).toHaveBeenCalledWith(
+        expect.objectContaining({
+          email: 'real@example.com',
+          name: 'Real User',
+          licenseKey: 'REAL-KEY',
+          tier: 'professional',
+          userId: 'user-123',
         }),
       );
     });

--- a/apps/desktop/src/main/services/__tests__/LicenseService.test.ts
+++ b/apps/desktop/src/main/services/__tests__/LicenseService.test.ts
@@ -446,7 +446,7 @@ describe('LicenseService', () => {
       );
     });
 
-    it('still uses unclaimed license data if auto-claim fails', async () => {
+    it('returns false if auto-claim fails (does not use unclaimed license)', async () => {
       mockConnector.isAuthenticated.mockReturnValue(true);
 
       const unclaimedLicense = {
@@ -469,20 +469,12 @@ describe('LicenseService', () => {
         error: 'Claim failed',
       });
 
-      mockedGetCurrentLicense.mockReturnValue(null);
-      mockedCreateLicense.mockReturnValue(buildLicense());
-
       const result = await service.verifyLicenseViaSupabase();
 
-      // Claim failed but unclaimed license data is still used to create local record
-      expect(result).toBe(true);
+      // Claim failed — should NOT proceed with unclaimed license
+      expect(result).toBe(false);
       expect(mockConnector.claimLicenseByEmail).toHaveBeenCalled();
-      expect(mockedCreateLicense).toHaveBeenCalledWith(
-        expect.objectContaining({
-          email: 'buyer@example.com',
-          licenseKey: 'AUTO-KEY',
-        }),
-      );
+      expect(mockedCreateLicense).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/desktop/src/main/services/__tests__/LicenseService.test.ts
+++ b/apps/desktop/src/main/services/__tests__/LicenseService.test.ts
@@ -59,7 +59,7 @@ import {
   updateLicense,
   deleteLicense,
 } from '../../database/queries/license';
-import { LicenseService } from '../LicenseService';
+import { LicenseService, DEMO_FIXTURE_LIMIT } from '../LicenseService';
 
 const mockedGetCurrentLicense = vi.mocked(getCurrentLicense);
 const mockedCreateLicense = vi.mocked(createLicense);
@@ -543,7 +543,7 @@ describe('LicenseService', () => {
       const lightingModule = createCall.modules.find((m: ModuleAccess) => m.module === 'lighting');
       expect(lightingModule?.features).toEqual({
         maxRevisions: 0,
-        maxFixtures: 25,
+        maxFixtures: DEMO_FIXTURE_LIMIT,
         multiDiscipline: false,
         advancedExport: false,
         cloudSync: false,
@@ -675,16 +675,17 @@ describe('LicenseService', () => {
   });
 
   describe('createDemoLicense — edge cases', () => {
-    it('does not delete non-demo existing license', () => {
+    it('returns existing license without creating demo if user has a real license', () => {
       const existingPro = buildLicense({ id: 'pro-id', tier: 'professional' });
       mockedGetCurrentLicense.mockReturnValue(existingPro);
-      mockedCreateLicense.mockReturnValue(buildLicense({ tier: 'demo' }));
 
-      service.createDemoLicense();
+      const result = service.createDemoLicense();
 
-      // Should not delete a professional license
+      // Should not delete or create — just return the existing license
       expect(mockedDeleteLicense).not.toHaveBeenCalled();
-      expect(mockedCreateLicense).toHaveBeenCalled();
+      expect(mockedCreateLicense).not.toHaveBeenCalled();
+      expect(result.id).toBe('pro-id');
+      expect(result.tier).toBe('professional');
     });
   });
 

--- a/apps/desktop/src/main/services/__tests__/LicenseService.test.ts
+++ b/apps/desktop/src/main/services/__tests__/LicenseService.test.ts
@@ -2,12 +2,11 @@
  * Tests for LicenseService
  *
  * Tests the perpetual fallback licensing model:
- * - Build date before maintenance end → canRunApp true, canSync true
- * - Build date after maintenance end → canRunApp false (canEdit false)
- * - Maintenance expired but build date valid → canRunApp true, canSync false
+ * - Build date before maintenance end -> canRunApp true, canSync true
+ * - Build date after maintenance end -> canRunApp false (canEdit false)
+ * - Maintenance expired but build date valid -> canRunApp true, canSync false
  * - Offline grace period
- * - activateLicenseKey with mocked Supabase RPC
- * - verifyLicenseViaSupabase updates local SQLite
+ * - verifyLicenseViaSupabase with email-based auto-claim
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -16,7 +15,6 @@ import type { UserLicense, ModuleAccess } from '../../../shared/types/license.ty
 // Mock the database queries
 vi.mock('../../database/queries/license', () => ({
   getCurrentLicense: vi.fn(),
-  getLicenseByKey: vi.fn(),
   createLicense: vi.fn(),
   updateLicense: vi.fn(),
 }));
@@ -36,24 +34,18 @@ const mockConnector = {
   isAuthenticated: vi.fn(),
   getUserId: vi.fn(),
   getSession: vi.fn(),
-  activateLicense: vi.fn(),
   fetchUserLicense: vi.fn(),
+  claimLicenseByEmail: vi.fn(),
 };
 
 vi.mock('../../services/sync/SupabaseConnector', () => ({
   getSupabaseConnector: () => mockConnector,
 }));
 
-import {
-  getCurrentLicense,
-  getLicenseByKey,
-  createLicense,
-  updateLicense,
-} from '../../database/queries/license';
+import { getCurrentLicense, createLicense, updateLicense } from '../../database/queries/license';
 import { LicenseService } from '../LicenseService';
 
 const mockedGetCurrentLicense = vi.mocked(getCurrentLicense);
-const mockedGetLicenseByKey = vi.mocked(getLicenseByKey);
 const mockedCreateLicense = vi.mocked(createLicense);
 const mockedUpdateLicense = vi.mocked(updateLicense);
 
@@ -138,15 +130,8 @@ describe('LicenseService', () => {
     });
 
     it('returns maintenance_expired when maintenance expired but build date is valid', () => {
-      // Maintenance ended yesterday, but the build date (mocked as "now") is before that
-      // We need the build to have happened BEFORE maintenanceEndDate
-      // Since APP_BUILD_DATE defaults to new Date() at module load time, and we can't easily
-      // control it, we test with maintenance far in the past
       const pastDate = Date.now() - 30 * 24 * 60 * 60 * 1000; // 30 days ago
 
-      // The APP_BUILD_DATE was set at module import time — it's approximately "now"
-      // So for the perpetual fallback to work, maintenanceEndDate must be >= build time
-      // Since we can't control APP_BUILD_DATE in tests, we test the expired-but-can-view path
       const license = buildLicense({
         maintenanceEndDate: pastDate,
         expirationDate: pastDate,
@@ -296,95 +281,6 @@ describe('LicenseService', () => {
     });
   });
 
-  describe('activateLicenseKey', () => {
-    it('returns error if not authenticated', async () => {
-      mockConnector.isAuthenticated.mockReturnValue(false);
-
-      const result = await service.activateLicenseKey('TEST-KEY');
-
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('signed in');
-    });
-
-    it('returns error if Supabase RPC fails', async () => {
-      mockConnector.isAuthenticated.mockReturnValue(true);
-      mockConnector.activateLicense.mockResolvedValue({
-        success: false,
-        error: 'Invalid or inactive license key',
-      });
-
-      const result = await service.activateLicenseKey('BAD-KEY');
-
-      expect(result.success).toBe(false);
-      expect(result.error).toBe('Invalid or inactive license key');
-    });
-
-    it('creates local license on successful activation', async () => {
-      mockConnector.isAuthenticated.mockReturnValue(true);
-      mockConnector.getUserId.mockReturnValue('user-123');
-      mockConnector.getSession.mockReturnValue({
-        user: { email: 'test@example.com' },
-      });
-
-      const serverLicense = {
-        id: 'srv-id',
-        licenseKey: 'VALID-KEY',
-        tier: 'professional',
-        modules: [],
-        maintenanceEndDate: '2027-01-01T00:00:00Z',
-        status: 'active',
-      };
-
-      mockConnector.activateLicense.mockResolvedValue({
-        success: true,
-        license: serverLicense,
-      });
-
-      mockedGetLicenseByKey.mockReturnValue(null);
-      mockedCreateLicense.mockReturnValue(buildLicense({ licenseKey: 'VALID-KEY' }));
-
-      const result = await service.activateLicenseKey('VALID-KEY');
-
-      expect(result.success).toBe(true);
-      expect(result.license).toBeDefined();
-      expect(mockedCreateLicense).toHaveBeenCalled();
-    });
-
-    it('updates existing local license on re-activation', async () => {
-      mockConnector.isAuthenticated.mockReturnValue(true);
-      mockConnector.getUserId.mockReturnValue('user-123');
-
-      const serverLicense = {
-        id: 'srv-id',
-        licenseKey: 'EXISTING-KEY',
-        tier: 'professional',
-        modules: [],
-        maintenanceEndDate: '2027-01-01T00:00:00Z',
-        status: 'active',
-      };
-
-      mockConnector.activateLicense.mockResolvedValue({
-        success: true,
-        license: serverLicense,
-      });
-
-      const existing = buildLicense({ id: 'local-id', licenseKey: 'EXISTING-KEY' });
-      mockedGetLicenseByKey.mockReturnValue(existing);
-      mockedUpdateLicense.mockReturnValue(existing);
-
-      const result = await service.activateLicenseKey('EXISTING-KEY');
-
-      expect(result.success).toBe(true);
-      expect(mockedUpdateLicense).toHaveBeenCalledWith(
-        'local-id',
-        expect.objectContaining({
-          userId: 'user-123',
-          tier: 'professional',
-        }),
-      );
-    });
-  });
-
   describe('verifyLicenseViaSupabase', () => {
     it('returns false if not authenticated', async () => {
       mockConnector.isAuthenticated.mockReturnValue(false);
@@ -457,6 +353,90 @@ describe('LicenseService', () => {
           email: 'new@example.com',
           licenseKey: 'NEW-KEY',
           tier: 'student',
+        }),
+      );
+    });
+
+    it('auto-claims unclaimed license matching email', async () => {
+      mockConnector.isAuthenticated.mockReturnValue(true);
+
+      // First call returns unclaimed license (no user_id)
+      const unclaimedLicense = {
+        id: 'srv-id',
+        license_key: 'AUTO-KEY',
+        user_id: null,
+        email: 'buyer@example.com',
+        tier: 'professional',
+        modules: [],
+        maintenance_end_date: '2027-06-01T00:00:00Z',
+        status: 'active',
+      };
+
+      // After claim, returns the same license with user_id set
+      const claimedLicense = {
+        ...unclaimedLicense,
+        user_id: 'user-456',
+      };
+
+      mockConnector.fetchUserLicense
+        .mockResolvedValueOnce(unclaimedLicense)
+        .mockResolvedValueOnce(claimedLicense);
+
+      mockConnector.claimLicenseByEmail.mockResolvedValue({
+        success: true,
+        license: claimedLicense,
+      });
+
+      mockedGetCurrentLicense.mockReturnValue(null);
+      mockedCreateLicense.mockReturnValue(buildLicense());
+
+      const result = await service.verifyLicenseViaSupabase();
+
+      expect(result).toBe(true);
+      expect(mockConnector.claimLicenseByEmail).toHaveBeenCalled();
+      expect(mockedCreateLicense).toHaveBeenCalledWith(
+        expect.objectContaining({
+          email: 'buyer@example.com',
+          licenseKey: 'AUTO-KEY',
+          userId: 'user-456',
+        }),
+      );
+    });
+
+    it('still uses unclaimed license data if auto-claim fails', async () => {
+      mockConnector.isAuthenticated.mockReturnValue(true);
+
+      const unclaimedLicense = {
+        id: 'srv-id',
+        license_key: 'AUTO-KEY',
+        user_id: null,
+        email: 'buyer@example.com',
+        tier: 'professional',
+        modules: [],
+        maintenance_end_date: '2027-06-01T00:00:00Z',
+        status: 'active',
+      };
+
+      // fetchUserLicense returns unclaimed license
+      mockConnector.fetchUserLicense.mockResolvedValueOnce(unclaimedLicense);
+
+      mockConnector.claimLicenseByEmail.mockResolvedValue({
+        success: false,
+        error: 'Claim failed',
+      });
+
+      mockedGetCurrentLicense.mockReturnValue(null);
+      mockedCreateLicense.mockReturnValue(buildLicense());
+
+      const result = await service.verifyLicenseViaSupabase();
+
+      // Claim failed but unclaimed license data is still used to create local record
+      expect(result).toBe(true);
+      expect(mockConnector.claimLicenseByEmail).toHaveBeenCalled();
+      expect(mockedCreateLicense).toHaveBeenCalledWith(
+        expect.objectContaining({
+          email: 'buyer@example.com',
+          licenseKey: 'AUTO-KEY',
         }),
       );
     });

--- a/apps/desktop/src/main/services/__tests__/SupabaseConnector.test.ts
+++ b/apps/desktop/src/main/services/__tests__/SupabaseConnector.test.ts
@@ -86,28 +86,28 @@ describe('SupabaseConnector', () => {
       expect(connector.isAuthenticated()).toBe(true);
     });
 
-    it('signIn returns error on failure', async () => {
+    it('signIn returns user-friendly error on failure', async () => {
       mockAuth.signInWithPassword.mockResolvedValue({
         data: { session: null },
-        error: { message: 'Invalid credentials' },
+        error: { message: 'Invalid login credentials' },
       });
 
       const result = await connector.signIn('bad@example.com', 'wrong');
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe('Invalid credentials');
+      expect(result.error).toBe('Invalid email or password');
     });
 
-    it('signUp returns error on failure', async () => {
+    it('signUp returns user-friendly error on failure', async () => {
       mockAuth.signUp.mockResolvedValue({
         data: { session: null },
-        error: { message: 'Email already in use' },
+        error: { message: 'User already registered' },
       });
 
       const result = await connector.signUp('taken@example.com', 'password123');
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe('Email already in use');
+      expect(result.error).toBe('An account with this email already exists');
     });
 
     it('signOut clears session', async () => {

--- a/apps/desktop/src/main/services/__tests__/SupabaseConnector.test.ts
+++ b/apps/desktop/src/main/services/__tests__/SupabaseConnector.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Tests for SupabaseConnector
+ *
+ * Tests the license-related methods of SupabaseConnector:
+ * - fetchUserLicense
+ * - claimLicenseByEmail
+ * - Authentication state
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock dependencies before imports
+vi.mock('../../config/env', () => ({
+  getConfig: () => ({
+    supabase: { url: 'https://test.supabase.co', anonKey: 'test-key' },
+    powersync: { url: 'https://test.powersync.com' },
+    app: { debugPowerSync: false },
+  }),
+}));
+
+vi.mock('../../utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// Mock Supabase client
+const mockFrom = vi.fn();
+const mockRpc = vi.fn();
+const mockAuth = {
+  getSession: vi.fn().mockResolvedValue({ data: { session: null } }),
+  onAuthStateChange: vi.fn().mockReturnValue({ data: { subscription: { unsubscribe: vi.fn() } } }),
+  signInWithPassword: vi.fn(),
+  signUp: vi.fn(),
+  signOut: vi.fn(),
+  resetPasswordForEmail: vi.fn(),
+};
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    from: mockFrom,
+    rpc: mockRpc,
+    auth: mockAuth,
+  }),
+}));
+
+vi.mock('@powersync/web', () => ({
+  AbstractPowerSyncDatabase: class {},
+  PowerSyncBackendConnector: class {},
+  UpdateType: { PUT: 'PUT', PATCH: 'PATCH', DELETE: 'DELETE' },
+}));
+
+import { SupabaseConnector } from '../sync/SupabaseConnector';
+
+describe('SupabaseConnector', () => {
+  let connector: SupabaseConnector;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    connector = new SupabaseConnector();
+  });
+
+  describe('authentication state', () => {
+    it('starts unauthenticated', () => {
+      expect(connector.isAuthenticated()).toBe(false);
+      expect(connector.getUserId()).toBeNull();
+      expect(connector.getSession()).toBeNull();
+    });
+
+    it('signIn updates session on success', async () => {
+      const mockSession = {
+        user: { id: 'user-123', email: 'test@example.com' },
+        access_token: 'token',
+      };
+      mockAuth.signInWithPassword.mockResolvedValue({
+        data: { session: mockSession },
+        error: null,
+      });
+
+      const result = await connector.signIn('test@example.com', 'password123');
+
+      expect(result.success).toBe(true);
+      expect(connector.isAuthenticated()).toBe(true);
+    });
+
+    it('signIn returns error on failure', async () => {
+      mockAuth.signInWithPassword.mockResolvedValue({
+        data: { session: null },
+        error: { message: 'Invalid credentials' },
+      });
+
+      const result = await connector.signIn('bad@example.com', 'wrong');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Invalid credentials');
+    });
+
+    it('signUp returns error on failure', async () => {
+      mockAuth.signUp.mockResolvedValue({
+        data: { session: null },
+        error: { message: 'Email already in use' },
+      });
+
+      const result = await connector.signUp('taken@example.com', 'password123');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Email already in use');
+    });
+
+    it('signOut clears session', async () => {
+      // First sign in
+      const mockSession = {
+        user: { id: 'user-123', email: 'test@example.com' },
+        access_token: 'token',
+      };
+      mockAuth.signInWithPassword.mockResolvedValue({
+        data: { session: mockSession },
+        error: null,
+      });
+      await connector.signIn('test@example.com', 'password123');
+      expect(connector.isAuthenticated()).toBe(true);
+
+      // Then sign out
+      mockAuth.signOut.mockResolvedValue({});
+      await connector.signOut();
+
+      expect(connector.isAuthenticated()).toBe(false);
+      expect(connector.getSession()).toBeNull();
+    });
+  });
+
+  describe('fetchUserLicense', () => {
+    it('returns null when not authenticated', async () => {
+      const result = await connector.fetchUserLicense();
+      expect(result).toBeNull();
+    });
+
+    it('returns license matched by user_id', async () => {
+      // Set up authenticated session
+      const mockSession = {
+        user: { id: 'user-123', email: 'test@example.com' },
+        access_token: 'token',
+      };
+      mockAuth.signInWithPassword.mockResolvedValue({
+        data: { session: mockSession },
+        error: null,
+      });
+      await connector.signIn('test@example.com', 'password123');
+
+      const mockLicense = {
+        id: 'lic-1',
+        license_key: 'KEY-1',
+        user_id: 'user-123',
+        email: 'test@example.com',
+        tier: 'professional',
+        modules: [],
+        maintenance_end_date: '2027-01-01T00:00:00Z',
+        status: 'active',
+      };
+
+      const mockChain = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: mockLicense, error: null }),
+      };
+      mockFrom.mockReturnValue(mockChain);
+
+      const result = await connector.fetchUserLicense();
+      expect(result).toEqual(mockLicense);
+    });
+
+    it('falls back to email match when no user_id match', async () => {
+      // Set up authenticated session
+      const mockSession = {
+        user: { id: 'user-123', email: 'test@example.com' },
+        access_token: 'token',
+      };
+      mockAuth.signInWithPassword.mockResolvedValue({
+        data: { session: mockSession },
+        error: null,
+      });
+      await connector.signIn('test@example.com', 'password123');
+
+      const unclaimedLicense = {
+        id: 'lic-2',
+        license_key: 'KEY-2',
+        user_id: null,
+        email: 'test@example.com',
+        tier: 'professional',
+        modules: [],
+        maintenance_end_date: '2027-01-01T00:00:00Z',
+        status: 'active',
+      };
+
+      // First call (by user_id) returns no match
+      const firstChain = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: null, error: { code: 'PGRST116' } }),
+      };
+
+      // Second call (by email) returns unclaimed license
+      const secondChain = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        is: vi.fn().mockReturnThis(),
+        order: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: unclaimedLicense, error: null }),
+      };
+
+      mockFrom.mockReturnValueOnce(firstChain).mockReturnValueOnce(secondChain);
+
+      const result = await connector.fetchUserLicense();
+      expect(result).toEqual(unclaimedLicense);
+    });
+  });
+
+  describe('claimLicenseByEmail', () => {
+    it('returns success on successful claim', async () => {
+      mockRpc.mockResolvedValue({
+        data: { success: true, license: { id: 'lic-1' } },
+        error: null,
+      });
+
+      const result = await connector.claimLicenseByEmail();
+      expect(result.success).toBe(true);
+    });
+
+    it('returns error on RPC failure', async () => {
+      mockRpc.mockResolvedValue({
+        data: null,
+        error: { message: 'Function call failed' },
+      });
+
+      const result = await connector.claimLicenseByEmail();
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Function call failed');
+    });
+  });
+
+  describe('resetPassword', () => {
+    it('returns success when reset email sent', async () => {
+      mockAuth.resetPasswordForEmail.mockResolvedValue({ error: null });
+
+      const result = await connector.resetPassword('test@example.com');
+      expect(result.success).toBe(true);
+    });
+
+    it('returns error on failure', async () => {
+      mockAuth.resetPasswordForEmail.mockResolvedValue({
+        error: { message: 'Rate limit exceeded' },
+      });
+
+      const result = await connector.resetPassword('test@example.com');
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Rate limit exceeded');
+    });
+  });
+
+  describe('session listeners', () => {
+    it('notifies listeners on session change', () => {
+      const listener = vi.fn();
+      connector.onSessionChange(listener);
+
+      // Simulate auth state change by calling the registered callback
+      const authCallback = mockAuth.onAuthStateChange.mock.calls[0][0];
+      const mockSession = { user: { id: 'user-1' }, access_token: 'tok' };
+      authCallback('SIGNED_IN', mockSession);
+
+      expect(listener).toHaveBeenCalledWith(mockSession);
+    });
+
+    it('unsubscribe removes listener', () => {
+      const listener = vi.fn();
+      const unsubscribe = connector.onSessionChange(listener);
+      unsubscribe();
+
+      // Simulate auth state change
+      const authCallback = mockAuth.onAuthStateChange.mock.calls[0][0];
+      authCallback('SIGNED_OUT', null);
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/desktop/src/main/services/sync/SupabaseConnector.ts
+++ b/apps/desktop/src/main/services/sync/SupabaseConnector.ts
@@ -70,7 +70,11 @@ export class SupabaseConnector implements PowerSyncBackendConnector {
     }
 
     // Enforce HTTPS in production to prevent credential leakage
-    if (process.env.NODE_ENV === 'production' && !config.supabase.url.startsWith('https://')) {
+    if (
+      process.env.NODE_ENV === 'production' &&
+      config.supabase.url &&
+      !config.supabase.url.startsWith('https://')
+    ) {
       throw new Error('Supabase URL must use HTTPS in production');
     }
 

--- a/apps/desktop/src/main/services/sync/SupabaseConnector.ts
+++ b/apps/desktop/src/main/services/sync/SupabaseConnector.ts
@@ -210,27 +210,14 @@ export class SupabaseConnector implements PowerSyncBackendConnector {
   // ============================================
 
   /**
-   * Activate a license key via Supabase RPC
-   */
-  async activateLicense(key: string): Promise<{ success: boolean; error?: string; license?: any }> {
-    const { data, error } = await this.supabase.rpc('activate_license', {
-      p_license_key: key,
-    });
-
-    if (error) {
-      return { success: false, error: error.message };
-    }
-
-    return data as { success: boolean; error?: string; license?: any };
-  }
-
-  /**
-   * Fetch the current user's active license from Supabase
+   * Fetch the current user's active license from Supabase.
+   * First checks by user_id (already claimed), then falls back to email match.
    */
   async fetchUserLicense(): Promise<any | null> {
     const userId = this.getUserId();
     if (!userId) return null;
 
+    // Try by user_id first (already claimed)
     const { data, error } = await this.supabase
       .from('licenses')
       .select('*')
@@ -238,11 +225,43 @@ export class SupabaseConnector implements PowerSyncBackendConnector {
       .eq('status', 'active')
       .single();
 
-    if (error || !data) {
-      return null;
+    if (!error && data) {
+      return data;
     }
 
-    return data;
+    // Fall back to email match (unclaimed license visible via RLS)
+    const userEmail = this.currentSession?.user?.email;
+    if (!userEmail) return null;
+
+    const { data: emailMatch, error: emailError } = await this.supabase
+      .from('licenses')
+      .select('*')
+      .eq('email', userEmail)
+      .is('user_id', null)
+      .eq('status', 'active')
+      .order('created_at', { ascending: true })
+      .limit(1)
+      .single();
+
+    if (!emailError && emailMatch) {
+      return emailMatch;
+    }
+
+    return null;
+  }
+
+  /**
+   * Claim an unclaimed license by email via Supabase RPC.
+   * Called automatically on sign-in when a license exists for the user's email.
+   */
+  async claimLicenseByEmail(): Promise<{ success: boolean; error?: string; license?: any }> {
+    const { data, error } = await this.supabase.rpc('claim_license_by_email');
+
+    if (error) {
+      return { success: false, error: error.message };
+    }
+
+    return data as { success: boolean; error?: string; license?: any };
   }
 
   // ============================================

--- a/apps/desktop/src/main/services/sync/SupabaseConnector.ts
+++ b/apps/desktop/src/main/services/sync/SupabaseConnector.ts
@@ -18,6 +18,25 @@ import {
 import { createClient, SupabaseClient, Session, AuthChangeEvent } from '@supabase/supabase-js';
 import { getConfig } from '../../config/env';
 import { logger } from '../../utils/logger';
+import type { ModuleAccess, LicenseTier } from '../../../shared/types/license.types';
+
+/**
+ * License record as stored in Supabase
+ */
+export interface SupabaseLicense {
+  id: string;
+  license_key: string;
+  user_id: string | null;
+  email: string;
+  name: string | null;
+  tier: LicenseTier;
+  modules: ModuleAccess[];
+  maintenance_end_date: string;
+  status: 'active' | 'suspended' | 'revoked';
+  cloud_sync: boolean;
+  created_at: string;
+  updated_at: string;
+}
 
 /**
  * Result of fetching credentials
@@ -48,6 +67,11 @@ export class SupabaseConnector implements PowerSyncBackendConnector {
       throw new Error(
         'Supabase configuration missing. Ensure SUPABASE_URL and SUPABASE_ANON_KEY are set.',
       );
+    }
+
+    // Enforce HTTPS in production to prevent credential leakage
+    if (process.env.NODE_ENV === 'production' && !config.supabase.url.startsWith('https://')) {
+      throw new Error('Supabase URL must use HTTPS in production');
     }
 
     this.supabase = createClient(config.supabase.url, config.supabase.anonKey, {
@@ -213,7 +237,7 @@ export class SupabaseConnector implements PowerSyncBackendConnector {
    * Fetch the current user's active license from Supabase.
    * First checks by user_id (already claimed), then falls back to email match.
    */
-  async fetchUserLicense(): Promise<any | null> {
+  async fetchUserLicense(): Promise<SupabaseLicense | null> {
     const userId = this.getUserId();
     if (!userId) return null;
 
@@ -254,14 +278,18 @@ export class SupabaseConnector implements PowerSyncBackendConnector {
    * Claim an unclaimed license by email via Supabase RPC.
    * Called automatically on sign-in when a license exists for the user's email.
    */
-  async claimLicenseByEmail(): Promise<{ success: boolean; error?: string; license?: any }> {
+  async claimLicenseByEmail(): Promise<{
+    success: boolean;
+    error?: string;
+    license?: SupabaseLicense;
+  }> {
     const { data, error } = await this.supabase.rpc('claim_license_by_email');
 
     if (error) {
       return { success: false, error: error.message };
     }
 
-    return data as { success: boolean; error?: string; license?: any };
+    return data as { success: boolean; error?: string; license?: SupabaseLicense };
   }
 
   // ============================================

--- a/apps/desktop/src/main/services/sync/SupabaseConnector.ts
+++ b/apps/desktop/src/main/services/sync/SupabaseConnector.ts
@@ -293,6 +293,9 @@ export class SupabaseConnector implements PowerSyncBackendConnector {
       return { success: false, error: error.message };
     }
 
+    if (!data || typeof data !== 'object' || typeof data.success !== 'boolean') {
+      return { success: false, error: 'Invalid response from license claim' };
+    }
     return data as { success: boolean; error?: string; license?: SupabaseLicense };
   }
 

--- a/apps/desktop/src/main/services/sync/SupabaseConnector.ts
+++ b/apps/desktop/src/main/services/sync/SupabaseConnector.ts
@@ -206,6 +206,46 @@ export class SupabaseConnector implements PowerSyncBackendConnector {
   }
 
   // ============================================
+  // License Operations
+  // ============================================
+
+  /**
+   * Activate a license key via Supabase RPC
+   */
+  async activateLicense(key: string): Promise<{ success: boolean; error?: string; license?: any }> {
+    const { data, error } = await this.supabase.rpc('activate_license', {
+      p_license_key: key,
+    });
+
+    if (error) {
+      return { success: false, error: error.message };
+    }
+
+    return data as { success: boolean; error?: string; license?: any };
+  }
+
+  /**
+   * Fetch the current user's active license from Supabase
+   */
+  async fetchUserLicense(): Promise<any | null> {
+    const userId = this.getUserId();
+    if (!userId) return null;
+
+    const { data, error } = await this.supabase
+      .from('licenses')
+      .select('*')
+      .eq('user_id', userId)
+      .eq('status', 'active')
+      .single();
+
+    if (error || !data) {
+      return null;
+    }
+
+    return data;
+  }
+
+  // ============================================
   // PowerSyncBackendConnector Interface
   // ============================================
 

--- a/apps/desktop/src/main/services/sync/SupabaseConnector.ts
+++ b/apps/desktop/src/main/services/sync/SupabaseConnector.ts
@@ -69,13 +69,13 @@ export class SupabaseConnector implements PowerSyncBackendConnector {
       );
     }
 
-    // Enforce HTTPS in production to prevent credential leakage
-    if (
-      process.env.NODE_ENV === 'production' &&
-      config.supabase.url &&
-      !config.supabase.url.startsWith('https://')
-    ) {
-      throw new Error('Supabase URL must use HTTPS in production');
+    // Enforce HTTPS to prevent credential leakage
+    if (config.supabase.url && !config.supabase.url.startsWith('https://')) {
+      if (process.env.NODE_ENV === 'production') {
+        throw new Error('Supabase URL must use HTTPS in production');
+      } else {
+        logger.warn('[Security] Supabase URL is not using HTTPS — credentials may be exposed');
+      }
     }
 
     this.supabase = createClient(config.supabase.url, config.supabase.anonKey, {
@@ -296,7 +296,12 @@ export class SupabaseConnector implements PowerSyncBackendConnector {
     if (!data || typeof data !== 'object' || typeof data.success !== 'boolean') {
       return { success: false, error: 'Invalid response from license claim' };
     }
-    return data as { success: boolean; error?: string; license?: SupabaseLicense };
+    // Return only known fields — don't pass through unexpected data from RPC
+    return {
+      success: data.success,
+      error: data.error,
+      license: data.license,
+    };
   }
 
   // ============================================

--- a/apps/desktop/src/main/services/sync/SupabaseConnector.ts
+++ b/apps/desktop/src/main/services/sync/SupabaseConnector.ts
@@ -21,6 +21,21 @@ import { logger } from '../../utils/logger';
 import type { ModuleAccess, LicenseTier } from '../../../shared/types/license.types';
 
 /**
+ * Map Supabase auth error messages to user-friendly strings.
+ * Prevents leaking implementation details (e.g., "JWT expired", database errors).
+ */
+function mapAuthError(message: string): string {
+  const lower = message.toLowerCase();
+  if (lower.includes('invalid login credentials')) return 'Invalid email or password';
+  if (lower.includes('email not confirmed')) return 'Please confirm your email before signing in';
+  if (lower.includes('user already registered')) return 'An account with this email already exists';
+  if (lower.includes('password')) return 'Password does not meet requirements';
+  if (lower.includes('rate limit') || lower.includes('too many'))
+    return 'Too many attempts. Please wait and try again.';
+  return 'Authentication failed. Please try again.';
+}
+
+/**
  * License record as stored in Supabase
  */
 export interface SupabaseLicense {
@@ -153,7 +168,7 @@ export class SupabaseConnector implements PowerSyncBackendConnector {
       });
 
       if (error) {
-        return { success: false, error: error.message };
+        return { success: false, error: mapAuthError(error.message) };
       }
 
       this.currentSession = data.session;
@@ -161,7 +176,7 @@ export class SupabaseConnector implements PowerSyncBackendConnector {
     } catch (error) {
       return {
         success: false,
-        error: error instanceof Error ? error.message : 'Sign in failed',
+        error: 'Sign in failed. Please try again.',
       };
     }
   }
@@ -177,7 +192,7 @@ export class SupabaseConnector implements PowerSyncBackendConnector {
       });
 
       if (error) {
-        return { success: false, error: error.message };
+        return { success: false, error: mapAuthError(error.message) };
       }
 
       // Note: Session may be null if email confirmation is required
@@ -186,7 +201,7 @@ export class SupabaseConnector implements PowerSyncBackendConnector {
     } catch (error) {
       return {
         success: false,
-        error: error instanceof Error ? error.message : 'Sign up failed',
+        error: 'Sign up failed. Please try again.',
       };
     }
   }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -173,8 +173,8 @@ contextBridge.exposeInMainWorld('api', {
     getAvailableModules: () => ipcRenderer.invoke('license:getAvailableModules'),
     canUseFeature: (module: string, feature: string) =>
       ipcRenderer.invoke('license:canUseFeature', module, feature),
-    activate: (licenseKey: string, email: string, modules: string[]) =>
-      ipcRenderer.invoke('license:activate', licenseKey, email, modules),
+    activate: (licenseKey: string) => ipcRenderer.invoke('license:activate', licenseKey),
+    refresh: () => ipcRenderer.invoke('license:refresh'),
     verifyOnline: () => ipcRenderer.invoke('license:verifyOnline'),
   },
 
@@ -472,7 +472,8 @@ export interface ElectronAPI {
     getModuleFeatures: (module: string) => Promise<any>;
     getAvailableModules: () => Promise<string[]>;
     canUseFeature: (module: string, feature: string) => Promise<boolean>;
-    activate: (licenseKey: string, email: string, modules: string[]) => Promise<any>;
+    activate: (licenseKey: string) => Promise<{ success: boolean; error?: string; license?: any }>;
+    refresh: () => Promise<{ success: boolean; license?: any }>;
     verifyOnline: () => Promise<boolean>;
   };
   settings: {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -173,7 +173,6 @@ contextBridge.exposeInMainWorld('api', {
     getAvailableModules: () => ipcRenderer.invoke('license:getAvailableModules'),
     canUseFeature: (module: string, feature: string) =>
       ipcRenderer.invoke('license:canUseFeature', module, feature),
-    activate: (licenseKey: string) => ipcRenderer.invoke('license:activate', licenseKey),
     refresh: () => ipcRenderer.invoke('license:refresh'),
     verifyOnline: () => ipcRenderer.invoke('license:verifyOnline'),
   },
@@ -472,7 +471,6 @@ export interface ElectronAPI {
     getModuleFeatures: (module: string) => Promise<any>;
     getAvailableModules: () => Promise<string[]>;
     canUseFeature: (module: string, feature: string) => Promise<boolean>;
-    activate: (licenseKey: string) => Promise<{ success: boolean; error?: string; license?: any }>;
     refresh: () => Promise<{ success: boolean; license?: any }>;
     verifyOnline: () => Promise<boolean>;
   };

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -474,7 +474,7 @@ export interface ElectronAPI {
     canUseFeature: (module: string, feature: string) => Promise<boolean>;
     refresh: () => Promise<{ success: boolean; license?: any }>;
     verifyOnline: () => Promise<boolean>;
-    createDemo: () => Promise<{ success: boolean; license?: any }>;
+    createDemo: () => Promise<{ success: boolean; license?: Record<string, unknown> }>;
   };
   settings: {
     get: () => Promise<any>;

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -175,6 +175,7 @@ contextBridge.exposeInMainWorld('api', {
       ipcRenderer.invoke('license:canUseFeature', module, feature),
     refresh: () => ipcRenderer.invoke('license:refresh'),
     verifyOnline: () => ipcRenderer.invoke('license:verifyOnline'),
+    createDemo: () => ipcRenderer.invoke('license:createDemo'),
   },
 
   // Settings operations
@@ -473,6 +474,7 @@ export interface ElectronAPI {
     canUseFeature: (module: string, feature: string) => Promise<boolean>;
     refresh: () => Promise<{ success: boolean; license?: any }>;
     verifyOnline: () => Promise<boolean>;
+    createDemo: () => Promise<{ success: boolean; license?: any }>;
   };
   settings: {
     get: () => Promise<any>;

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -19,7 +19,6 @@ import { SettingsDialog } from './components/common/SettingsDialog';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { AuthModal } from './components/auth';
 import { OfflineBanner } from './components/sync';
-import { useUser } from './hooks/useUser';
 import { useSettingsStore } from './store/settingsStore';
 import { useUIStore } from './store/uiStore';
 import { useAuthStore } from './store/authStore';
@@ -30,7 +29,7 @@ import { useMenuHandlers } from './hooks/useMenuHandlers';
 import { useProjectMenuHandlers } from './hooks/useProjectMenuHandlers';
 
 function AppContent() {
-  const { status } = useUser();
+  const licenseStatus = useAuthStore((state) => state.licenseStatus);
   const navigate = useNavigate();
   const isSettingsDialogOpen = useUIStore((state) => state.isSettingsDialogOpen);
   const closeSettingsDialog = useUIStore((state) => state.closeSettingsDialog);
@@ -56,7 +55,7 @@ function AppContent() {
   return (
     <>
       {/* License Status Banner - shows warnings for expiration/offline */}
-      {status && <LicenseBanner status={status} />}
+      {licenseStatus && <LicenseBanner status={licenseStatus} />}
 
       {/* Offline Banner - shows when cloud sync is disconnected */}
       <OfflineBanner />

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -177,6 +177,16 @@ export default function App() {
     setShowSplash(false);
     // Mark splash as shown for this session
     sessionStorage.setItem('splashShown', 'true');
+
+    // First-launch auth prompt: if not authenticated and never prompted
+    const authPrompted = localStorage.getItem('showstack-auth-prompted');
+    if (!authPrompted) {
+      const authState = useAuthStore.getState();
+      if (!authState.isAuthenticated) {
+        authState.setFirstLaunchPrompt(true);
+        authState.openAuthModal('login');
+      }
+    }
   };
 
   const handleConsentClose = () => {

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -28,6 +28,22 @@ import { logger } from './utils/logger';
 import { useMenuHandlers } from './hooks/useMenuHandlers';
 import { useProjectMenuHandlers } from './hooks/useProjectMenuHandlers';
 
+/** Safe localStorage wrapper — no-ops if storage is unavailable */
+function safeGetItem(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+function safeSetItem(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    // Storage unavailable — non-fatal
+  }
+}
+
 function AppContent() {
   const licenseStatus = useAuthStore((state) => state.licenseStatus);
   const navigate = useNavigate();
@@ -169,7 +185,7 @@ export default function App() {
   // Show consent dialog on first launch
   const [showConsent, setShowConsent] = useState(() => {
     // Check if consent was already given (check if user has made a choice)
-    const consentShown = localStorage.getItem('showstack-consent-shown');
+    const consentShown = safeGetItem('showstack-consent-shown');
     return !consentShown;
   });
 
@@ -179,7 +195,7 @@ export default function App() {
     sessionStorage.setItem('splashShown', 'true');
 
     // First-launch auth prompt: if not authenticated and never prompted
-    const authPrompted = localStorage.getItem('showstack-auth-prompted');
+    const authPrompted = safeGetItem('showstack-auth-prompted');
     if (!authPrompted) {
       const authState = useAuthStore.getState();
       if (!authState.isAuthenticated) {
@@ -192,7 +208,7 @@ export default function App() {
   const handleConsentClose = () => {
     setShowConsent(false);
     // Mark consent dialog as shown
-    localStorage.setItem('showstack-consent-shown', 'true');
+    safeSetItem('showstack-consent-shown', 'true');
   };
 
   // Initialize global error handlers
@@ -260,7 +276,9 @@ export default function App() {
               {/* Show consent dialog on first launch after splash */}
               {showConsent && <ConsentDialog onClose={handleConsentClose} />}
               {/* Auth Modal for cloud sync login/signup */}
-              <AuthModal />
+              <ErrorBoundary>
+                <AuthModal />
+              </ErrorBoundary>
             </>
           )}
         </Router>

--- a/apps/desktop/src/renderer/src/components/License/Account/LicenseSection.tsx
+++ b/apps/desktop/src/renderer/src/components/License/Account/LicenseSection.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { logger } from '../../../utils/logger';
 import { useUser } from '../../../hooks/useUser';
+import { useAuthStore } from '../../../store/authStore';
 import { CheckCircle, XCircle, AlertCircle } from 'lucide-react';
 
 /**
@@ -8,14 +9,14 @@ import { CheckCircle, XCircle, AlertCircle } from 'lucide-react';
  *
  * Shows:
  * - License activation form (if no license)
- * - License status, tier, and expiration
+ * - License status, tier, and maintenance date
  * - Available modules
  * - Enabled features
  */
 export function LicenseSection() {
-  const { license, loading, activateLicense } = useUser();
+  const { license, loading, refreshStatus } = useUser();
+  const { isAuthenticated, activateLicense } = useAuthStore();
   const [licenseKey, setLicenseKey] = useState('');
-  const [email, setEmail] = useState('');
   const [activating, setActivating] = useState(false);
   const [error, setError] = useState('');
 
@@ -27,7 +28,7 @@ export function LicenseSection() {
       logger.info('License properties:', {
         tier: license.tier,
         status: license.status,
-        expirationDate: license.expirationDate,
+        maintenanceEndDate: license.maintenanceEndDate,
         licenseKey: license.licenseKey,
         email: license.email,
         modules: license.modules,
@@ -36,15 +37,18 @@ export function LicenseSection() {
   }, [license, loading]);
 
   async function handleActivate() {
-    if (!licenseKey || !email) return;
+    if (!licenseKey) return;
 
     setActivating(true);
     setError('');
     try {
-      // For now, default to 'prep' module - this would come from purchase
-      await activateLicense(licenseKey, email, ['prep']);
-      setLicenseKey('');
-      setEmail('');
+      const result = await activateLicense(licenseKey);
+      if (result.success) {
+        setLicenseKey('');
+        await refreshStatus();
+      } else {
+        setError(result.error || 'Activation failed. Please check your license key and try again.');
+      }
     } catch (err) {
       logger.error('Activation failed:', err);
       setError('Activation failed. Please check your license key and try again.');
@@ -69,16 +73,11 @@ export function LicenseSection() {
       <div className="space-y-6">
         <h3 className="text-lg font-semibold text-gray-900">Activate License</h3>
 
-        <div>
-          <label className="block font-medium mb-2 text-gray-900">Email</label>
-          <input
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            className="w-full px-3 py-2 border border-gray-300 rounded text-gray-900"
-            placeholder="your@email.com"
-          />
-        </div>
+        {!isAuthenticated && (
+          <p className="text-sm text-gray-500">
+            Sign in to your account first, then enter your license key.
+          </p>
+        )}
 
         <div>
           <label className="block font-medium mb-2 text-gray-900">License Key</label>
@@ -88,6 +87,7 @@ export function LicenseSection() {
             onChange={(e) => setLicenseKey(e.target.value)}
             className="w-full px-3 py-2 border border-gray-300 rounded font-mono text-gray-900"
             placeholder="XXXX-XXXX-XXXX-XXXX"
+            disabled={!isAuthenticated}
           />
         </div>
 
@@ -95,7 +95,7 @@ export function LicenseSection() {
 
         <button
           onClick={handleActivate}
-          disabled={activating || !licenseKey || !email}
+          disabled={activating || !licenseKey || !isAuthenticated}
           className="px-4 py-2 bg-blue-500 text-gray-900 dark:text-white rounded hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
         >
           {activating ? 'Activating...' : 'Activate License'}
@@ -129,9 +129,9 @@ export function LicenseSection() {
         </div>
 
         <div>
-          <span className="text-sm text-gray-600">Expires:</span>
+          <span className="text-sm text-gray-600">Maintenance Until:</span>
           <span className="ml-2 font-medium text-gray-900">
-            {new Date(license.expirationDate).toLocaleDateString()}
+            {new Date(license.maintenanceEndDate).toLocaleDateString()}
           </span>
         </div>
 

--- a/apps/desktop/src/renderer/src/components/License/Account/LicenseSection.tsx
+++ b/apps/desktop/src/renderer/src/components/License/Account/LicenseSection.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { logger } from '../../../utils/logger';
 import { useUser } from '../../../hooks/useUser';
 import { useAuthStore } from '../../../store/authStore';
@@ -8,17 +8,14 @@ import { CheckCircle, XCircle, AlertCircle } from 'lucide-react';
  * License section of the Account dialog
  *
  * Shows:
- * - License activation form (if no license)
  * - License status, tier, and maintenance date
  * - Available modules
  * - Enabled features
+ * - Prompt to sign in if no license found
  */
 export function LicenseSection() {
-  const { license, loading, refreshStatus } = useUser();
-  const { isAuthenticated, activateLicense } = useAuthStore();
-  const [licenseKey, setLicenseKey] = useState('');
-  const [activating, setActivating] = useState(false);
-  const [error, setError] = useState('');
+  const { license, loading } = useUser();
+  const { isAuthenticated } = useAuthStore();
 
   // Debug logging
   React.useEffect(() => {
@@ -36,32 +33,11 @@ export function LicenseSection() {
     }
   }, [license, loading]);
 
-  async function handleActivate() {
-    if (!licenseKey) return;
-
-    setActivating(true);
-    setError('');
-    try {
-      const result = await activateLicense(licenseKey);
-      if (result.success) {
-        setLicenseKey('');
-        await refreshStatus();
-      } else {
-        setError(result.error || 'Activation failed. Please check your license key and try again.');
-      }
-    } catch (err) {
-      logger.error('Activation failed:', err);
-      setError('Activation failed. Please check your license key and try again.');
-    } finally {
-      setActivating(false);
-    }
-  }
-
   if (loading) {
     return <div className="text-gray-600">Loading...</div>;
   }
 
-  // Check if license is truly valid with all required fields
+  // No valid license — prompt to sign in
   if (
     !license ||
     !license.email ||
@@ -71,35 +47,15 @@ export function LicenseSection() {
   ) {
     return (
       <div className="space-y-6">
-        <h3 className="text-lg font-semibold text-gray-900">Activate License</h3>
+        <h3 className="text-lg font-semibold text-gray-900">License</h3>
 
-        {!isAuthenticated && (
-          <p className="text-sm text-gray-500">
-            Sign in to your account first, then enter your license key.
+        <div className="bg-gray-50 rounded-lg p-4">
+          <p className="text-sm text-gray-600">
+            {!isAuthenticated
+              ? 'Sign in with the email associated with your purchase to activate your license automatically.'
+              : 'No license found for your account. If you recently purchased, it may take a moment to sync.'}
           </p>
-        )}
-
-        <div>
-          <label className="block font-medium mb-2 text-gray-900">License Key</label>
-          <input
-            type="text"
-            value={licenseKey}
-            onChange={(e) => setLicenseKey(e.target.value)}
-            className="w-full px-3 py-2 border border-gray-300 rounded font-mono text-gray-900"
-            placeholder="XXXX-XXXX-XXXX-XXXX"
-            disabled={!isAuthenticated}
-          />
         </div>
-
-        {error && <div className="text-red-600 text-sm">{error}</div>}
-
-        <button
-          onClick={handleActivate}
-          disabled={activating || !licenseKey || !isAuthenticated}
-          className="px-4 py-2 bg-blue-500 text-gray-900 dark:text-white rounded hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-        >
-          {activating ? 'Activating...' : 'Activate License'}
-        </button>
       </div>
     );
   }
@@ -133,11 +89,6 @@ export function LicenseSection() {
           <span className="ml-2 font-medium text-gray-900">
             {new Date(license.maintenanceEndDate).toLocaleDateString()}
           </span>
-        </div>
-
-        <div>
-          <span className="text-sm text-gray-600">License Key:</span>
-          <span className="ml-2 font-mono text-sm text-gray-900">{license.licenseKey}</span>
         </div>
       </div>
 

--- a/apps/desktop/src/renderer/src/components/License/ModuleSelector.tsx
+++ b/apps/desktop/src/renderer/src/components/License/ModuleSelector.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { logger } from '../../utils/logger';
-import { Package, Wrench, Briefcase, GraduationCap, Lock } from 'lucide-react';
+import { Lightbulb, Speaker, Monitor, ClipboardList, Bus, DollarSign, Lock } from 'lucide-react';
 import type { ShowStackModule } from '../../../../shared/types/license.types';
 
 interface ModuleSelectorProps {
@@ -11,7 +11,7 @@ interface ModuleSelectorProps {
 /**
  * Module selector component for switching between ShowStack modules
  *
- * Displays all available modules (Prep, Production, Manager, Student) and shows
+ * Displays all available modules (Lighting, Sound, Video, etc.) and shows
  * locked state for modules the user doesn't have access to.
  *
  * Features:
@@ -22,7 +22,7 @@ interface ModuleSelectorProps {
  *
  * @example
  * ```tsx
- * const [currentModule, setCurrentModule] = useState<ShowStackModule>('prep');
+ * const [currentModule, setCurrentModule] = useState<ShowStackModule>('lighting');
  *
  * return (
  *   <ModuleSelector
@@ -52,25 +52,35 @@ export function ModuleSelector({ currentModule, onModuleChange }: ModuleSelector
   }
 
   const moduleConfig = {
-    prep: {
-      icon: Package,
-      label: 'Prep',
-      description: 'Shop orders & equipment tracking',
+    lighting: {
+      icon: Lightbulb,
+      label: 'Lighting',
+      description: 'Fixture management & paperwork',
     },
-    production: {
-      icon: Wrench,
-      label: 'Production',
-      description: 'Production management & paperwork',
+    sound: {
+      icon: Speaker,
+      label: 'Sound',
+      description: 'Audio system design',
     },
-    manager: {
-      icon: Briefcase,
-      label: 'Manager',
-      description: 'Tour & financial management',
+    video: {
+      icon: Monitor,
+      label: 'Video',
+      description: 'Video & projection planning',
     },
-    student: {
-      icon: GraduationCap,
-      label: 'Student',
-      description: 'Educational version',
+    production_management: {
+      icon: ClipboardList,
+      label: 'Production Mgmt',
+      description: 'Scheduling & logistics',
+    },
+    touring: {
+      icon: Bus,
+      label: 'Touring',
+      description: 'Tour management & per diems',
+    },
+    producer: {
+      icon: DollarSign,
+      label: 'Producer',
+      description: 'Budgeting & financial tracking',
     },
   };
 

--- a/apps/desktop/src/renderer/src/components/SplashScreen.tsx
+++ b/apps/desktop/src/renderer/src/components/SplashScreen.tsx
@@ -1,15 +1,21 @@
 import { useEffect, useState } from 'react';
 import { Layers, CheckCircle, AlertCircle, Loader } from 'lucide-react';
-import { useUser } from '../hooks/useUser';
+import { useAuthStore } from '../store/authStore';
 
 interface SplashScreenProps {
   onComplete: () => void;
 }
 
 export function SplashScreen({ onComplete }: SplashScreenProps) {
-  const { license, status, loading } = useUser();
+  const licenseStatus = useAuthStore((state) => state.licenseStatus);
+  const hasLicense = useAuthStore((state) => state.hasLicense);
   const [progress, setProgress] = useState(0);
   const [statusText, setStatusText] = useState('Initializing...');
+
+  // Load license status during splash
+  useEffect(() => {
+    useAuthStore.getState().refreshLicenseStatus();
+  }, []);
 
   useEffect(() => {
     // Simulate initialization steps
@@ -42,7 +48,7 @@ export function SplashScreen({ onComplete }: SplashScreenProps) {
 
   // Determine license display
   const getLicenseDisplay = () => {
-    if (loading) {
+    if (!licenseStatus) {
       return (
         <div className="flex items-center gap-2 text-gray-400">
           <Loader className="w-4 h-4 animate-spin" />
@@ -51,7 +57,7 @@ export function SplashScreen({ onComplete }: SplashScreenProps) {
       );
     }
 
-    if (!status || !status.isValid) {
+    if (!hasLicense) {
       return (
         <div className="flex items-center gap-2 text-amber-400">
           <AlertCircle className="w-4 h-4" />
@@ -61,12 +67,9 @@ export function SplashScreen({ onComplete }: SplashScreenProps) {
     }
 
     return (
-      <div className="flex flex-col items-center gap-1 text-green-400">
-        <div className="flex items-center gap-2">
-          <CheckCircle className="w-4 h-4" />
-          <span className="text-sm font-medium">{license?.name}</span>
-        </div>
-        <span className="text-xs text-gray-400">{license?.tier} License</span>
+      <div className="flex items-center gap-2 text-green-400">
+        <CheckCircle className="w-4 h-4" />
+        <span className="text-sm font-medium">License Active</span>
       </div>
     );
   };

--- a/apps/desktop/src/renderer/src/components/account/LicenseInfo.tsx
+++ b/apps/desktop/src/renderer/src/components/account/LicenseInfo.tsx
@@ -1,14 +1,43 @@
-import { FileText, CheckCircle, Calendar, AlertCircle } from 'lucide-react';
+import { useState } from 'react';
+import { FileText, CheckCircle, Calendar, AlertCircle, Key } from 'lucide-react';
 import { useUser } from '../../hooks/useUser';
+import { useAuthStore } from '../../store/authStore';
 
 export function LicenseInfo() {
-  const { status } = useUser();
+  const { license, status, refreshStatus } = useUser();
+  const { isAuthenticated, activateLicense } = useAuthStore();
+  const [licenseKey, setLicenseKey] = useState('');
+  const [activating, setActivating] = useState(false);
+  const [activationError, setActivationError] = useState<string | null>(null);
+  const [activationSuccess, setActivationSuccess] = useState(false);
 
-  const hasLicense = status?.isValid || false;
-  const licenseType = status?.tier || 'None';
-  const expirationDate = status?.expiresAt
-    ? new Date(status.expiresAt).toLocaleDateString()
+  const hasLicense = !!license;
+  const licenseType = license?.tier || 'None';
+  const maintenanceDate = license?.maintenanceEndDate
+    ? new Date(license.maintenanceEndDate).toLocaleDateString()
     : 'N/A';
+  const isMaintenanceExpired = status?.status === 'maintenance_expired';
+  const isActive = status?.status === 'active';
+
+  const handleActivate = async () => {
+    if (!licenseKey.trim()) return;
+
+    setActivating(true);
+    setActivationError(null);
+    setActivationSuccess(false);
+
+    const result = await activateLicense(licenseKey.trim());
+
+    if (result.success) {
+      setActivationSuccess(true);
+      setLicenseKey('');
+      await refreshStatus();
+    } else {
+      setActivationError(result.error || 'Activation failed');
+    }
+
+    setActivating(false);
+  };
 
   return (
     <div className="space-y-6">
@@ -17,74 +46,137 @@ export function LicenseInfo() {
           License Information
         </h2>
         <p className="text-gray-600 dark:text-gray-400">
-          View your license status and subscription details
+          View your license status and maintenance details
         </p>
       </div>
 
-      {/* Subscription Management - Now at top */}
-      {hasLicense ? (
+      {/* Maintenance Status */}
+      {hasLicense && isActive && (
         <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 rounded-lg p-4">
           <div className="flex items-start gap-2">
             <Calendar className="w-5 h-5 text-blue-600 dark:text-blue-500 mt-0.5 flex-shrink-0" />
             <div>
-              <h4 className="font-medium text-blue-900 mb-1">Subscription Management</h4>
-              <p className="text-sm text-blue-800 dark:text-blue-300 mb-3">
-                Your license expires on {expirationDate}. Manage your subscription in the billing
-                portal.
-              </p>
-              <button className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-gray-900 dark:text-white rounded-md text-sm font-medium transition-colors">
-                Manage Subscription
-              </button>
-            </div>
-          </div>
-        </div>
-      ) : (
-        <div className="bg-amber-50 dark:bg-amber-900/40 border border-amber-200 dark:border-amber-700 rounded-lg p-4">
-          <div className="flex items-start gap-2">
-            <AlertCircle className="w-5 h-5 text-amber-600 dark:text-amber-400 mt-0.5 flex-shrink-0" />
-            <div>
-              <h4 className="font-medium text-amber-900 dark:text-amber-200 mb-1">
-                No Active License
+              <h4 className="font-medium text-blue-900 dark:text-blue-200 mb-1">
+                Active Maintenance
               </h4>
-              <p className="text-sm text-amber-800 dark:text-amber-200 mb-3">
-                You don't have an active license. Purchase a license to unlock all features and
-                receive updates.
+              <p className="text-sm text-blue-800 dark:text-blue-300">
+                Active until {maintenanceDate}. You have access to updates and cloud sync.
               </p>
-              <button className="px-4 py-2 bg-amber-600 hover:bg-amber-700 text-white rounded-md text-sm font-medium transition-colors">
-                Purchase License
-              </button>
             </div>
           </div>
         </div>
       )}
 
-      {/* License Status */}
-      <div className="bg-white dark:bg-gray-800 border border-gray-200 rounded-lg p-6">
+      {hasLicense && isMaintenanceExpired && (
+        <div className="bg-amber-50 dark:bg-amber-900/40 border border-amber-200 dark:border-amber-700 rounded-lg p-4">
+          <div className="flex items-start gap-2">
+            <AlertCircle className="w-5 h-5 text-amber-600 dark:text-amber-400 mt-0.5 flex-shrink-0" />
+            <div>
+              <h4 className="font-medium text-amber-900 dark:text-amber-200 mb-1">
+                Maintenance Expired
+              </h4>
+              <p className="text-sm text-amber-800 dark:text-amber-200">
+                Your maintenance expired on {maintenanceDate}. The app continues to work, but cloud
+                sync is disabled. Renew to get updates and sync.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* License Activation — shown when no license or not authenticated */}
+      {(!hasLicense || !isAuthenticated) && (
+        <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6">
+          <div className="flex items-center gap-3 mb-4">
+            <Key className="w-6 h-6 text-gray-400" />
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+              Activate License
+            </h3>
+          </div>
+
+          {!isAuthenticated && (
+            <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+              Sign in to your account first, then enter your license key below.
+            </p>
+          )}
+
+          {activationError && (
+            <div className="mb-4 p-3 bg-red-900/30 border border-red-700 rounded text-red-300 text-sm">
+              {activationError}
+            </div>
+          )}
+
+          {activationSuccess && (
+            <div className="mb-4 p-3 bg-green-900/30 border border-green-700 rounded text-green-300 text-sm">
+              License activated successfully!
+            </div>
+          )}
+
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={licenseKey}
+              onChange={(e) => setLicenseKey(e.target.value)}
+              placeholder="Enter your license key"
+              className="flex-1 px-4 py-2 bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-gray-900 dark:text-white focus:outline-none focus:border-blue-500"
+              disabled={activating || !isAuthenticated}
+            />
+            <button
+              onClick={handleActivate}
+              disabled={activating || !licenseKey.trim() || !isAuthenticated}
+              className="px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-800 disabled:cursor-not-allowed text-white rounded text-sm font-medium transition-colors"
+            >
+              {activating ? 'Activating...' : 'Activate'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* License Details */}
+      <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6">
         {hasLicense ? (
           <>
             <div className="flex items-start justify-between mb-6">
               <div className="flex items-center gap-3">
                 <CheckCircle className="w-8 h-8 text-green-600" />
                 <div>
-                  <h3 className="text-xl font-semibold text-gray-900 dark:text-white">
+                  <h3 className="text-xl font-semibold text-gray-900 dark:text-white capitalize">
                     {licenseType} License
                   </h3>
-                  <p className="text-sm text-gray-500 dark:text-gray-400">Active license</p>
+                  <p className="text-sm text-gray-500 dark:text-gray-400">
+                    {isMaintenanceExpired ? 'Maintenance expired' : 'Active license'}
+                  </p>
                 </div>
               </div>
-              <span className="px-3 py-1 bg-green-100 text-green-700 rounded-full text-sm font-medium">
-                Active
+              <span
+                className={`px-3 py-1 rounded-full text-sm font-medium ${
+                  isActive
+                    ? 'bg-green-100 text-green-700'
+                    : isMaintenanceExpired
+                      ? 'bg-amber-100 text-amber-700'
+                      : 'bg-red-100 text-red-700'
+                }`}
+              >
+                {isActive
+                  ? 'Active'
+                  : isMaintenanceExpired
+                    ? 'Maintenance Expired'
+                    : status?.status || 'Unknown'}
               </span>
             </div>
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
               <div className="p-4 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
                 <div className="text-sm text-gray-600 dark:text-gray-400 mb-1">License Type</div>
-                <div className="font-semibold text-gray-900 dark:text-white">{licenseType}</div>
+                <div className="font-semibold text-gray-900 dark:text-white capitalize">
+                  {licenseType}
+                </div>
               </div>
               <div className="p-4 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
-                <div className="text-sm text-gray-600 dark:text-gray-400 mb-1">Expiration Date</div>
-                <div className="font-semibold text-gray-900 dark:text-white">{expirationDate}</div>
+                <div className="text-sm text-gray-600 dark:text-gray-400 mb-1">
+                  Maintenance Until
+                </div>
+                <div className="font-semibold text-gray-900 dark:text-white">{maintenanceDate}</div>
               </div>
             </div>
 
@@ -94,19 +186,25 @@ export function LicenseInfo() {
               </h4>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
                 {[
-                  'Unlimited Projects',
-                  'Advanced Layout Designer',
-                  'Cloud Sync & Backup',
-                  'Priority Support',
-                  'Team Collaboration',
-                  'Custom Templates',
+                  { name: 'Unlimited Projects', available: true },
+                  { name: 'Advanced Layout Designer', available: true },
+                  { name: 'Cloud Sync & Backup', available: status?.canSync ?? false },
+                  { name: 'Priority Support', available: licenseType !== 'student' },
+                  { name: 'Custom Templates', available: true },
+                  { name: 'Software Updates', available: !isMaintenanceExpired },
                 ].map((feature) => (
                   <div
-                    key={feature}
-                    className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300"
+                    key={feature.name}
+                    className={`flex items-center gap-2 text-sm ${
+                      feature.available
+                        ? 'text-gray-700 dark:text-gray-300'
+                        : 'text-gray-400 dark:text-gray-500 line-through'
+                    }`}
                   >
-                    <CheckCircle className="w-4 h-4 text-green-600" />
-                    <span>{feature}</span>
+                    <CheckCircle
+                      className={`w-4 h-4 ${feature.available ? 'text-green-600' : 'text-gray-300'}`}
+                    />
+                    <span>{feature.name}</span>
                   </div>
                 ))}
               </div>
@@ -119,9 +217,8 @@ export function LicenseInfo() {
               No License Found
             </h3>
             <p className="text-gray-600 dark:text-gray-400 mb-4">
-              Purchase a license to access premium features and receive updates.
+              Enter a license key above to activate your ShowStack license.
             </p>
-            <p className="text-sm text-gray-500 dark:text-gray-400">License Type: {licenseType}</p>
           </div>
         )}
       </div>

--- a/apps/desktop/src/renderer/src/components/account/LicenseInfo.tsx
+++ b/apps/desktop/src/renderer/src/components/account/LicenseInfo.tsx
@@ -1,15 +1,8 @@
-import { useState } from 'react';
-import { FileText, CheckCircle, Calendar, AlertCircle, Key } from 'lucide-react';
+import { FileText, CheckCircle, Calendar, AlertCircle } from 'lucide-react';
 import { useUser } from '../../hooks/useUser';
-import { useAuthStore } from '../../store/authStore';
 
 export function LicenseInfo() {
-  const { license, status, refreshStatus } = useUser();
-  const { isAuthenticated, activateLicense } = useAuthStore();
-  const [licenseKey, setLicenseKey] = useState('');
-  const [activating, setActivating] = useState(false);
-  const [activationError, setActivationError] = useState<string | null>(null);
-  const [activationSuccess, setActivationSuccess] = useState(false);
+  const { license, status } = useUser();
 
   const hasLicense = !!license;
   const licenseType = license?.tier || 'None';
@@ -18,26 +11,6 @@ export function LicenseInfo() {
     : 'N/A';
   const isMaintenanceExpired = status?.status === 'maintenance_expired';
   const isActive = status?.status === 'active';
-
-  const handleActivate = async () => {
-    if (!licenseKey.trim()) return;
-
-    setActivating(true);
-    setActivationError(null);
-    setActivationSuccess(false);
-
-    const result = await activateLicense(licenseKey.trim());
-
-    if (result.success) {
-      setActivationSuccess(true);
-      setLicenseKey('');
-      await refreshStatus();
-    } else {
-      setActivationError(result.error || 'Activation failed');
-    }
-
-    setActivating(false);
-  };
 
   return (
     <div className="space-y-6">
@@ -80,54 +53,6 @@ export function LicenseInfo() {
                 sync is disabled. Renew to get updates and sync.
               </p>
             </div>
-          </div>
-        </div>
-      )}
-
-      {/* License Activation — shown when no license or not authenticated */}
-      {(!hasLicense || !isAuthenticated) && (
-        <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6">
-          <div className="flex items-center gap-3 mb-4">
-            <Key className="w-6 h-6 text-gray-400" />
-            <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
-              Activate License
-            </h3>
-          </div>
-
-          {!isAuthenticated && (
-            <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
-              Sign in to your account first, then enter your license key below.
-            </p>
-          )}
-
-          {activationError && (
-            <div className="mb-4 p-3 bg-red-900/30 border border-red-700 rounded text-red-300 text-sm">
-              {activationError}
-            </div>
-          )}
-
-          {activationSuccess && (
-            <div className="mb-4 p-3 bg-green-900/30 border border-green-700 rounded text-green-300 text-sm">
-              License activated successfully!
-            </div>
-          )}
-
-          <div className="flex gap-2">
-            <input
-              type="text"
-              value={licenseKey}
-              onChange={(e) => setLicenseKey(e.target.value)}
-              placeholder="Enter your license key"
-              className="flex-1 px-4 py-2 bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-gray-900 dark:text-white focus:outline-none focus:border-blue-500"
-              disabled={activating || !isAuthenticated}
-            />
-            <button
-              onClick={handleActivate}
-              disabled={activating || !licenseKey.trim() || !isAuthenticated}
-              className="px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-800 disabled:cursor-not-allowed text-white rounded text-sm font-medium transition-colors"
-            >
-              {activating ? 'Activating...' : 'Activate'}
-            </button>
           </div>
         </div>
       )}
@@ -217,7 +142,8 @@ export function LicenseInfo() {
               No License Found
             </h3>
             <p className="text-gray-600 dark:text-gray-400 mb-4">
-              Enter a license key above to activate your ShowStack license.
+              Sign in with the email associated with your purchase to activate your license
+              automatically.
             </p>
           </div>
         )}

--- a/apps/desktop/src/renderer/src/components/account/UserProfile.tsx
+++ b/apps/desktop/src/renderer/src/components/account/UserProfile.tsx
@@ -158,7 +158,7 @@ export function UserProfile() {
                 Demo Mode
               </span>
               <p className="text-sm text-gray-600 dark:text-gray-400 mt-2">
-                25 fixtures, no cloud sync, no PDF/Excel export
+                Limited fixtures, no cloud sync, no PDF/Excel export
               </p>
             </div>
             <button

--- a/apps/desktop/src/renderer/src/components/account/UserProfile.tsx
+++ b/apps/desktop/src/renderer/src/components/account/UserProfile.tsx
@@ -25,7 +25,7 @@ export function UserProfile() {
   const signOut = useAuthStore((state) => state.signOut);
   const openAuthModal = useAuthStore((state) => state.openAuthModal);
   // Check if current license is demo tier
-  const isDemoMode = licenseStatus?.message?.includes('Demo mode');
+  const isDemoMode = licenseStatus?.tier === 'demo';
 
   // Local state for form inputs
   const [name, setName] = useState(userProfile.name);

--- a/apps/desktop/src/renderer/src/components/account/UserProfile.tsx
+++ b/apps/desktop/src/renderer/src/components/account/UserProfile.tsx
@@ -1,12 +1,31 @@
 import { useState } from 'react';
-import { UserCircle, Mail, Building, Phone, Save, Camera, Check } from 'lucide-react';
+import {
+  UserCircle,
+  Mail,
+  Building,
+  Phone,
+  Save,
+  Camera,
+  Check,
+  LogOut,
+  Shield,
+} from 'lucide-react';
 import { logger } from '../../utils/logger';
 import { useSettingsStore } from '../../store/settingsStore';
+import { useAuthStore } from '../../store/authStore';
 
 export function UserProfile() {
   const userProfile = useSettingsStore((state) => state.userProfile);
   const updateUserProfile = useSettingsStore((state) => state.updateUserProfile);
   const [saved, setSaved] = useState(false);
+
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const authEmail = useAuthStore((state) => state.email);
+  const licenseStatus = useAuthStore((state) => state.licenseStatus);
+  const signOut = useAuthStore((state) => state.signOut);
+  const openAuthModal = useAuthStore((state) => state.openAuthModal);
+  // Check if current license is demo tier
+  const isDemoMode = licenseStatus?.message?.includes('Demo mode');
 
   // Local state for form inputs
   const [name, setName] = useState(userProfile.name);
@@ -104,6 +123,64 @@ export function UserProfile() {
         <p className="text-gray-600 dark:text-gray-400">
           Manage your personal information and designer credits
         </p>
+      </div>
+
+      {/* Auth Status */}
+      <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4 flex items-center gap-2">
+          <Shield className="w-5 h-5 text-blue-600 dark:text-blue-500" />
+          <span>Account Status</span>
+        </h3>
+
+        {isAuthenticated ? (
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm text-gray-600 dark:text-gray-400">Signed in as</p>
+              <p className="text-base font-medium text-gray-900 dark:text-white">{authEmail}</p>
+              {licenseStatus && (
+                <p className="text-xs text-green-600 dark:text-green-400 mt-1">
+                  {licenseStatus.message}
+                </p>
+              )}
+            </div>
+            <button
+              onClick={() => signOut()}
+              className="flex items-center gap-2 px-4 py-2 text-sm text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-md transition-colors"
+            >
+              <LogOut className="w-4 h-4" />
+              <span>Sign Out</span>
+            </button>
+          </div>
+        ) : isDemoMode ? (
+          <div className="flex items-center justify-between">
+            <div>
+              <span className="inline-block px-2 py-1 text-xs font-semibold text-amber-700 bg-amber-100 dark:text-amber-300 dark:bg-amber-900/30 rounded-full">
+                Demo Mode
+              </span>
+              <p className="text-sm text-gray-600 dark:text-gray-400 mt-2">
+                25 fixtures, no cloud sync, no PDF/Excel export
+              </p>
+            </div>
+            <button
+              onClick={() => openAuthModal('login')}
+              className="flex items-center gap-2 px-4 py-2 text-sm text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors"
+            >
+              Sign in for full access
+            </button>
+          </div>
+        ) : (
+          <div className="flex items-center justify-between">
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              Sign in to unlock cloud sync and full features
+            </p>
+            <button
+              onClick={() => openAuthModal('login')}
+              className="flex items-center gap-2 px-4 py-2 text-sm text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors"
+            >
+              Sign In
+            </button>
+          </div>
+        )}
       </div>
 
       {/* Avatar */}

--- a/apps/desktop/src/renderer/src/components/auth/AuthModal.tsx
+++ b/apps/desktop/src/renderer/src/components/auth/AuthModal.tsx
@@ -6,15 +6,22 @@
  */
 
 import { useEffect } from 'react';
-import { X, Cloud } from 'lucide-react';
+import { X } from 'lucide-react';
 import { useAuthStore } from '../../store/authStore';
 import { LoginForm } from './LoginForm';
 import { SignUpForm } from './SignUpForm';
 import { PasswordResetForm } from './PasswordResetForm';
 
 export function AuthModal() {
-  const { showAuthModal, authModalView, closeAuthModal, setAuthModalView, isLoading } =
-    useAuthStore();
+  const {
+    showAuthModal,
+    authModalView,
+    closeAuthModal,
+    setAuthModalView,
+    isLoading,
+    isFirstLaunchPrompt,
+    activateDemoMode,
+  } = useAuthStore();
 
   // Handle escape key to close modal
   useEffect(() => {
@@ -45,6 +52,11 @@ export function AuthModal() {
     return null;
   }
 
+  const handleDemoMode = async () => {
+    await activateDemoMode();
+    localStorage.setItem('showstack-auth-prompted', 'true');
+  };
+
   const handleBackdropClick = (e: React.MouseEvent) => {
     if (e.target === e.currentTarget && !isLoading) {
       closeAuthModal();
@@ -73,8 +85,7 @@ export function AuthModal() {
         {/* Header with Logo */}
         <div className="pt-6 pb-2 px-6 text-center">
           <div className="flex items-center justify-center gap-2 text-blue-600 mb-2">
-            <Cloud className="h-8 w-8" />
-            <span className="text-xl font-bold">ShowStack Cloud</span>
+            <span className="text-xl font-bold">ShowStack</span>
           </div>
         </div>
 
@@ -95,6 +106,26 @@ export function AuthModal() {
             <PasswordResetForm onSwitchToLogin={() => setAuthModalView('login')} />
           )}
         </div>
+
+        {/* Demo Mode Button (first-launch only) */}
+        {isFirstLaunchPrompt && (
+          <div className="px-6 pb-4">
+            <div className="relative flex items-center justify-center my-2">
+              <div className="border-t border-gray-200 w-full" />
+              <span className="bg-white px-3 text-xs text-gray-400 absolute">or</span>
+            </div>
+            <button
+              onClick={handleDemoMode}
+              disabled={isLoading}
+              className="w-full py-2 px-4 text-sm text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded-md transition-colors disabled:opacity-50"
+            >
+              Continue in Demo Mode
+            </button>
+            <p className="text-xs text-gray-400 text-center mt-1">
+              25 fixtures, no cloud sync, no exports
+            </p>
+          </div>
+        )}
 
         {/* Footer */}
         <div className="px-6 py-4 bg-gray-50 text-center text-xs text-gray-500 border-t">

--- a/apps/desktop/src/renderer/src/components/common/EditProjectDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/common/EditProjectDialog.tsx
@@ -65,7 +65,7 @@ export function EditProjectDialog({ isOpen, project, onClose, onSave }: EditProj
   const [closing, setClosing] = useState('');
   const [loadOut, setLoadOut] = useState('');
 
-  const [enabledModules, setEnabledModules] = useState<string[]>(['production']);
+  const [enabledModules, setEnabledModules] = useState<string[]>(['lighting']);
 
   // Initialize form when project changes
   useEffect(() => {
@@ -135,7 +135,7 @@ export function EditProjectDialog({ isOpen, project, onClose, onSave }: EditProj
       setClosing(project.show_dates?.closing || '');
       setLoadOut(project.show_dates?.load_out || '');
 
-      setEnabledModules(project.enabled_modules || ['production']);
+      setEnabledModules(project.enabled_modules || ['lighting']);
     }
   }, [project]);
 
@@ -980,14 +980,14 @@ export function EditProjectDialog({ isOpen, project, onClose, onSave }: EditProj
                 <label className="flex items-center gap-3 p-3 bg-gray-100 dark:bg-gray-700 rounded cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-650">
                   <input
                     type="checkbox"
-                    checked={enabledModules.includes('production')}
-                    onChange={() => toggleModule('production')}
+                    checked={enabledModules.includes('lighting')}
+                    onChange={() => toggleModule('lighting')}
                     className="w-4 h-4"
                   />
                   <div className="flex-1">
                     <div className="font-medium">ShowStack:Lighting</div>
                     <p className="text-xs text-gray-600 dark:text-gray-400">
-                      Fixture management & technical planning
+                      Fixture management & paperwork
                     </p>
                   </div>
                 </label>
@@ -995,20 +995,39 @@ export function EditProjectDialog({ isOpen, project, onClose, onSave }: EditProj
                 <label className="flex items-center gap-3 p-3 bg-gray-100 dark:bg-gray-700 rounded cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-650">
                   <input
                     type="checkbox"
-                    checked={enabledModules.includes('manager')}
-                    onChange={() => toggleModule('manager')}
+                    checked={enabledModules.includes('sound')}
+                    onChange={() => toggleModule('sound')}
                     disabled={true}
                     className="w-4 h-4"
                   />
                   <div className="flex-1">
                     <div className="flex items-center gap-2">
-                      <span className="font-medium">ShowStack:Manager</span>
+                      <span className="font-medium">ShowStack:Sound</span>
+                      <span className="px-2 py-0.5 bg-gray-400 dark:bg-gray-600 text-gray-900 dark:text-white text-xs rounded">
+                        Locked
+                      </span>
+                    </div>
+                    <p className="text-xs text-gray-600 dark:text-gray-400">Audio system design</p>
+                  </div>
+                </label>
+
+                <label className="flex items-center gap-3 p-3 bg-gray-100 dark:bg-gray-700 rounded cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-650">
+                  <input
+                    type="checkbox"
+                    checked={enabledModules.includes('video')}
+                    onChange={() => toggleModule('video')}
+                    disabled={true}
+                    className="w-4 h-4"
+                  />
+                  <div className="flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className="font-medium">ShowStack:Video</span>
                       <span className="px-2 py-0.5 bg-gray-400 dark:bg-gray-600 text-gray-900 dark:text-white text-xs rounded">
                         Locked
                       </span>
                     </div>
                     <p className="text-xs text-gray-600 dark:text-gray-400">
-                      Tour scheduling & logistics
+                      Video & projection planning
                     </p>
                   </div>
                 </label>

--- a/apps/desktop/src/renderer/src/components/common/NewProjectDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/common/NewProjectDialog.tsx
@@ -11,7 +11,7 @@ export function NewProjectDialog({ isOpen, onClose, onCreate }: NewProjectDialog
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [logoPath, setLogoPath] = useState('');
-  const [enabledModules, setEnabledModules] = useState<string[]>(['production']); // Production is default/unlocked
+  const [enabledModules, setEnabledModules] = useState<string[]>(['lighting']); // Production is default/unlocked
 
   if (!isOpen) return null;
 
@@ -23,7 +23,7 @@ export function NewProjectDialog({ isOpen, onClose, onCreate }: NewProjectDialog
       setName('');
       setDescription('');
       setLogoPath('');
-      setEnabledModules(['production']);
+      setEnabledModules(['lighting']);
       onClose();
     }
   };
@@ -32,7 +32,7 @@ export function NewProjectDialog({ isOpen, onClose, onCreate }: NewProjectDialog
     setName('');
     setDescription('');
     setLogoPath('');
-    setEnabledModules(['production']);
+    setEnabledModules(['lighting']);
     onClose();
   };
 
@@ -133,30 +133,47 @@ export function NewProjectDialog({ isOpen, onClose, onCreate }: NewProjectDialog
               <label className="flex items-center gap-3 p-3 bg-gray-700 rounded cursor-pointer hover:bg-gray-650">
                 <input
                   type="checkbox"
-                  checked={enabledModules.includes('production')}
-                  onChange={() => toggleModule('production')}
+                  checked={enabledModules.includes('lighting')}
+                  onChange={() => toggleModule('lighting')}
                   className="w-4 h-4"
                 />
                 <div className="flex-1">
                   <div className="font-medium">ShowStack:Lighting</div>
-                  <p className="text-xs text-gray-400">Fixture management & technical planning</p>
+                  <p className="text-xs text-gray-400">Fixture management & paperwork</p>
                 </div>
               </label>
 
               <label className="flex items-center gap-3 p-3 bg-gray-700 rounded cursor-pointer hover:bg-gray-650">
                 <input
                   type="checkbox"
-                  checked={enabledModules.includes('manager')}
-                  onChange={() => toggleModule('manager')}
+                  checked={enabledModules.includes('sound')}
+                  onChange={() => toggleModule('sound')}
                   disabled={true}
                   className="w-4 h-4"
                 />
                 <div className="flex-1">
                   <div className="flex items-center gap-2">
-                    <span className="font-medium">ShowStack:Manager</span>
+                    <span className="font-medium">ShowStack:Sound</span>
                     <span className="px-2 py-0.5 bg-gray-600 text-xs rounded">Locked</span>
                   </div>
-                  <p className="text-xs text-gray-400">Tour scheduling & logistics</p>
+                  <p className="text-xs text-gray-400">Audio system design</p>
+                </div>
+              </label>
+
+              <label className="flex items-center gap-3 p-3 bg-gray-700 rounded cursor-pointer hover:bg-gray-650">
+                <input
+                  type="checkbox"
+                  checked={enabledModules.includes('video')}
+                  onChange={() => toggleModule('video')}
+                  disabled={true}
+                  className="w-4 h-4"
+                />
+                <div className="flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium">ShowStack:Video</span>
+                    <span className="px-2 py-0.5 bg-gray-600 text-xs rounded">Locked</span>
+                  </div>
+                  <p className="text-xs text-gray-400">Video & projection planning</p>
                 </div>
               </label>
             </div>

--- a/apps/desktop/src/renderer/src/hooks/useFeature.ts
+++ b/apps/desktop/src/renderer/src/hooks/useFeature.ts
@@ -6,12 +6,12 @@ import type { ShowStackModule } from '../../../shared/types/license.types';
  * Hook for checking if a specific feature is enabled for the user's license
  *
  * @param module - The ShowStack module the feature belongs to
- * @param feature - The feature name to check (e.g., 'bulkOperations', 'logoIntegration')
+ * @param feature - The feature name to check (e.g., 'cloudSync', 'advancedExport')
  * @returns Object with enabled boolean and loading state
  *
  * @example
  * ```tsx
- * const { enabled, loading } = useFeature('prep', 'bulkOperations');
+ * const { enabled, loading } = useFeature('lighting', 'advancedExport');
  *
  * return (
  *   <div>

--- a/apps/desktop/src/renderer/src/hooks/useModuleAccess.ts
+++ b/apps/desktop/src/renderer/src/hooks/useModuleAccess.ts
@@ -5,15 +5,15 @@ import type { ShowStackModule, ModuleFeatures } from '../../../shared/types/lice
 /**
  * Hook for checking if user has access to a specific ShowStack module
  *
- * @param module - The module to check access for ('prep', 'production', 'manager', 'student')
+ * @param module - The module to check access for ('lighting', 'sound', 'video', etc.)
  * @returns Object with hasAccess boolean, module features, and loading state
  *
  * @example
  * ```tsx
- * const { hasAccess, features, loading } = useModuleAccess('production');
+ * const { hasAccess, features, loading } = useModuleAccess('lighting');
  *
  * if (loading) return <div>Loading...</div>;
- * if (!hasAccess) return <UpgradePrompt module="production" />;
+ * if (!hasAccess) return <UpgradePrompt module="lighting" />;
  *
  * return <ProductionApp features={features} />;
  * ```

--- a/apps/desktop/src/renderer/src/hooks/useUser.ts
+++ b/apps/desktop/src/renderer/src/hooks/useUser.ts
@@ -1,26 +1,22 @@
 import { useState, useEffect } from 'react';
 import { logger } from '../utils/logger';
-import type {
-  UserLicense,
-  LicenseValidation,
-  ShowStackModule,
-} from '../../../shared/types/license.types';
+import type { UserLicense, LicenseValidation } from '../../../shared/types/license.types';
 
 /**
  * Hook for accessing user license information and status
  *
- * Provides current license, validation status, and activation functionality.
- * Automatically loads on mount and provides methods to activate new licenses.
+ * Provides current license, validation status, and refresh functionality.
+ * Automatically loads on mount.
  *
  * @returns {object} License data and methods
  * @returns {UserLicense | null} license - Current user license
  * @returns {LicenseValidation | null} status - Current license validation status
  * @returns {boolean} loading - Loading state
- * @returns {function} activateLicense - Function to activate a new license
+ * @returns {function} refreshStatus - Function to refresh license status
  *
  * @example
  * ```tsx
- * const { license, status, loading, activateLicense } = useUser();
+ * const { license, status, loading, refreshStatus } = useUser();
  *
  * if (loading) return <div>Loading...</div>;
  *
@@ -62,19 +58,8 @@ export function useUser() {
     }
   }
 
-  async function activateLicense(licenseKey: string, email: string, modules: ShowStackModule[]) {
-    try {
-      const data = await window.api.license.activate(licenseKey, email, modules);
-      setLicense(data);
-      await loadStatus();
-      return data;
-    } catch (error) {
-      logger.error('Failed to activate license:', error);
-      throw error;
-    }
-  }
-
   async function refreshStatus() {
+    await loadLicense();
     await loadStatus();
   }
 
@@ -82,7 +67,6 @@ export function useUser() {
     license,
     status,
     loading,
-    activateLicense,
     refreshStatus,
   };
 }

--- a/apps/desktop/src/renderer/src/pages/Login.tsx
+++ b/apps/desktop/src/renderer/src/pages/Login.tsx
@@ -1,27 +1,61 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useAuthStore } from '../store/authStore';
 
 export function Login() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [mode, setMode] = useState<'login' | 'signup' | 'reset'>('login');
+  const [resetSent, setResetSent] = useState(false);
   const navigate = useNavigate();
+  const { signIn, signUp, resetPassword, isLoading, error, clearError } = useAuthStore();
 
-  const handleLogin = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    // TODO: Implement actual authentication
-    // For now, just navigate to landing page
-    navigate('/modules');
+
+    if (mode === 'reset') {
+      const success = await resetPassword(email);
+      if (success) {
+        setResetSent(true);
+      }
+      return;
+    }
+
+    const success =
+      mode === 'login' ? await signIn(email, password) : await signUp(email, password);
+
+    if (success) {
+      navigate('/modules');
+    }
+  };
+
+  const switchMode = (newMode: 'login' | 'signup' | 'reset') => {
+    setMode(newMode);
+    setResetSent(false);
+    clearError();
   };
 
   return (
     <div className="h-screen flex items-center justify-center bg-gray-900">
       <div className="w-full max-w-md p-8 bg-gray-800 rounded-lg border border-gray-700">
         <div className="text-center mb-8">
-          <h1 className="text-4xl font-bold text-gray-900 dark:text-white mb-2">ShowStack</h1>
+          <h1 className="text-4xl font-bold text-white mb-2">ShowStack</h1>
           <p className="text-gray-400">Production Management Suite</p>
         </div>
 
-        <form onSubmit={handleLogin} className="space-y-4">
+        {error && (
+          <div className="mb-4 p-3 bg-red-900/30 border border-red-700 rounded text-red-300 text-sm">
+            {error}
+          </div>
+        )}
+
+        {resetSent && mode === 'reset' && (
+          <div className="mb-4 p-3 bg-green-900/30 border border-green-700 rounded text-green-300 text-sm">
+            Password reset email sent. Check your inbox.
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-4">
           <div>
             <label htmlFor="email" className="block text-sm font-medium text-gray-300 mb-2">
               Email
@@ -31,51 +65,88 @@ export function Login() {
               type="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              className="w-full px-4 py-2 bg-gray-700 border border-gray-600 rounded text-gray-900 dark:text-white focus:outline-none focus:border-blue-500"
+              className="w-full px-4 py-2 bg-gray-700 border border-gray-600 rounded text-white focus:outline-none focus:border-blue-500"
               placeholder="you@example.com"
               required
+              disabled={isLoading}
             />
           </div>
 
-          <div>
-            <label htmlFor="password" className="block text-sm font-medium text-gray-300 mb-2">
-              Password
-            </label>
-            <input
-              id="password"
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              className="w-full px-4 py-2 bg-gray-700 border border-gray-600 rounded text-gray-900 dark:text-white focus:outline-none focus:border-blue-500"
-              placeholder="••••••••"
-              required
-            />
-          </div>
+          {mode !== 'reset' && (
+            <div>
+              <label htmlFor="password" className="block text-sm font-medium text-gray-300 mb-2">
+                Password
+              </label>
+              <input
+                id="password"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="w-full px-4 py-2 bg-gray-700 border border-gray-600 rounded text-white focus:outline-none focus:border-blue-500"
+                placeholder="••••••••"
+                required
+                minLength={6}
+                disabled={isLoading}
+              />
+            </div>
+          )}
 
           <button
             type="submit"
-            className="w-full py-2 bg-blue-600 hover:bg-blue-700 rounded text-gray-900 dark:text-white font-medium transition"
+            disabled={isLoading}
+            className="w-full py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-800 disabled:cursor-not-allowed rounded text-white font-medium transition"
           >
-            Sign In
+            {isLoading
+              ? 'Please wait...'
+              : mode === 'login'
+                ? 'Sign In'
+                : mode === 'signup'
+                  ? 'Create Account'
+                  : 'Send Reset Link'}
           </button>
         </form>
 
+        {mode === 'login' && (
+          <div className="mt-4 text-center">
+            <button
+              onClick={() => switchMode('reset')}
+              className="text-sm text-blue-500 hover:text-blue-400"
+            >
+              Forgot password?
+            </button>
+          </div>
+        )}
+
         <div className="mt-6 text-center text-sm text-gray-400">
-          <p>
-            Don't have an account?{' '}
-            <a href="#" className="text-blue-500 hover:text-blue-400">
-              Sign up
-            </a>
-          </p>
+          {mode === 'login' ? (
+            <p>
+              Don&apos;t have an account?{' '}
+              <button
+                onClick={() => switchMode('signup')}
+                className="text-blue-500 hover:text-blue-400"
+              >
+                Sign up
+              </button>
+            </p>
+          ) : (
+            <p>
+              Already have an account?{' '}
+              <button
+                onClick={() => switchMode('login')}
+                className="text-blue-500 hover:text-blue-400"
+              >
+                Sign in
+              </button>
+            </p>
+          )}
         </div>
 
-        {/* Development bypass */}
         <div className="mt-8 pt-6 border-t border-gray-700 text-center">
           <button
             onClick={() => navigate('/modules')}
             className="text-sm text-gray-500 hover:text-gray-400"
           >
-            Skip login (development)
+            Continue without account
           </button>
         </div>
       </div>

--- a/apps/desktop/src/renderer/src/pages/Login.tsx
+++ b/apps/desktop/src/renderer/src/pages/Login.tsx
@@ -85,7 +85,7 @@ export function Login() {
                 className="w-full px-4 py-2 bg-gray-700 border border-gray-600 rounded text-white focus:outline-none focus:border-blue-500"
                 placeholder="••••••••"
                 required
-                minLength={6}
+                minLength={8}
                 disabled={isLoading}
               />
             </div>

--- a/apps/desktop/src/renderer/src/pages/Login.tsx
+++ b/apps/desktop/src/renderer/src/pages/Login.tsx
@@ -141,14 +141,16 @@ export function Login() {
           )}
         </div>
 
-        <div className="mt-8 pt-6 border-t border-gray-700 text-center">
-          <button
-            onClick={() => navigate('/modules')}
-            className="text-sm text-gray-500 hover:text-gray-400"
-          >
-            Continue without account
-          </button>
-        </div>
+        {mode !== 'reset' && (
+          <div className="mt-8 pt-6 border-t border-gray-700 text-center">
+            <button
+              onClick={() => navigate('/modules')}
+              className="text-sm text-gray-500 hover:text-gray-400"
+            >
+              Continue without account
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/desktop/src/renderer/src/store/authStore.ts
+++ b/apps/desktop/src/renderer/src/store/authStore.ts
@@ -26,6 +26,7 @@ export interface SyncStatus {
  */
 export interface LicenseStatus {
   status: 'active' | 'grace' | 'expired' | 'suspended' | 'maintenance_expired';
+  tier: 'professional' | 'student' | 'institutional' | 'demo' | null;
   message: string;
   canView: boolean;
   canEdit: boolean;
@@ -134,7 +135,18 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         ]);
         // Mark auth as prompted so first-launch prompt won't show again
         safeLocalStorage('showstack-auth-prompted', 'true');
-        set({ isLoading: false, showAuthModal: false, isFirstLaunchPrompt: false });
+        // Surface license verification failure to the user
+        if (result.licenseVerified === false) {
+          set({
+            isLoading: false,
+            showAuthModal: false,
+            isFirstLaunchPrompt: false,
+            error:
+              'Signed in, but no license found for this account. Some features may be limited.',
+          });
+        } else {
+          set({ isLoading: false, showAuthModal: false, isFirstLaunchPrompt: false });
+        }
         return true;
       } else {
         set({ isLoading: false, error: result.error || 'Sign in failed' });

--- a/apps/desktop/src/renderer/src/store/authStore.ts
+++ b/apps/desktop/src/renderer/src/store/authStore.ts
@@ -22,6 +22,20 @@ export interface SyncStatus {
 }
 
 /**
+ * License status from main process
+ */
+export interface LicenseStatus {
+  status: 'active' | 'grace' | 'expired' | 'suspended' | 'maintenance_expired';
+  message: string;
+  canView: boolean;
+  canEdit: boolean;
+  canSync: boolean;
+  warningLevel?: 'low' | 'medium' | 'high';
+  daysUntilExpiration?: number;
+  daysSinceVerification?: number;
+}
+
+/**
  * Auth state
  */
 export interface AuthState {
@@ -31,6 +45,10 @@ export interface AuthState {
   email: string | null;
   isLoading: boolean;
   error: string | null;
+
+  // License
+  hasLicense: boolean;
+  licenseStatus: LicenseStatus | null;
 
   // Sync status
   syncStatus: SyncStatus;
@@ -47,6 +65,8 @@ export interface AuthState {
   resetPassword: (email: string) => Promise<boolean>;
   refreshAuthState: () => Promise<void>;
   refreshSyncStatus: () => Promise<void>;
+  refreshLicenseStatus: () => Promise<void>;
+  activateLicense: (key: string) => Promise<{ success: boolean; error?: string }>;
   initializeSync: () => Promise<void>;
 
   // UI actions
@@ -73,6 +93,8 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   email: null,
   isLoading: false,
   error: null,
+  hasLicense: false,
+  licenseStatus: null,
   syncStatus: defaultSyncStatus,
   isCloudConfigured: false,
   showAuthModal: false,
@@ -88,6 +110,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       if (result.success) {
         // Refresh auth state after successful sign in
         await get().refreshAuthState();
+        await get().refreshLicenseStatus();
         await get().refreshSyncStatus();
         set({ isLoading: false, showAuthModal: false });
         return true;
@@ -194,6 +217,34 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       set({ syncStatus: status });
     } catch (error) {
       logger.error('[AuthStore] Failed to refresh sync status:', error);
+    }
+  },
+
+  // Refresh license status
+  refreshLicenseStatus: async () => {
+    try {
+      const status = await window.api.license.getStatus();
+      set({
+        licenseStatus: status,
+        hasLicense: status.status !== 'expired' || status.canView,
+      });
+    } catch (error) {
+      logger.error('[AuthStore] Failed to refresh license status:', error);
+    }
+  },
+
+  // Activate a license key
+  activateLicense: async (key: string) => {
+    try {
+      const result = await window.api.license.activate(key);
+      if (result.success) {
+        await get().refreshLicenseStatus();
+      }
+      return result;
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Activation failed';
+      logger.error('[AuthStore] Failed to activate license:', error);
+      return { success: false, error: errorMessage };
     }
   },
 

--- a/apps/desktop/src/renderer/src/store/authStore.ts
+++ b/apps/desktop/src/renderer/src/store/authStore.ts
@@ -81,7 +81,7 @@ export interface AuthState {
   clearError: () => void;
 }
 
-/** Safe localStorage wrapper — no-ops if storage is unavailable */
+/** Safe localStorage wrapper — logs warning if storage is unavailable */
 function safeLocalStorage(key: string, value?: string): string | null {
   try {
     if (value !== undefined) {
@@ -89,7 +89,10 @@ function safeLocalStorage(key: string, value?: string): string | null {
       return value;
     }
     return localStorage.getItem(key);
-  } catch {
+  } catch (e) {
+    logger.warn(`[AuthStore] localStorage unavailable for key "${key}"`, {
+      error: e instanceof Error ? e.message : String(e),
+    });
     return null;
   }
 }

--- a/apps/desktop/src/renderer/src/store/authStore.ts
+++ b/apps/desktop/src/renderer/src/store/authStore.ts
@@ -57,6 +57,7 @@ export interface AuthState {
   // UI state
   showAuthModal: boolean;
   authModalView: 'login' | 'signup' | 'reset';
+  isFirstLaunchPrompt: boolean;
 
   // Actions
   signIn: (email: string, password: string) => Promise<boolean>;
@@ -68,10 +69,14 @@ export interface AuthState {
   refreshLicenseStatus: () => Promise<void>;
   initializeSync: () => Promise<void>;
 
+  // Demo mode
+  activateDemoMode: () => Promise<void>;
+
   // UI actions
   openAuthModal: (view?: 'login' | 'signup' | 'reset') => void;
   closeAuthModal: () => void;
   setAuthModalView: (view: 'login' | 'signup' | 'reset') => void;
+  setFirstLaunchPrompt: (value: boolean) => void;
   clearError: () => void;
 }
 
@@ -98,6 +103,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   isCloudConfigured: false,
   showAuthModal: false,
   authModalView: 'login',
+  isFirstLaunchPrompt: false,
 
   // Sign in
   signIn: async (email: string, password: string) => {
@@ -111,7 +117,9 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         await get().refreshAuthState();
         await get().refreshLicenseStatus();
         await get().refreshSyncStatus();
-        set({ isLoading: false, showAuthModal: false });
+        // Mark auth as prompted so first-launch prompt won't show again
+        localStorage.setItem('showstack-auth-prompted', 'true');
+        set({ isLoading: false, showAuthModal: false, isFirstLaunchPrompt: false });
         return true;
       } else {
         set({ isLoading: false, error: result.error || 'Sign in failed' });
@@ -265,17 +273,34 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     }
   },
 
+  // Demo mode
+  activateDemoMode: async () => {
+    try {
+      await window.api.license.createDemo();
+      await get().refreshLicenseStatus();
+      set({ isFirstLaunchPrompt: false, showAuthModal: false });
+    } catch (error) {
+      logger.error('[AuthStore] Failed to activate demo mode', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  },
+
   // UI actions
   openAuthModal: (view = 'login') => {
     set({ showAuthModal: true, authModalView: view, error: null });
   },
 
   closeAuthModal: () => {
-    set({ showAuthModal: false, error: null });
+    set({ showAuthModal: false, error: null, isFirstLaunchPrompt: false });
   },
 
   setAuthModalView: (view) => {
     set({ authModalView: view, error: null });
+  },
+
+  setFirstLaunchPrompt: (value) => {
+    set({ isFirstLaunchPrompt: value });
   },
 
   clearError: () => {

--- a/apps/desktop/src/renderer/src/store/authStore.ts
+++ b/apps/desktop/src/renderer/src/store/authStore.ts
@@ -121,6 +121,14 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 
   // Sign in
   signIn: async (email: string, password: string) => {
+    if (!email?.trim()) {
+      set({ error: 'Email is required' });
+      return false;
+    }
+    if (password.length < 8) {
+      set({ error: 'Password must be at least 8 characters' });
+      return false;
+    }
     set({ isLoading: true, error: null });
 
     try {
@@ -163,6 +171,14 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 
   // Sign up
   signUp: async (email: string, password: string) => {
+    if (!email?.trim()) {
+      set({ error: 'Email is required' });
+      return false;
+    }
+    if (password.length < 8) {
+      set({ error: 'Password must be at least 8 characters' });
+      return false;
+    }
     set({ isLoading: true, error: null });
 
     try {

--- a/apps/desktop/src/renderer/src/store/authStore.ts
+++ b/apps/desktop/src/renderer/src/store/authStore.ts
@@ -113,10 +113,12 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       const result = await window.api.auth.signIn(email, password);
 
       if (result.success) {
-        // Refresh auth state after successful sign in
-        await get().refreshAuthState();
-        await get().refreshLicenseStatus();
-        await get().refreshSyncStatus();
+        // Refresh all state in parallel to avoid sequential re-renders
+        await Promise.all([
+          get().refreshAuthState(),
+          get().refreshLicenseStatus(),
+          get().refreshSyncStatus(),
+        ]);
         // Mark auth as prompted so first-launch prompt won't show again
         localStorage.setItem('showstack-auth-prompted', 'true');
         set({ isLoading: false, showAuthModal: false, isFirstLaunchPrompt: false });

--- a/apps/desktop/src/renderer/src/store/authStore.ts
+++ b/apps/desktop/src/renderer/src/store/authStore.ts
@@ -252,6 +252,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 
       // Refresh states
       await get().refreshAuthState();
+      await get().refreshLicenseStatus();
       await get().refreshSyncStatus();
 
       // Subscribe to status changes

--- a/apps/desktop/src/renderer/src/store/authStore.ts
+++ b/apps/desktop/src/renderer/src/store/authStore.ts
@@ -80,6 +80,19 @@ export interface AuthState {
   clearError: () => void;
 }
 
+/** Safe localStorage wrapper — no-ops if storage is unavailable */
+function safeLocalStorage(key: string, value?: string): string | null {
+  try {
+    if (value !== undefined) {
+      localStorage.setItem(key, value);
+      return value;
+    }
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
 const defaultSyncStatus: SyncStatus = {
   state: 'disconnected',
   connected: false,
@@ -120,7 +133,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
           get().refreshSyncStatus(),
         ]);
         // Mark auth as prompted so first-launch prompt won't show again
-        localStorage.setItem('showstack-auth-prompted', 'true');
+        safeLocalStorage('showstack-auth-prompted', 'true');
         set({ isLoading: false, showAuthModal: false, isFirstLaunchPrompt: false });
         return true;
       } else {

--- a/apps/desktop/src/renderer/src/store/authStore.ts
+++ b/apps/desktop/src/renderer/src/store/authStore.ts
@@ -66,7 +66,6 @@ export interface AuthState {
   refreshAuthState: () => Promise<void>;
   refreshSyncStatus: () => Promise<void>;
   refreshLicenseStatus: () => Promise<void>;
-  activateLicense: (key: string) => Promise<{ success: boolean; error?: string }>;
   initializeSync: () => Promise<void>;
 
   // UI actions
@@ -230,21 +229,6 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       });
     } catch (error) {
       logger.error('[AuthStore] Failed to refresh license status:', error);
-    }
-  },
-
-  // Activate a license key
-  activateLicense: async (key: string) => {
-    try {
-      const result = await window.api.license.activate(key);
-      if (result.success) {
-        await get().refreshLicenseStatus();
-      }
-      return result;
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Activation failed';
-      logger.error('[AuthStore] Failed to activate license:', error);
-      return { success: false, error: errorMessage };
     }
   },
 

--- a/apps/desktop/src/renderer/src/utils/recentFiles.ts
+++ b/apps/desktop/src/renderer/src/utils/recentFiles.ts
@@ -8,7 +8,7 @@ export interface RecentFile {
   moduleType?: string; // production, manager, design
 }
 
-type ModuleType = 'production' | 'manager' | 'design';
+type ModuleType = 'lighting' | 'sound' | 'video' | 'production_management' | 'touring' | 'producer';
 
 const RECENT_FILES_KEY_PREFIX = 'showstack_recentFiles';
 const MAX_RECENT_FILES = 10;
@@ -104,9 +104,12 @@ export async function clearRecentFiles(moduleType?: ModuleType): Promise<void> {
       localStorage.removeItem(storageKey);
     } else {
       // Clear all module-specific keys
-      localStorage.removeItem(getStorageKey('production'));
-      localStorage.removeItem(getStorageKey('manager'));
-      localStorage.removeItem(getStorageKey('design'));
+      localStorage.removeItem(getStorageKey('lighting'));
+      localStorage.removeItem(getStorageKey('sound'));
+      localStorage.removeItem(getStorageKey('video'));
+      localStorage.removeItem(getStorageKey('production_management'));
+      localStorage.removeItem(getStorageKey('touring'));
+      localStorage.removeItem(getStorageKey('producer'));
       localStorage.removeItem(RECENT_FILES_KEY_PREFIX); // Legacy key
     }
   } catch (error) {
@@ -122,9 +125,9 @@ export function getModuleTypeFromPath(filePath: string): ModuleType | undefined 
   if (filePath.endsWith('.ss')) return undefined;
 
   // Legacy formats
-  if (filePath.endsWith('.ssp')) return 'production';
-  if (filePath.endsWith('.ssm')) return 'manager';
-  if (filePath.endsWith('.ssd')) return 'design';
+  if (filePath.endsWith('.ssp')) return 'lighting';
+  if (filePath.endsWith('.ssm')) return 'production_management';
+  if (filePath.endsWith('.ssd')) return 'lighting';
   return undefined;
 }
 

--- a/apps/desktop/src/shared/types/license.types.ts
+++ b/apps/desktop/src/shared/types/license.types.ts
@@ -6,10 +6,12 @@
  */
 
 export type ShowStackModule =
-  | 'prep' // ShowStack:Prep (Shop Order Builder - current product)
-  | 'production' // ShowStack:Lighting (LightWright competitor)
-  | 'manager' // ShowStack:Manager (Production/Tour management)
-  | 'student'; // ShowStack:Student (Educational version)
+  | 'lighting' // ShowStack:Lighting (fixture management & paperwork)
+  | 'sound' // ShowStack:Sound (audio system design)
+  | 'video' // ShowStack:Video (video/projection planning)
+  | 'production_management' // ShowStack:Production Management (scheduling & logistics)
+  | 'touring' // ShowStack:Touring (tour management & per diems)
+  | 'producer'; // ShowStack:Producer (budgeting & financial tracking)
 
 export type LicenseTier =
   | 'professional' // Full access, all features
@@ -49,35 +51,6 @@ export interface ModuleFeatures {
   advancedExport: boolean;
   cloudSync: boolean;
   prioritySupport: boolean;
-
-  // Module-specific features
-  prepFeatures?: PrepModuleFeatures;
-  productionFeatures?: ProductionModuleFeatures;
-  managerFeatures?: ManagerModuleFeatures;
-}
-
-export interface PrepModuleFeatures {
-  maxProjects: number; // -1 for unlimited, 3 for student
-  logoIntegration: boolean;
-  vendorTemplates: boolean;
-  equipmentDatabase: boolean;
-  bulkOperations: boolean;
-}
-
-export interface ProductionModuleFeatures {
-  vectorworksIntegration: boolean;
-  etcEosIntegration: boolean;
-  paperworkGeneration: boolean;
-  labelSystem: boolean;
-  powerManagement: boolean;
-}
-
-export interface ManagerModuleFeatures {
-  plaidIntegration: boolean; // Financial tracking
-  multiShowManagement: boolean;
-  budgetTracking: boolean;
-  perDiemCalculation: boolean;
-  tourLogistics: boolean;
 }
 
 export interface LicenseValidation {

--- a/apps/desktop/src/shared/types/license.types.ts
+++ b/apps/desktop/src/shared/types/license.types.ts
@@ -27,6 +27,7 @@ export interface UserLicense {
   tier: LicenseTier;
   status: 'active' | 'expired' | 'suspended';
   userId?: string;
+  cloudSync: boolean; // Whether cloud sync is enabled for this license (Supabase flag)
 
   // Module access control
   modules: ModuleAccess[];
@@ -57,6 +58,7 @@ export interface ModuleFeatures {
 
 export interface LicenseValidation {
   status: 'active' | 'grace' | 'expired' | 'suspended' | 'maintenance_expired';
+  tier: LicenseTier | null; // Current license tier, null if no license
   message: string;
   canView: boolean;
   canEdit: boolean;

--- a/apps/desktop/src/shared/types/license.types.ts
+++ b/apps/desktop/src/shared/types/license.types.ts
@@ -16,7 +16,8 @@ export type ShowStackModule =
 export type LicenseTier =
   | 'professional' // Full access, all features
   | 'student' // Limited features, educational pricing
-  | 'institutional'; // Multi-seat, institutional pricing
+  | 'institutional' // Multi-seat, institutional pricing
+  | 'demo'; // Demo mode — restricted local-only access
 
 export interface UserLicense {
   id: string;
@@ -47,6 +48,7 @@ export interface ModuleAccess {
 export interface ModuleFeatures {
   // Universal features (apply to all modules)
   maxRevisions: number;
+  maxFixtures: number; // -1 = unlimited
   multiDiscipline: boolean;
   advancedExport: boolean;
   cloudSync: boolean;

--- a/apps/desktop/src/shared/types/license.types.ts
+++ b/apps/desktop/src/shared/types/license.types.ts
@@ -23,11 +23,13 @@ export interface UserLicense {
   licenseKey: string;
   tier: LicenseTier;
   status: 'active' | 'expired' | 'suspended';
+  userId?: string;
 
   // Module access control
   modules: ModuleAccess[];
 
-  expirationDate: number; // Unix timestamp
+  expirationDate: number; // Unix timestamp (legacy, maps to maintenanceEndDate)
+  maintenanceEndDate: number; // Unix timestamp — perpetual fallback pivot date
   lastVerified: number; // Unix timestamp
   createdAt: number; // Unix timestamp
   updatedAt: number; // Unix timestamp
@@ -79,10 +81,11 @@ export interface ManagerModuleFeatures {
 }
 
 export interface LicenseValidation {
-  status: 'active' | 'grace' | 'expired' | 'suspended';
+  status: 'active' | 'grace' | 'expired' | 'suspended' | 'maintenance_expired';
   message: string;
   canView: boolean;
   canEdit: boolean;
+  canSync: boolean;
   warningLevel?: 'low' | 'medium' | 'high';
   daysUntilExpiration?: number;
   daysSinceVerification?: number;

--- a/docs/features/POST_REFACTOR_ROADMAP.md
+++ b/docs/features/POST_REFACTOR_ROADMAP.md
@@ -165,12 +165,14 @@ autoUpdater.on('update-available', (info) => {
 
 ### Phase 2: The Gateway (Supabase)
 
-- [ ] Create `public.licenses` table in Supabase.
+- [x] Create `public.licenses` table in Supabase.
 - [ ] Deploy `purchase-webhook` Edge Function.
 - [ ] Connect Stripe/Shopify webhooks to the function URL.
 
 ### Phase 3: The Client Logic (Electron)
 
-- [ ] Update `LicenseService` to check dates, not version numbers.
+- [x] Update `LicenseService` to check dates, not version numbers.
 - [ ] Implement `UpdateService` to gate downloads based on maintenance expiry.
 - [ ] Verify the "Offline Fallback" works by setting your system clock forward 2 years.
+
+**Status Update (February 2026):** LicenseService now implements perpetual fallback licensing with `APP_BUILD_DATE` vs `maintenanceEndDate` comparison. Supabase Auth replaces the "Dual Activation" flow — users sign in with email/password and licenses are auto-claimed by email. Demo mode provides restricted access for unauthenticated users. The e-commerce webhook (Phase 2) and auto-updater gate (Phase 4) are still pending.

--- a/docs/supabase/migrations/001_licenses.sql
+++ b/docs/supabase/migrations/001_licenses.sql
@@ -1,0 +1,54 @@
+-- ShowStack Licenses Table
+-- Run via Supabase SQL editor or as a migration
+
+CREATE TABLE public.licenses (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  license_key TEXT UNIQUE NOT NULL,
+  user_id UUID REFERENCES auth.users(id),
+  email TEXT NOT NULL,
+  tier TEXT NOT NULL CHECK(tier IN ('professional', 'student', 'institutional')),
+  modules JSONB NOT NULL DEFAULT '[]',
+  maintenance_end_date TIMESTAMPTZ NOT NULL,
+  status TEXT NOT NULL DEFAULT 'active' CHECK(status IN ('active', 'suspended', 'revoked')),
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+ALTER TABLE public.licenses ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can read own licenses"
+  ON public.licenses FOR SELECT USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can claim unclaimed licenses"
+  ON public.licenses FOR UPDATE
+  USING (user_id IS NULL)
+  WITH CHECK (auth.uid() = user_id);
+
+-- RPC function for license activation
+CREATE OR REPLACE FUNCTION public.activate_license(p_license_key TEXT)
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE v_license RECORD;
+BEGIN
+  SELECT * INTO v_license FROM public.licenses
+  WHERE license_key = p_license_key AND status = 'active' FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Invalid or inactive license key');
+  END IF;
+
+  IF v_license.user_id IS NOT NULL AND v_license.user_id != auth.uid() THEN
+    RETURN jsonb_build_object('success', false, 'error', 'License already claimed by another account');
+  END IF;
+
+  UPDATE public.licenses
+  SET user_id = auth.uid(),
+      email = (SELECT email FROM auth.users WHERE id = auth.uid()),
+      updated_at = NOW()
+  WHERE id = v_license.id;
+
+  RETURN jsonb_build_object('success', true, 'license', jsonb_build_object(
+    'id', v_license.id, 'licenseKey', v_license.license_key,
+    'tier', v_license.tier, 'modules', v_license.modules,
+    'maintenanceEndDate', v_license.maintenance_end_date, 'status', v_license.status
+  ));
+END; $$;

--- a/docs/supabase/migrations/001_licenses.sql
+++ b/docs/supabase/migrations/001_licenses.sql
@@ -3,7 +3,7 @@
 
 CREATE TABLE public.licenses (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  license_key TEXT UNIQUE NOT NULL,
+  license_key TEXT UNIQUE NOT NULL DEFAULT gen_random_uuid()::text,
   user_id UUID REFERENCES auth.users(id),
   email TEXT NOT NULL,
   tier TEXT NOT NULL CHECK(tier IN ('professional', 'student', 'institutional')),
@@ -16,33 +16,52 @@ CREATE TABLE public.licenses (
 
 ALTER TABLE public.licenses ENABLE ROW LEVEL SECURITY;
 
+-- Users can read licenses already claimed by them (user_id set)
 CREATE POLICY "Users can read own licenses"
   ON public.licenses FOR SELECT USING (auth.uid() = user_id);
 
+-- Users can read unclaimed licenses matching their email (for auto-claim window)
+CREATE POLICY "Users can read licenses matching their email"
+  ON public.licenses FOR SELECT USING (
+    user_id IS NULL
+    AND email = (SELECT email FROM auth.users WHERE id = auth.uid())
+  );
+
+-- Users can claim unclaimed licenses (set user_id to their own)
 CREATE POLICY "Users can claim unclaimed licenses"
   ON public.licenses FOR UPDATE
   USING (user_id IS NULL)
   WITH CHECK (auth.uid() = user_id);
 
--- RPC function for license activation
-CREATE OR REPLACE FUNCTION public.activate_license(p_license_key TEXT)
+-- RPC function for email-based license claiming
+-- Called on sign-in: finds an unclaimed license matching the user's email and claims it
+CREATE OR REPLACE FUNCTION public.claim_license_by_email()
 RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $$
-DECLARE v_license RECORD;
+DECLARE
+  v_license RECORD;
+  v_user_email TEXT;
 BEGIN
+  -- Get current user's email
+  SELECT email INTO v_user_email FROM auth.users WHERE id = auth.uid();
+
+  IF v_user_email IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Unable to determine user email');
+  END IF;
+
+  -- Find an unclaimed license matching this email
   SELECT * INTO v_license FROM public.licenses
-  WHERE license_key = p_license_key AND status = 'active' FOR UPDATE;
+  WHERE email = v_user_email AND user_id IS NULL AND status = 'active'
+  ORDER BY created_at ASC
+  LIMIT 1
+  FOR UPDATE;
 
   IF NOT FOUND THEN
-    RETURN jsonb_build_object('success', false, 'error', 'Invalid or inactive license key');
+    RETURN jsonb_build_object('success', false, 'error', 'No unclaimed license found for this email');
   END IF;
 
-  IF v_license.user_id IS NOT NULL AND v_license.user_id != auth.uid() THEN
-    RETURN jsonb_build_object('success', false, 'error', 'License already claimed by another account');
-  END IF;
-
+  -- Claim the license
   UPDATE public.licenses
   SET user_id = auth.uid(),
-      email = (SELECT email FROM auth.users WHERE id = auth.uid()),
       updated_at = NOW()
   WHERE id = v_license.id;
 

--- a/docs/supabase/migrations/001_licenses.sql
+++ b/docs/supabase/migrations/001_licenses.sql
@@ -32,10 +32,13 @@ CREATE POLICY "Users can read licenses matching their email"
     AND email = (SELECT email FROM auth.users WHERE id = auth.uid())
   );
 
--- Users can claim unclaimed licenses (set user_id to their own)
+-- Users can claim unclaimed licenses matching their verified email
 CREATE POLICY "Users can claim unclaimed licenses"
   ON public.licenses FOR UPDATE
-  USING (user_id IS NULL)
+  USING (
+    user_id IS NULL
+    AND email = (SELECT email FROM auth.users WHERE id = auth.uid())
+  )
   WITH CHECK (auth.uid() = user_id);
 
 -- Audit table for license claim events

--- a/docs/supabase/migrations/001_licenses.sql
+++ b/docs/supabase/migrations/001_licenses.sql
@@ -14,6 +14,11 @@ CREATE TABLE public.licenses (
   updated_at TIMESTAMPTZ DEFAULT NOW()
 );
 
+-- Indexes for common lookup patterns
+CREATE INDEX idx_licenses_user_id ON public.licenses(user_id) WHERE user_id IS NOT NULL;
+CREATE INDEX idx_licenses_email ON public.licenses(email);
+CREATE INDEX idx_licenses_email_unclaimed ON public.licenses(email) WHERE user_id IS NULL AND status = 'active';
+
 ALTER TABLE public.licenses ENABLE ROW LEVEL SECURITY;
 
 -- Users can read licenses already claimed by them (user_id set)
@@ -33,19 +38,50 @@ CREATE POLICY "Users can claim unclaimed licenses"
   USING (user_id IS NULL)
   WITH CHECK (auth.uid() = user_id);
 
+-- Audit table for license claim events
+CREATE TABLE IF NOT EXISTS public.license_audit_log (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  license_id UUID REFERENCES public.licenses(id),
+  user_id UUID NOT NULL,
+  user_email TEXT NOT NULL,
+  action TEXT NOT NULL,
+  details JSONB DEFAULT '{}',
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+ALTER TABLE public.license_audit_log ENABLE ROW LEVEL SECURITY;
+
+-- Only service role can read audit logs (no user access)
+-- Admins access via Supabase dashboard
+
 -- RPC function for email-based license claiming
 -- Called on sign-in: finds an unclaimed license matching the user's email and claims it
+-- Uses SECURITY DEFINER to bypass RLS for the atomic claim operation.
+-- Safety: auth.uid() ensures only the authenticated user's email is used,
+-- and the function only claims licenses matching that exact email.
 CREATE OR REPLACE FUNCTION public.claim_license_by_email()
 RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $$
 DECLARE
   v_license RECORD;
   v_user_email TEXT;
+  v_user_id UUID;
 BEGIN
+  -- Verify caller is authenticated
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Not authenticated');
+  END IF;
+
   -- Get current user's email
-  SELECT email INTO v_user_email FROM auth.users WHERE id = auth.uid();
+  SELECT email INTO v_user_email FROM auth.users WHERE id = v_user_id;
 
   IF v_user_email IS NULL THEN
     RETURN jsonb_build_object('success', false, 'error', 'Unable to determine user email');
+  END IF;
+
+  -- Check if user already has a claimed license (prevent double-claiming)
+  IF EXISTS (SELECT 1 FROM public.licenses WHERE user_id = v_user_id AND status = 'active') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'User already has an active license');
   END IF;
 
   -- Find an unclaimed license matching this email
@@ -61,9 +97,16 @@ BEGIN
 
   -- Claim the license
   UPDATE public.licenses
-  SET user_id = auth.uid(),
+  SET user_id = v_user_id,
       updated_at = NOW()
   WHERE id = v_license.id;
+
+  -- Audit log
+  INSERT INTO public.license_audit_log (license_id, user_id, user_email, action, details)
+  VALUES (v_license.id, v_user_id, v_user_email, 'claim_by_email', jsonb_build_object(
+    'tier', v_license.tier,
+    'license_key', v_license.license_key
+  ));
 
   RETURN jsonb_build_object('success', true, 'license', jsonb_build_object(
     'id', v_license.id, 'licenseKey', v_license.license_key,

--- a/docs/supabase/migrations/001_licenses.sql
+++ b/docs/supabase/migrations/001_licenses.sql
@@ -6,6 +6,7 @@ CREATE TABLE public.licenses (
   license_key TEXT UNIQUE NOT NULL DEFAULT gen_random_uuid()::text,
   user_id UUID REFERENCES auth.users(id),
   email TEXT NOT NULL,
+  name TEXT,
   tier TEXT NOT NULL CHECK(tier IN ('professional', 'student', 'institutional')),
   modules JSONB NOT NULL DEFAULT '[]',
   maintenance_end_date TIMESTAMPTZ NOT NULL,

--- a/docs/supabase/migrations/002_add_cloud_sync.sql
+++ b/docs/supabase/migrations/002_add_cloud_sync.sql
@@ -1,3 +1,0 @@
--- Add cloud_sync flag to licenses table
--- Run this in Supabase SQL editor
-ALTER TABLE licenses ADD COLUMN cloud_sync BOOLEAN DEFAULT false;

--- a/docs/supabase/migrations/002_add_cloud_sync.sql
+++ b/docs/supabase/migrations/002_add_cloud_sync.sql
@@ -1,0 +1,3 @@
+-- Add cloud_sync flag to licenses table
+-- Run this in Supabase SQL editor
+ALTER TABLE licenses ADD COLUMN cloud_sync BOOLEAN DEFAULT false;

--- a/docs/supabase/migrations/002_add_cloud_sync_and_name.sql
+++ b/docs/supabase/migrations/002_add_cloud_sync_and_name.sql
@@ -1,0 +1,11 @@
+-- Add cloud_sync flag and name column to licenses table
+-- Run this in Supabase SQL editor (for deployments using 001_licenses.sql without these columns)
+--
+-- cloud_sync: controls whether this license is allowed to use PowerSync cloud sync.
+--   Set to true by admin when granting cloud access (professional/institutional tiers).
+--   Checked by the client in LicenseService when determining canSync status.
+--
+-- name: user display name, populated from Supabase auth profile on license claim.
+
+ALTER TABLE licenses ADD COLUMN IF NOT EXISTS cloud_sync BOOLEAN DEFAULT false;
+ALTER TABLE licenses ADD COLUMN IF NOT EXISTS name TEXT;

--- a/docs/user/LICENSING_SYSTEM_README.md
+++ b/docs/user/LICENSING_SYSTEM_README.md
@@ -19,7 +19,8 @@ The licensing system provides:
 
 - **Offline-First**: 14-day grace period, non-blocking verification
 - **Module-Based**: Lighting, Sound, Video, Production Management, Touring, Producer modules
-- **Tier-Based Features**: Professional, Student, Institutional tiers
+- **Tier-Based Features**: Professional, Student, Institutional, Demo tiers
+- **Demo Mode**: Restricted local-only access for unauthenticated users
 - **Graceful Degradation**: Read-only mode on expiration (not lockout)
 - **Smart Warnings**: 7-day expiration alerts
 
@@ -33,7 +34,7 @@ The licensing system is integrated into the main ShowStack application. To ensur
    npm install lucide-react
    ```
 
-2. **Database is auto-initialized** on first run (sql.js)
+2. **Database is auto-initialized** on first run (better-sqlite3)
 
 3. **No additional setup required** - the system is ready to use!
 
@@ -289,13 +290,14 @@ function SoundModule() {
 
 ### Universal Features
 
-| Feature          | Professional | Student | Institutional |
-| ---------------- | ------------ | ------- | ------------- |
-| Max Revisions    | 5            | 2       | 3             |
-| Multi-Discipline | Yes          | No      | Yes           |
-| Advanced Export  | Yes          | No      | Yes           |
-| Cloud Sync       | Yes          | No      | Yes           |
-| Priority Support | Yes          | No      | Yes           |
+| Feature          | Professional | Student | Institutional | Demo |
+| ---------------- | ------------ | ------- | ------------- | ---- |
+| Max Revisions    | 5            | 2       | 3             | 0    |
+| Max Fixtures     | Unlimited    | 100     | Unlimited     | 25   |
+| Multi-Discipline | Yes          | No      | Yes           | No   |
+| Advanced Export  | Yes          | No      | Yes           | No   |
+| Cloud Sync       | Yes          | No      | Yes           | No   |
+| Priority Support | Yes          | No      | Yes           | No   |
 
 ### Modules
 
@@ -318,6 +320,7 @@ To test different license states during development:
 2. **Expired License**: Set `maintenanceEndDate` to past date
 3. **Offline Mode**: Set `lastVerified` to 15+ days ago
 4. **Approaching Expiration**: Set `maintenanceEndDate` to 5 days from now
+5. **Demo Mode**: Call `licenseService.createDemoLicense()` or use the "Continue in Demo Mode" button on first launch
 
 ### Adding New Features
 
@@ -341,6 +344,7 @@ The license verification endpoint should return:
       "enabled": true,
       "features": {
         "maxRevisions": 5,
+        "maxFixtures": -1,
         "multiDiscipline": true,
         "advancedExport": true,
         "cloudSync": true,

--- a/docs/user/LICENSING_SYSTEM_README.md
+++ b/docs/user/LICENSING_SYSTEM_README.md
@@ -2,7 +2,7 @@
 
 Complete module-based licensing system for ShowStack with offline-first validation, tier-based feature differentiation, and graceful degradation.
 
-## 📋 Table of Contents
+## Table of Contents
 
 - [Overview](#overview)
 - [Installation](#installation)
@@ -18,7 +18,7 @@ Complete module-based licensing system for ShowStack with offline-first validati
 The licensing system provides:
 
 - **Offline-First**: 14-day grace period, non-blocking verification
-- **Module-Based**: Prep, Production, Manager, Student modules
+- **Module-Based**: Lighting, Sound, Video, Production Management, Touring, Producer modules
 - **Tier-Based Features**: Professional, Student, Institutional tiers
 - **Graceful Degradation**: Read-only mode on expiration (not lockout)
 - **Smart Warnings**: 7-day expiration alerts
@@ -63,13 +63,13 @@ function App() {
 import { useModuleAccess } from './hooks/useUser';
 import { UpgradePrompt } from './components/License/UpgradePrompt';
 
-function ProductionModule() {
-  const { hasAccess, loading } = useModuleAccess('production');
+function LightingModule() {
+  const { hasAccess, loading } = useModuleAccess('lighting');
 
   if (loading) return <div>Loading...</div>;
-  if (!hasAccess) return <UpgradePrompt module="production" />;
+  if (!hasAccess) return <UpgradePrompt module="lighting" />;
 
-  return <ProductionApp />;
+  return <LightingApp />;
 }
 ```
 
@@ -78,12 +78,12 @@ function ProductionModule() {
 ```tsx
 import { useFeature } from './hooks/useFeature';
 
-function EquipmentList() {
-  const { enabled } = useFeature('prep', 'bulkOperations');
+function ExportPanel() {
+  const { enabled } = useFeature('lighting', 'advancedExport');
 
   return (
     <div>
-      {enabled ? <BulkOperationsToolbar /> : <p>Bulk operations available in Professional plan</p>}
+      {enabled ? <AdvancedExportToolbar /> : <p>Advanced export available in Professional plan</p>}
     </div>
   );
 }
@@ -150,8 +150,8 @@ src/
 ### Data Flow
 
 ```
-1. App starts → Database initialized → Background verifier starts
-2. Renderer requests license status → IPC → LicenseService → Database
+1. App starts -> Database initialized -> Background verifier starts
+2. Renderer requests license status -> IPC -> LicenseService -> Database
 3. LicenseService checks:
    - Is license expired?
    - Is verification stale (>14 days offline)?
@@ -182,7 +182,7 @@ const { license, status, loading, activateLicense } = useUser();
 Check if user has access to a specific module.
 
 ```tsx
-const { hasAccess, features, loading } = useModuleAccess('prep');
+const { hasAccess, features, loading } = useModuleAccess('lighting');
 
 // hasAccess: boolean
 // features: ModuleFeatures | null
@@ -194,7 +194,7 @@ const { hasAccess, features, loading } = useModuleAccess('prep');
 Check if a specific feature is enabled.
 
 ```tsx
-const { enabled, loading } = useFeature('prep', 'bulkOperations');
+const { enabled, loading } = useFeature('lighting', 'advancedExport');
 
 // enabled: boolean
 // loading: boolean
@@ -243,94 +243,45 @@ Full account management UI with tabs.
 
 ## Usage Examples
 
-### Example 1: Gate Bulk Operations
+### Example 1: Gate Advanced Export
 
 ```tsx
-function EquipmentList() {
-  const { enabled } = useFeature('prep', 'bulkOperations');
+function ExportPanel() {
+  const { enabled } = useFeature('lighting', 'advancedExport');
 
   return (
     <div>
-      <EquipmentTable />
-      {enabled ? <BulkOperationsToolbar /> : <UpgradePrompt feature="Bulk Operations" />}
+      <BasicExport />
+      {enabled ? <AdvancedExportToolbar /> : <UpgradePrompt feature="Advanced Export" />}
     </div>
   );
 }
 ```
 
-### Example 2: Disable Logo Upload for Students
+### Example 2: Check Cloud Sync Access
 
 ```tsx
-function LogoUpload() {
-  const { enabled } = useFeature('prep', 'logoIntegration');
+function SyncButton() {
+  const { enabled } = useFeature('lighting', 'cloudSync');
 
   return (
-    <div>
-      <label>Company Logo</label>
-      <input
-        type="file"
-        disabled={!enabled}
-        className={!enabled ? 'opacity-50 cursor-not-allowed' : ''}
-      />
-      {!enabled && (
-        <p className="text-sm text-gray-500">Logo integration available in Professional plan</p>
-      )}
-    </div>
+    <button disabled={!enabled}>
+      {enabled ? 'Sync to Cloud' : 'Cloud Sync (Professional plan)'}
+    </button>
   );
 }
 ```
 
-### Example 3: Project Limits
+### Example 3: Module Access Gate
 
 ```tsx
-function ProjectCreation() {
-  const { features } = useModuleAccess('prep');
-  const [projectCount, setProjectCount] = useState(2);
+function SoundModule() {
+  const { hasAccess, loading } = useModuleAccess('sound');
 
-  const maxProjects = features?.prepFeatures?.maxProjects ?? 3;
-  const canCreate = maxProjects === -1 || projectCount < maxProjects;
+  if (loading) return <div>Loading...</div>;
+  if (!hasAccess) return <UpgradePrompt module="sound" />;
 
-  return (
-    <div>
-      <h2>
-        Projects ({projectCount}/{maxProjects === -1 ? '∞' : maxProjects})
-      </h2>
-      <button onClick={() => setProjectCount(projectCount + 1)} disabled={!canCreate}>
-        Create New Project
-      </button>
-      {!canCreate && <UpgradePrompt feature="Unlimited Projects" />}
-    </div>
-  );
-}
-```
-
-### Example 4: Conditional Integration Buttons
-
-```tsx
-function IntegrationButtons() {
-  const { features } = useModuleAccess('production');
-
-  return (
-    <div className="flex gap-2">
-      <button>Import CSV</button>
-
-      {features?.productionFeatures?.vectorworksIntegration && (
-        <button>Import from Vectorworks</button>
-      )}
-
-      {features?.productionFeatures?.etcEosIntegration && <button>Sync with ETC Eos</button>}
-
-      {!features?.productionFeatures?.vectorworksIntegration && (
-        <button
-          onClick={() => {
-            /* Show upgrade modal */
-          }}
-        >
-          🔒 Unlock Vectorworks
-        </button>
-      )}
-    </div>
-  );
+  return <SoundApp />;
 }
 ```
 
@@ -341,30 +292,21 @@ function IntegrationButtons() {
 | Feature          | Professional | Student | Institutional |
 | ---------------- | ------------ | ------- | ------------- |
 | Max Revisions    | 5            | 2       | 3             |
-| Multi-Discipline | ✅           | ❌      | ✅            |
-| Advanced Export  | ✅           | ❌      | ✅            |
-| Cloud Sync       | ✅           | ❌      | ✅            |
-| Priority Support | ✅           | ❌      | ✅            |
+| Multi-Discipline | Yes          | No      | Yes           |
+| Advanced Export  | Yes          | No      | Yes           |
+| Cloud Sync       | Yes          | No      | Yes           |
+| Priority Support | Yes          | No      | Yes           |
 
-### Production Module Features
+### Modules
 
-| Feature                 | Professional | Student | Institutional |
-| ----------------------- | ------------ | ------- | ------------- |
-| Vectorworks Integration | ✅           | ❌      | ✅            |
-| ETC Eos Integration     | ✅           | ❌      | ✅            |
-| Paperwork Generation    | ✅           | ✅      | ✅            |
-| Label System            | ✅           | ✅      | ✅            |
-| Power Management        | ✅           | ❌      | ✅            |
-
-### Manager Module Features
-
-| Feature               | Professional | Student | Institutional |
-| --------------------- | ------------ | ------- | ------------- |
-| Plaid Integration     | ✅           | ❌      | ❌            |
-| Multi-Show Management | ✅           | ✅      | ✅            |
-| Budget Tracking       | ✅           | ✅      | ✅            |
-| Per Diem Calculation  | ✅           | ❌      | ✅            |
-| Tour Logistics        | ✅           | ❌      | ✅            |
+| Module                | Description                    |
+| --------------------- | ------------------------------ |
+| Lighting              | Fixture management & paperwork |
+| Sound                 | Audio system design            |
+| Video                 | Video & projection planning    |
+| Production Management | Scheduling & logistics         |
+| Touring               | Tour management & per diems    |
+| Producer              | Budgeting & financial tracking |
 
 ## Development
 
@@ -373,13 +315,13 @@ function IntegrationButtons() {
 To test different license states during development:
 
 1. **No License**: Delete from database manually
-2. **Expired License**: Set `expirationDate` to past date
+2. **Expired License**: Set `maintenanceEndDate` to past date
 3. **Offline Mode**: Set `lastVerified` to 15+ days ago
-4. **Approaching Expiration**: Set `expirationDate` to 5 days from now
+4. **Approaching Expiration**: Set `maintenanceEndDate` to 5 days from now
 
 ### Adding New Features
 
-1. Add feature to appropriate `ModuleFeatures` interface in `license.types.ts`
+1. Add feature to `ModuleFeatures` interface in `license.types.ts`
 2. Update `getDefaultFeaturesForTier()` in `LicenseService.ts`
 3. Use `useFeature()` hook in components
 4. Update documentation
@@ -392,20 +334,24 @@ The license verification endpoint should return:
 {
   "status": "active",
   "tier": "professional",
-  "expirationDate": "2025-12-31T00:00:00Z",
+  "maintenance_end_date": "2026-12-31T00:00:00Z",
   "modules": [
     {
-      "module": "prep",
+      "module": "lighting",
       "enabled": true,
       "features": {
-        /* ... */
+        "maxRevisions": 5,
+        "multiDiscipline": true,
+        "advancedExport": true,
+        "cloudSync": true,
+        "prioritySupport": true
       }
     }
   ]
 }
 ```
 
-See `LicenseService.ts:verifyLicenseOnline()` for implementation details.
+See `LicenseService.ts:verifyLicenseViaSupabase()` for implementation details.
 
 ## Support
 
@@ -415,6 +361,6 @@ See `LicenseService.ts:verifyLicenseOnline()` for implementation details.
 
 ---
 
-**Version**: 1.0.0
-**Last Updated**: November 2025
+**Version**: 2.0.0
+**Last Updated**: February 2026
 **Author**: ShowStack Development Team


### PR DESCRIPTION
## Summary
- Supabase Auth integration (sign in, sign up, sign out, password reset)
- Email-based license auto-claim — no manual key entry needed
- Perpetual fallback licensing model with demo mode for unauthenticated users
- First-launch auth prompt with "Continue in Demo Mode" option
- Demo tier: 25 fixtures, no cloud sync, no PDF/Excel export, no revisions
- Account page shows auth status (signed in / demo / not signed in)
- `maxFixtures` feature limit per tier (demo: 25, student: 100, pro/institutional: unlimited)
- Updated PROJECT_STATUS.md, NEXT_STEPS.md, POST_REFACTOR_ROADMAP.md, LICENSING_SYSTEM_README.md
- Closed GitHub issues #34, #71, #72, #73

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run test:run` — 1,576 tests pass (56 files)
- [x] `npm run lint` — 0 new warnings (821 total, within CI threshold)
- [x] Manual: fresh launch → splash → auth prompt → "Continue in Demo Mode" → app loads with demo restrictions
- [ ] Manual: Account page shows "Demo Mode" badge with sign-in button
- [x] Manual: Sign in → license verified → demo replaced with real license

🤖 Generated with [Claude Code](https://claude.com/claude-code)