### PR TITLE
Pre-1.0 hardening: issues #62, #79, #81 + auth deep link flow

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -45,17 +45,55 @@ const MEMORY_MONITOR_INTERVAL_MS = 5 * 60 * 1000;
 // Set app name for macOS menu bar
 app.setName('ShowStack');
 
+// Register custom URL scheme for email verification callbacks.
+// Supabase redirects to showstack://auth/callback after email confirmation.
+// Must be called before app ready on macOS.
+if (process.defaultApp) {
+  // Dev: Electron is the default app, pass the app path as argv[1]
+  if (process.argv.length >= 2) {
+    app.setAsDefaultProtocolClient('showstack', process.execPath, [process.argv[1]]);
+  }
+} else {
+  app.setAsDefaultProtocolClient('showstack');
+}
+
+/**
+ * Forward a deep-link URL to the renderer so it can complete auth.
+ * The URL has the form: showstack://auth/callback#access_token=...&type=signup
+ */
+function handleDeepLink(url: string): void {
+  logger.info('Received deep link URL', { url });
+  const win = BrowserWindow.getAllWindows()[0];
+  if (win) {
+    win.webContents.send('auth:deepLink', url);
+  }
+}
+
 // Disable hardware acceleration on Linux
 if (process.platform === 'linux') {
   app.disableHardwareAcceleration();
 }
 
-// Single instance lock
+// Single instance lock — also receives deep links on Windows/Linux via argv
 const gotTheLock = app.requestSingleInstanceLock();
 if (!gotTheLock) {
   app.quit();
   process.exit(0);
 }
+
+// Windows/Linux: deep link arrives as argv when a second instance is launched
+app.on('second-instance', (_event, commandLine) => {
+  const url = commandLine.find((arg) => arg.startsWith('showstack://'));
+  if (url) {
+    handleDeepLink(url);
+  }
+  // Focus the existing window
+  const win = BrowserWindow.getAllWindows()[0];
+  if (win) {
+    if (win.isMinimized()) win.restore();
+    win.focus();
+  }
+});
 
 app.on('ready', async () => {
   try {
@@ -144,6 +182,12 @@ app.on('activate', () => {
   if (BrowserWindow.getAllWindows().length === 0) {
     windowManager.createLandingWindow();
   }
+});
+
+// macOS: deep link arrives as open-url event
+app.on('open-url', (event, url) => {
+  event.preventDefault();
+  handleDeepLink(url);
 });
 
 app.on('before-quit', async () => {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -163,6 +163,19 @@ app.on('ready', async () => {
   // Create landing window
   windowManager.createLandingWindow();
 
+  // Windows/Linux: on the very first launch via a showstack:// URL the URL
+  // arrives in process.argv (no second-instance fires). Send it to the
+  // renderer once the window finishes loading.
+  if (process.platform !== 'darwin') {
+    const deepLinkUrl = process.argv.find((arg) => arg.startsWith('showstack://'));
+    if (deepLinkUrl) {
+      const win = BrowserWindow.getAllWindows()[0];
+      if (win) {
+        win.webContents.once('did-finish-load', () => handleDeepLink(deepLinkUrl));
+      }
+    }
+  }
+
   // Start periodic performance monitoring
   setInterval(() => {
     performanceMonitor.trackMemoryUsage();

--- a/apps/desktop/src/main/ipc/license.ts
+++ b/apps/desktop/src/main/ipc/license.ts
@@ -7,6 +7,15 @@ import { errorHandler } from '../errors';
 import { logger } from '../utils/logger';
 
 /**
+ * Simple rate limiter for license:getStatus to prevent renderer hammering.
+ * Allows one call per interval; subsequent calls within the window return the
+ * cached result instead of hitting the database on every tick.
+ */
+const LICENSE_STATUS_RATE_LIMIT_MS = 2000; // 2 seconds
+let lastLicenseStatusCall = 0;
+let cachedLicenseStatus: unknown = null;
+
+/**
  * Register all license and settings IPC handlers
  */
 export function registerLicenseHandlers(): void {
@@ -15,14 +24,25 @@ export function registerLicenseHandlers(): void {
   // ============================================
 
   /**
-   * Get current license validation status
+   * Get current license validation status.
+   * Rate-limited to prevent renderer from hammering the database on every render.
    */
   ipcMain.handle('license:getStatus', async () => {
+    const now = Date.now();
+    if (
+      cachedLicenseStatus !== null &&
+      now - lastLicenseStatusCall < LICENSE_STATUS_RATE_LIMIT_MS
+    ) {
+      return cachedLicenseStatus;
+    }
     try {
-      return await errorHandler.executeWithRetry(
+      const result = await errorHandler.executeWithRetry(
         async () => licenseService.getLicenseStatus(),
         'license:getStatus',
       );
+      cachedLicenseStatus = result;
+      lastLicenseStatusCall = now;
+      return result;
     } catch (error) {
       logger.error('Failed to get license status:', {
         operation: 'license:getStatus',

--- a/apps/desktop/src/main/ipc/sync.ts
+++ b/apps/desktop/src/main/ipc/sync.ts
@@ -204,46 +204,39 @@ export function registerSyncHandlers(): void {
     }
 
     try {
-      // Parse both query string and hash fragment from the URL
-      const questionIndex = url.indexOf('?');
-      const hashIndex = url.indexOf('#');
+      const parsedUrl = new URL(url);
+      const queryParams = parsedUrl.searchParams;
+      const hashParams = new URLSearchParams(parsedUrl.hash.substring(1));
 
       // token_hash flows use query params (?token_hash=...&type=recovery|invite)
-      if (questionIndex !== -1) {
-        const queryString =
-          hashIndex !== -1 ? url.slice(questionIndex + 1, hashIndex) : url.slice(questionIndex + 1);
-        const params = new URLSearchParams(queryString);
-        const tokenHash = params.get('token_hash');
-        const type = params.get('type') as 'recovery' | 'invite' | null;
+      const tokenHash = queryParams.get('token_hash');
+      const tokenType = queryParams.get('type') as 'recovery' | 'invite' | null;
 
-        if (tokenHash && (type === 'recovery' || type === 'invite')) {
-          const connector = getSupabaseConnector();
-          const { error } = await connector.getClient().auth.verifyOtp({
-            token_hash: tokenHash,
-            type,
-          });
+      if (tokenHash && (tokenType === 'recovery' || tokenType === 'invite')) {
+        const connector = getSupabaseConnector();
+        const { error } = await connector.getClient().auth.verifyOtp({
+          token_hash: tokenHash,
+          type: tokenType,
+        });
 
-          if (error) {
-            return { success: false, error: error.message };
-          }
-
-          // User is authenticated but must set a password before proceeding
-          return { success: true, type };
+        if (error) {
+          return { success: false, error: error.message };
         }
+
+        // User is authenticated but must set a password before proceeding
+        return { success: true, type: tokenType };
       }
 
       // access_token flows use hash fragment (#access_token=...&refresh_token=...&type=signup|invite|recovery)
       // This is the format Supabase produces when {{ .ConfirmationURL }} is used in email templates.
-      if (hashIndex !== -1) {
-        const params = new URLSearchParams(url.slice(hashIndex + 1));
-        const accessToken = params.get('access_token');
-        const refreshToken = params.get('refresh_token');
-        const type = (params.get('type') ?? 'signup') as 'signup' | 'invite' | 'recovery';
+      const accessToken = hashParams.get('access_token');
+      const refreshToken = hashParams.get('refresh_token');
 
-        if (!accessToken || !refreshToken) {
-          return { success: false, error: 'Missing access_token or refresh_token in URL' };
-        }
-
+      if (accessToken && refreshToken) {
+        const sessionType = (hashParams.get('type') ?? 'signup') as
+          | 'signup'
+          | 'invite'
+          | 'recovery';
         const connector = getSupabaseConnector();
         const { data, error } = await connector.getClient().auth.setSession({
           access_token: accessToken,
@@ -256,7 +249,7 @@ export function registerSyncHandlers(): void {
 
         // For invite and recovery, the user is authenticated but must set a password.
         // The renderer will show SetPasswordForm when type is not 'signup'.
-        return { success: true, type, hasSession: !!data.session };
+        return { success: true, type: sessionType, hasSession: !!data.session };
       }
 
       return { success: false, error: 'No recognisable token in URL' };

--- a/apps/desktop/src/main/ipc/sync.ts
+++ b/apps/desktop/src/main/ipc/sync.ts
@@ -185,6 +185,49 @@ export function registerSyncHandlers(): void {
   });
 
   /**
+   * Exchange deep-link tokens for a Supabase session.
+   * Called by the renderer after receiving an auth:deepLink event (email verification callback).
+   * The URL has the form: showstack://auth/callback#access_token=...&refresh_token=...&type=signup
+   */
+  ipcMain.handle('auth:exchangeDeepLink', async (_, url: string) => {
+    if (!url || typeof url !== 'string') {
+      return { success: false, error: 'Invalid URL' };
+    }
+
+    try {
+      const hashIndex = url.indexOf('#');
+      if (hashIndex === -1) {
+        return { success: false, error: 'No token fragment in URL' };
+      }
+
+      const params = new URLSearchParams(url.slice(hashIndex + 1));
+      const accessToken = params.get('access_token');
+      const refreshToken = params.get('refresh_token');
+
+      if (!accessToken || !refreshToken) {
+        return { success: false, error: 'Missing access_token or refresh_token in URL' };
+      }
+
+      const connector = getSupabaseConnector();
+      const { data, error } = await connector.getClient().auth.setSession({
+        access_token: accessToken,
+        refresh_token: refreshToken,
+      });
+
+      if (error) {
+        return { success: false, error: error.message };
+      }
+
+      return { success: true, hasSession: !!data.session };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Deep link exchange failed',
+      };
+    }
+  });
+
+  /**
    * Request password reset
    */
   ipcMain.handle('auth:resetPassword', async (_, email: string) => {

--- a/apps/desktop/src/main/ipc/sync.ts
+++ b/apps/desktop/src/main/ipc/sync.ts
@@ -232,11 +232,13 @@ export function registerSyncHandlers(): void {
         }
       }
 
-      // access_token flows use hash fragment (#access_token=...&refresh_token=...&type=signup)
+      // access_token flows use hash fragment (#access_token=...&refresh_token=...&type=signup|invite|recovery)
+      // This is the format Supabase produces when {{ .ConfirmationURL }} is used in email templates.
       if (hashIndex !== -1) {
         const params = new URLSearchParams(url.slice(hashIndex + 1));
         const accessToken = params.get('access_token');
         const refreshToken = params.get('refresh_token');
+        const type = (params.get('type') ?? 'signup') as 'signup' | 'invite' | 'recovery';
 
         if (!accessToken || !refreshToken) {
           return { success: false, error: 'Missing access_token or refresh_token in URL' };
@@ -252,7 +254,9 @@ export function registerSyncHandlers(): void {
           return { success: false, error: error.message };
         }
 
-        return { success: true, type: 'signup', hasSession: !!data.session };
+        // For invite and recovery, the user is authenticated but must set a password.
+        // The renderer will show SetPasswordForm when type is not 'signup'.
+        return { success: true, type, hasSession: !!data.session };
       }
 
       return { success: false, error: 'No recognisable token in URL' };

--- a/apps/desktop/src/main/ipc/sync.ts
+++ b/apps/desktop/src/main/ipc/sync.ts
@@ -14,6 +14,7 @@ import {
 import { licenseService } from '../services/LicenseService';
 import { presenceService } from '../services/PresenceService';
 import { logger } from '../utils/logger';
+import { validatePassword } from '@showstack/shared';
 
 /** Basic email format validation */
 function isValidEmail(email: string): boolean {
@@ -266,11 +267,12 @@ export function registerSyncHandlers(): void {
    * Called after a recovery or invite deep link has been verified via auth:exchangeDeepLink.
    */
   ipcMain.handle('auth:updatePassword', async (_, password: string) => {
-    if (!password || typeof password !== 'string' || password.length < 8) {
-      return { success: false, error: 'Password must be at least 8 characters' };
+    if (!password || typeof password !== 'string') {
+      return { success: false, error: 'Password is required' };
     }
-    if (!/\d/.test(password)) {
-      return { success: false, error: 'Password must contain at least one number' };
+    const passwordError = validatePassword(password);
+    if (passwordError) {
+      return { success: false, error: passwordError };
     }
 
     try {

--- a/apps/desktop/src/main/ipc/sync.ts
+++ b/apps/desktop/src/main/ipc/sync.ts
@@ -269,6 +269,9 @@ export function registerSyncHandlers(): void {
     if (!password || typeof password !== 'string' || password.length < 8) {
       return { success: false, error: 'Password must be at least 8 characters' };
     }
+    if (!/\d/.test(password)) {
+      return { success: false, error: 'Password must contain at least one number' };
+    }
 
     try {
       const connector = getSupabaseConnector();

--- a/apps/desktop/src/main/ipc/sync.ts
+++ b/apps/desktop/src/main/ipc/sync.ts
@@ -186,8 +186,17 @@ export function registerSyncHandlers(): void {
 
   /**
    * Exchange deep-link tokens for a Supabase session.
-   * Called by the renderer after receiving an auth:deepLink event (email verification callback).
-   * The URL has the form: showstack://auth/callback#access_token=...&refresh_token=...&type=signup
+   * Called by the renderer after receiving an auth:deepLink event.
+   *
+   * Two URL formats are handled:
+   *   - Email confirmation (type=signup):
+   *       showstack://auth/callback#access_token=...&refresh_token=...&type=signup
+   *       → calls setSession(); user is immediately authenticated
+   *   - Password reset (type=recovery) and invite (type=invite):
+   *       showstack://auth/callback?token_hash=...&type=recovery|invite
+   *       → calls verifyOtp(); user must then set a password via auth:updatePassword
+   *
+   * Returns { success, type } so the renderer can decide what to show next.
    */
   ipcMain.handle('auth:exchangeDeepLink', async (_, url: string) => {
     if (!url || typeof url !== 'string') {
@@ -195,34 +204,88 @@ export function registerSyncHandlers(): void {
     }
 
     try {
+      // Parse both query string and hash fragment from the URL
+      const questionIndex = url.indexOf('?');
       const hashIndex = url.indexOf('#');
-      if (hashIndex === -1) {
-        return { success: false, error: 'No token fragment in URL' };
+
+      // token_hash flows use query params (?token_hash=...&type=recovery|invite)
+      if (questionIndex !== -1) {
+        const queryString =
+          hashIndex !== -1 ? url.slice(questionIndex + 1, hashIndex) : url.slice(questionIndex + 1);
+        const params = new URLSearchParams(queryString);
+        const tokenHash = params.get('token_hash');
+        const type = params.get('type') as 'recovery' | 'invite' | null;
+
+        if (tokenHash && (type === 'recovery' || type === 'invite')) {
+          const connector = getSupabaseConnector();
+          const { error } = await connector.getClient().auth.verifyOtp({
+            token_hash: tokenHash,
+            type,
+          });
+
+          if (error) {
+            return { success: false, error: error.message };
+          }
+
+          // User is authenticated but must set a password before proceeding
+          return { success: true, type };
+        }
       }
 
-      const params = new URLSearchParams(url.slice(hashIndex + 1));
-      const accessToken = params.get('access_token');
-      const refreshToken = params.get('refresh_token');
+      // access_token flows use hash fragment (#access_token=...&refresh_token=...&type=signup)
+      if (hashIndex !== -1) {
+        const params = new URLSearchParams(url.slice(hashIndex + 1));
+        const accessToken = params.get('access_token');
+        const refreshToken = params.get('refresh_token');
 
-      if (!accessToken || !refreshToken) {
-        return { success: false, error: 'Missing access_token or refresh_token in URL' };
+        if (!accessToken || !refreshToken) {
+          return { success: false, error: 'Missing access_token or refresh_token in URL' };
+        }
+
+        const connector = getSupabaseConnector();
+        const { data, error } = await connector.getClient().auth.setSession({
+          access_token: accessToken,
+          refresh_token: refreshToken,
+        });
+
+        if (error) {
+          return { success: false, error: error.message };
+        }
+
+        return { success: true, type: 'signup', hasSession: !!data.session };
       }
 
+      return { success: false, error: 'No recognisable token in URL' };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Deep link exchange failed',
+      };
+    }
+  });
+
+  /**
+   * Update the authenticated user's password.
+   * Called after a recovery or invite deep link has been verified via auth:exchangeDeepLink.
+   */
+  ipcMain.handle('auth:updatePassword', async (_, password: string) => {
+    if (!password || typeof password !== 'string' || password.length < 8) {
+      return { success: false, error: 'Password must be at least 8 characters' };
+    }
+
+    try {
       const connector = getSupabaseConnector();
-      const { data, error } = await connector.getClient().auth.setSession({
-        access_token: accessToken,
-        refresh_token: refreshToken,
-      });
+      const { error } = await connector.getClient().auth.updateUser({ password });
 
       if (error) {
         return { success: false, error: error.message };
       }
 
-      return { success: true, hasSession: !!data.session };
+      return { success: true };
     } catch (error) {
       return {
         success: false,
-        error: error instanceof Error ? error.message : 'Deep link exchange failed',
+        error: error instanceof Error ? error.message : 'Password update failed',
       };
     }
   });

--- a/apps/desktop/src/main/services/BackupService.ts
+++ b/apps/desktop/src/main/services/BackupService.ts
@@ -3,6 +3,7 @@ import { join } from 'path';
 import { mkdir, readdir, rm, readFile, writeFile, stat, copyFile, unlink } from 'fs/promises';
 import { createReadStream, createWriteStream } from 'fs';
 import { createGzip, createGunzip } from 'zlib';
+import { createHash } from 'crypto';
 import { pipeline } from 'stream/promises';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
@@ -18,6 +19,14 @@ const BackupMetadataSchema = z.object({
   appDbSize: z.number(),
   projectDbSize: z.number(),
   version: z.string(),
+  // SHA-256 checksums of the stored backup files (compressed if present).
+  // Optional for backwards compatibility with pre-compression backups.
+  checksums: z
+    .object({
+      appDb: z.string(),
+      projectDb: z.string(),
+    })
+    .optional(),
 });
 
 export type BackupMetadata = z.infer<typeof BackupMetadataSchema>;
@@ -168,6 +177,19 @@ export class BackupService {
   }
 
   /**
+   * Compute the SHA-256 hash of a file, returned as a hex string.
+   */
+  private async sha256File(filePath: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const hash = createHash('sha256');
+      const stream = createReadStream(filePath);
+      stream.on('data', (chunk) => hash.update(chunk));
+      stream.on('end', () => resolve(hash.digest('hex')));
+      stream.on('error', reject);
+    });
+  }
+
+  /**
    * Wrap a promise with a timeout.
    */
   private withTimeout<T>(promise: Promise<T>, timeoutMs: number, operation: string): Promise<T> {
@@ -270,9 +292,13 @@ export class BackupService {
       await this.compressFile(appBackupPath, appBackupGzPath);
       await this.compressFile(projectBackupPath, projectBackupGzPath);
 
-      // Get compressed file sizes for metadata
+      // Get compressed file sizes and checksums for metadata
       const appDbStat = await stat(appBackupGzPath);
       const projectDbStat = await stat(projectBackupGzPath);
+      const [appDbChecksum, projectDbChecksum] = await Promise.all([
+        this.sha256File(appBackupGzPath),
+        this.sha256File(projectBackupGzPath),
+      ]);
 
       // Write metadata last — if missing, backup is incomplete
       const metadata: BackupMetadata = {
@@ -281,6 +307,10 @@ export class BackupService {
         appDbSize: appDbStat.size,
         projectDbSize: projectDbStat.size,
         version: app.getVersion(),
+        checksums: {
+          appDb: appDbChecksum,
+          projectDb: projectDbChecksum,
+        },
       };
 
       await writeFile(join(backupDir, 'metadata.json'), JSON.stringify(metadata, null, 2));
@@ -488,6 +518,29 @@ export class BackupService {
       }
 
       logger.info(`Restoring from backup`, { backupDir: backupDirName });
+
+      // Verify checksums if present in metadata (compressed files only)
+      if (metadata.checksums) {
+        const appGzPath = join(backupDir, 'showstack-app.db.gz');
+        const projectGzPath = join(backupDir, 'showstack-projects.db.gz');
+        const [actualApp, actualProject] = await Promise.all([
+          this.sha256File(appGzPath),
+          this.sha256File(projectGzPath),
+        ]);
+        if (actualApp !== metadata.checksums.appDb) {
+          return {
+            success: false,
+            error: 'Backup integrity check failed: app database checksum mismatch',
+          };
+        }
+        if (actualProject !== metadata.checksums.projectDb) {
+          return {
+            success: false,
+            error: 'Backup integrity check failed: projects database checksum mismatch',
+          };
+        }
+        logger.debug('Backup checksums verified', { backupDir: backupDirName });
+      }
 
       // Save current DB files for rollback before overwriting
       await mkdir(tempDir, { recursive: true });

--- a/apps/desktop/src/main/services/BackupService.ts
+++ b/apps/desktop/src/main/services/BackupService.ts
@@ -1,6 +1,9 @@
 import { app } from 'electron';
 import { join } from 'path';
-import { mkdir, readdir, rm, readFile, writeFile, stat, copyFile } from 'fs/promises';
+import { mkdir, readdir, rm, readFile, writeFile, stat, copyFile, unlink } from 'fs/promises';
+import { createReadStream, createWriteStream } from 'fs';
+import { createGzip, createGunzip } from 'zlib';
+import { pipeline } from 'stream/promises';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { z } from 'zod';
@@ -150,6 +153,21 @@ export class BackupService {
   }
 
   /**
+   * Compress a file using gzip and delete the original.
+   */
+  private async compressFile(srcPath: string, destPath: string): Promise<void> {
+    await pipeline(createReadStream(srcPath), createGzip(), createWriteStream(destPath));
+    await unlink(srcPath);
+  }
+
+  /**
+   * Decompress a gzip file to a destination path.
+   */
+  private async decompressFile(srcPath: string, destPath: string): Promise<void> {
+    await pipeline(createReadStream(srcPath), createGunzip(), createWriteStream(destPath));
+  }
+
+  /**
    * Wrap a promise with a timeout.
    */
   private withTimeout<T>(promise: Promise<T>, timeoutMs: number, operation: string): Promise<T> {
@@ -234,6 +252,8 @@ export class BackupService {
 
       const appBackupPath = join(backupDir, 'showstack-app.db');
       const projectBackupPath = join(backupDir, 'showstack-projects.db');
+      const appBackupGzPath = `${appBackupPath}.gz`;
+      const projectBackupGzPath = `${projectBackupPath}.gz`;
 
       await this.withTimeout(appDb.backup(appBackupPath), BACKUP_TIMEOUT_MS, 'App database backup');
       await this.withTimeout(
@@ -242,13 +262,17 @@ export class BackupService {
         'Project database backup',
       );
 
-      // Verify backup integrity with quick_check
+      // Verify backup integrity before compression (requires uncompressed file)
       await this.verifyBackupIntegrity(appBackupPath, 'app');
       await this.verifyBackupIntegrity(projectBackupPath, 'project');
 
-      // Get file sizes
-      const appDbStat = await stat(appBackupPath);
-      const projectDbStat = await stat(projectBackupPath);
+      // Compress backups to save disk space (~60-80% reduction for SQLite files)
+      await this.compressFile(appBackupPath, appBackupGzPath);
+      await this.compressFile(projectBackupPath, projectBackupGzPath);
+
+      // Get compressed file sizes for metadata
+      const appDbStat = await stat(appBackupGzPath);
+      const projectDbStat = await stat(projectBackupGzPath);
 
       // Write metadata last — if missing, backup is incomplete
       const metadata: BackupMetadata = {
@@ -410,12 +434,19 @@ export class BackupService {
     const backupDir = join(this.backupsDir, backupDirName);
 
     try {
-      const appDbStat = await stat(join(backupDir, 'showstack-app.db'));
-      const projectDbStat = await stat(join(backupDir, 'showstack-projects.db'));
       await stat(join(backupDir, 'metadata.json'));
 
-      // Verify files have content
-      return appDbStat.size > 0 && projectDbStat.size > 0;
+      // Support both compressed (new) and uncompressed (legacy) backup formats
+      const appDbGzStat = await stat(join(backupDir, 'showstack-app.db.gz')).catch(() => null);
+      const appDbStat =
+        appDbGzStat ?? (await stat(join(backupDir, 'showstack-app.db')).catch(() => null));
+      const projectDbGzStat = await stat(join(backupDir, 'showstack-projects.db.gz')).catch(
+        () => null,
+      );
+      const projectDbStat =
+        projectDbGzStat ?? (await stat(join(backupDir, 'showstack-projects.db')).catch(() => null));
+
+      return (appDbStat?.size ?? 0) > 0 && (projectDbStat?.size ?? 0) > 0;
     } catch {
       return false;
     }
@@ -467,9 +498,30 @@ export class BackupService {
       databaseManager.close();
 
       try {
-        // Copy backup files to database paths
-        await copyFile(join(backupDir, 'showstack-app.db'), appDbPath);
-        await copyFile(join(backupDir, 'showstack-projects.db'), projectDbPath);
+        // Restore backup files — support both compressed (.db.gz) and legacy (.db) formats
+        const appGzPath = join(backupDir, 'showstack-app.db.gz');
+        const projectGzPath = join(backupDir, 'showstack-projects.db.gz');
+        const appLegacyPath = join(backupDir, 'showstack-app.db');
+        const projectLegacyPath = join(backupDir, 'showstack-projects.db');
+
+        const appGzExists = await stat(appGzPath)
+          .then(() => true)
+          .catch(() => false);
+        const projectGzExists = await stat(projectGzPath)
+          .then(() => true)
+          .catch(() => false);
+
+        if (appGzExists) {
+          await this.decompressFile(appGzPath, appDbPath);
+        } else {
+          await copyFile(appLegacyPath, appDbPath);
+        }
+
+        if (projectGzExists) {
+          await this.decompressFile(projectGzPath, projectDbPath);
+        } else {
+          await copyFile(projectLegacyPath, projectDbPath);
+        }
 
         // Reinitialize databases
         await databaseManager.initialize();

--- a/apps/desktop/src/main/services/BackupService.ts
+++ b/apps/desktop/src/main/services/BackupService.ts
@@ -557,12 +557,14 @@ export class BackupService {
         const appLegacyPath = join(backupDir, 'showstack-app.db');
         const projectLegacyPath = join(backupDir, 'showstack-projects.db');
 
-        const appGzExists = await stat(appGzPath)
-          .then(() => true)
-          .catch(() => false);
-        const projectGzExists = await stat(projectGzPath)
-          .then(() => true)
-          .catch(() => false);
+        const [appGzExists, projectGzExists] = await Promise.all([
+          stat(appGzPath)
+            .then(() => true)
+            .catch(() => false),
+          stat(projectGzPath)
+            .then(() => true)
+            .catch(() => false),
+        ]);
 
         if (appGzExists) {
           await this.decompressFile(appGzPath, appDbPath);

--- a/apps/desktop/src/main/services/ShopOrderProjectService.ts
+++ b/apps/desktop/src/main/services/ShopOrderProjectService.ts
@@ -131,6 +131,10 @@ export class ShopOrderProjectService {
       throw new ValidationError('Project ID is required', 'id', id);
     }
 
+    // Backup before destructive operation (matches ProjectService behaviour)
+    const { backupService } = await import('./BackupService');
+    await backupService.performBackup(`before-delete-shop-order-${id}`);
+
     await errorHandler.executeWithRetry(
       async () => deleteShopOrderProject(id),
       'shop-order:projects:delete',

--- a/apps/desktop/src/main/services/__tests__/BackupService.test.ts
+++ b/apps/desktop/src/main/services/__tests__/BackupService.test.ts
@@ -20,10 +20,18 @@ const {
   mockBackup,
   mockAppDb,
   mockProjectDb,
+  mockHashInstance,
+  mockCreateHash,
 } = vi.hoisted(() => {
   const mockBackup = vi.fn().mockResolvedValue(undefined);
   const mockPragma = vi.fn().mockReturnValue([{ quick_check: 'ok' }]);
   const mockCloseDb = vi.fn();
+  const mockHashInstance = {
+    update: vi.fn().mockReturnThis(),
+    digest: vi
+      .fn()
+      .mockReturnValue('abc123def456abc123def456abc123def456abc123def456abc123def456abc1'),
+  };
   return {
     mockMkdir: vi.fn().mockResolvedValue(undefined),
     mockReaddir: vi.fn().mockResolvedValue([]),
@@ -43,6 +51,8 @@ const {
     mockBackup,
     mockAppDb: { backup: mockBackup },
     mockProjectDb: { backup: mockBackup },
+    mockHashInstance,
+    mockCreateHash: vi.fn().mockReturnValue(mockHashInstance),
   };
 });
 
@@ -76,10 +86,28 @@ vi.mock('fs/promises', () => ({
   unlink: (...args: unknown[]) => mockUnlink(...args),
 }));
 
-// Mock fs (used for createReadStream/createWriteStream in compression)
+// Mock fs (used for createReadStream/createWriteStream in compression and sha256File)
+// createReadStream must support both pipeline (compression) and event-based (sha256File) usage.
 vi.mock('fs', () => ({
-  createReadStream: vi.fn(() => ({ pipe: vi.fn() })),
+  createReadStream: vi.fn(() => {
+    // Returns an object that works for both stream.pipeline (pipe interface)
+    // and the event-based sha256File (on('data'/'end'/'error') interface).
+    const emitter: { pipe: ReturnType<typeof vi.fn>; on: ReturnType<typeof vi.fn> } = {
+      pipe: vi.fn(),
+      on: vi.fn().mockImplementation(function (event: string, handler: () => void) {
+        // Fire 'end' asynchronously so sha256File's promise resolves cleanly
+        if (event === 'end') Promise.resolve().then(() => handler());
+        return emitter;
+      }),
+    };
+    return emitter;
+  }),
   createWriteStream: vi.fn(() => ({ on: vi.fn() })),
+}));
+
+// Mock crypto (createHash used in sha256File for backup integrity checksums)
+vi.mock('crypto', () => ({
+  createHash: (...args: unknown[]) => mockCreateHash(...args),
 }));
 
 // Mock zlib (used for createGzip/createGunzip in compression)
@@ -146,6 +174,13 @@ describe('BackupService', () => {
       close: mockCloseDb,
     });
 
+    // Mock crypto hash for sha256File
+    mockCreateHash.mockReturnValue(mockHashInstance);
+    mockHashInstance.update.mockReturnThis();
+    mockHashInstance.digest.mockReturnValue(
+      'abc123def456abc123def456abc123def456abc123def456abc123def456abc1',
+    );
+
     // Mock the private disk space check to avoid real execFile calls
     vi.spyOn(service as never, 'getFreeDiskSpaceMB' as never).mockResolvedValue(50000 as never);
 
@@ -163,6 +198,10 @@ describe('BackupService', () => {
             appDbSize: 1024,
             projectDbSize: 1024,
             version: '1.0.0',
+            checksums: {
+              appDb: 'abc123def456abc123def456abc123def456abc123def456abc123def456abc1',
+              projectDb: 'abc123def456abc123def456abc123def456abc123def456abc123def456abc1',
+            },
           }),
         );
       }

--- a/apps/desktop/src/main/services/__tests__/BackupService.test.ts
+++ b/apps/desktop/src/main/services/__tests__/BackupService.test.ts
@@ -12,6 +12,8 @@ const {
   mockWriteFile,
   mockStat,
   mockCopyFile,
+  mockUnlink,
+  mockPipeline,
   mockPragma,
   mockCloseDb,
   mockBetterSqlite3,
@@ -30,6 +32,8 @@ const {
     mockWriteFile: vi.fn().mockResolvedValue(undefined),
     mockStat: vi.fn(),
     mockCopyFile: vi.fn().mockResolvedValue(undefined),
+    mockUnlink: vi.fn().mockResolvedValue(undefined),
+    mockPipeline: vi.fn().mockResolvedValue(undefined),
     mockPragma,
     mockCloseDb,
     mockBetterSqlite3: vi.fn().mockReturnValue({
@@ -69,6 +73,24 @@ vi.mock('fs/promises', () => ({
   writeFile: (...args: unknown[]) => mockWriteFile(...args),
   stat: (...args: unknown[]) => mockStat(...args),
   copyFile: (...args: unknown[]) => mockCopyFile(...args),
+  unlink: (...args: unknown[]) => mockUnlink(...args),
+}));
+
+// Mock fs (used for createReadStream/createWriteStream in compression)
+vi.mock('fs', () => ({
+  createReadStream: vi.fn(() => ({ pipe: vi.fn() })),
+  createWriteStream: vi.fn(() => ({ on: vi.fn() })),
+}));
+
+// Mock zlib (used for createGzip/createGunzip in compression)
+vi.mock('zlib', () => ({
+  createGzip: vi.fn(() => ({ pipe: vi.fn() })),
+  createGunzip: vi.fn(() => ({ pipe: vi.fn() })),
+}));
+
+// Mock stream/promises (pipeline used in compression)
+vi.mock('stream/promises', () => ({
+  pipeline: (...args: unknown[]) => mockPipeline(...args),
 }));
 
 // Mock better-sqlite3 for integrity verification
@@ -108,6 +130,8 @@ describe('BackupService', () => {
     mockRm.mockResolvedValue(undefined);
     mockWriteFile.mockResolvedValue(undefined);
     mockCopyFile.mockResolvedValue(undefined);
+    mockUnlink.mockResolvedValue(undefined);
+    mockPipeline.mockResolvedValue(undefined);
     vi.mocked(databaseManager.initialize).mockResolvedValue(undefined);
     vi.mocked(databaseManager.forceCheckpoint).mockReturnValue({
       appBusy: false,
@@ -508,8 +532,10 @@ describe('BackupService', () => {
       expect(mockMkdir).toHaveBeenCalledWith(expect.stringContaining('.restore-rollback'), {
         recursive: true,
       });
-      // 2 rollback copies + 2 restore copies = 4 copyFile calls
-      expect(mockCopyFile).toHaveBeenCalledTimes(4);
+      // 2 rollback copies only (restore uses pipeline for compressed files)
+      expect(mockCopyFile).toHaveBeenCalledTimes(2);
+      // 2 decompress pipeline calls (one per database)
+      expect(mockPipeline).toHaveBeenCalledTimes(2);
       expect(databaseManager.close).toHaveBeenCalled();
       expect(databaseManager.initialize).toHaveBeenCalled();
       // Rollback dir should be cleaned up on success
@@ -607,8 +633,14 @@ describe('BackupService', () => {
 
   describe('validateBackup', () => {
     it('should reject dirs without both DB files', async () => {
-      // First file exists, second doesn't
-      mockStat.mockResolvedValueOnce({ size: 1024 }).mockRejectedValueOnce(new Error('ENOENT'));
+      // stat call order: metadata.json, app.db.gz, app.db, project.db.gz, project.db
+      // Simulate: app.db.gz missing, app.db exists, project.db.gz missing, project.db missing
+      mockStat
+        .mockResolvedValueOnce({ size: 1024 }) // metadata.json
+        .mockRejectedValueOnce(new Error('ENOENT')) // app.db.gz → null
+        .mockResolvedValueOnce({ size: 1024 }) // app.db → found
+        .mockRejectedValueOnce(new Error('ENOENT')) // project.db.gz → null
+        .mockRejectedValueOnce(new Error('ENOENT')); // project.db → null
 
       const valid = await service.validateBackup('backup-123');
 
@@ -616,10 +648,11 @@ describe('BackupService', () => {
     });
 
     it('should reject dirs with empty DB files', async () => {
+      // stat call order: metadata.json, app.db.gz (empty), project.db.gz (valid)
       mockStat
-        .mockResolvedValueOnce({ size: 0 })
-        .mockResolvedValueOnce({ size: 1024 })
-        .mockResolvedValueOnce({ size: 100 });
+        .mockResolvedValueOnce({ size: 1024 }) // metadata.json
+        .mockResolvedValueOnce({ size: 0 }) // app.db.gz → size 0 (empty)
+        .mockResolvedValueOnce({ size: 1024 }); // project.db.gz → ok
 
       const valid = await service.validateBackup('backup-123');
 

--- a/apps/desktop/src/main/services/__tests__/ShopOrderProjectService.test.ts
+++ b/apps/desktop/src/main/services/__tests__/ShopOrderProjectService.test.ts
@@ -9,14 +9,19 @@ import { ValidationError } from '../../errors';
 // Hoisted mocks for mutable state
 // ============================================
 
-const { mockIsAuthenticated, mockGetUserId, mockSyncShopOrder, mockDeleteShopOrder } = vi.hoisted(
-  () => ({
-    mockIsAuthenticated: vi.fn(),
-    mockGetUserId: vi.fn(),
-    mockSyncShopOrder: vi.fn(),
-    mockDeleteShopOrder: vi.fn(),
-  }),
-);
+const {
+  mockIsAuthenticated,
+  mockGetUserId,
+  mockSyncShopOrder,
+  mockDeleteShopOrder,
+  mockPerformBackup,
+} = vi.hoisted(() => ({
+  mockIsAuthenticated: vi.fn(),
+  mockGetUserId: vi.fn(),
+  mockSyncShopOrder: vi.fn(),
+  mockDeleteShopOrder: vi.fn(),
+  mockPerformBackup: vi.fn(),
+}));
 
 // Mock dependencies
 vi.mock('../../utils/logger', () => ({
@@ -64,6 +69,12 @@ vi.mock('../sync/projectSync', () => ({
   deleteShopOrderFromPowerSync: mockDeleteShopOrder,
 }));
 
+vi.mock('../BackupService', () => ({
+  backupService: {
+    performBackup: mockPerformBackup,
+  },
+}));
+
 import { ShopOrderProjectService } from '../ShopOrderProjectService';
 import {
   getAllShopOrderProjects,
@@ -109,6 +120,7 @@ describe('ShopOrderProjectService', () => {
     mockGetUserId.mockReturnValue(null);
     mockSyncShopOrder.mockResolvedValue(undefined);
     mockDeleteShopOrder.mockResolvedValue(undefined);
+    mockPerformBackup.mockResolvedValue(undefined);
   });
 
   describe('getAll', () => {

--- a/apps/desktop/src/main/services/sync/SupabaseConnector.ts
+++ b/apps/desktop/src/main/services/sync/SupabaseConnector.ts
@@ -202,20 +202,35 @@ export class SupabaseConnector implements PowerSyncBackendConnector {
   /**
    * Sign up with email and password
    */
-  async signUp(email: string, password: string): Promise<{ success: boolean; error?: string }> {
+  async signUp(
+    email: string,
+    password: string,
+  ): Promise<{ success: boolean; error?: string; emailConfirmationRequired?: boolean }> {
     try {
       const { data, error } = await this.supabase.auth.signUp({
         email,
         password,
+        options: {
+          // Redirect to the app's custom URL scheme after email confirmation.
+          // Configure Supabase dashboard → Auth → URL Configuration to allow showstack://*.
+          emailRedirectTo: 'showstack://auth/callback',
+        },
       });
 
       if (error) {
         return { success: false, error: mapAuthError(error.message) };
       }
 
-      // Note: Session may be null if email confirmation is required
+      // Session is null when email confirmation is required (Supabase default).
+      // Return a distinct flag so the UI can show the appropriate message.
       this.currentSession = data.session;
-      return { success: true };
+      if (!data.session) {
+        return {
+          success: true,
+          emailConfirmationRequired: true,
+        };
+      }
+      return { success: true, emailConfirmationRequired: false };
     } catch (error) {
       return {
         success: false,

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -389,6 +389,16 @@ contextBridge.exposeInMainWorld('api', {
     signOut: () => ipcRenderer.invoke('auth:signOut'),
     resetPassword: (email: string) => ipcRenderer.invoke('auth:resetPassword', email),
     getState: () => ipcRenderer.invoke('auth:getState'),
+    onDeepLink: (callback: (url: string) => void) => {
+      const wrapper = (_event: unknown, url: string) => callback(url);
+      ipcRenderer.on('auth:deepLink', wrapper as Parameters<typeof ipcRenderer.on>[1]);
+      return () =>
+        ipcRenderer.removeListener(
+          'auth:deepLink',
+          wrapper as Parameters<typeof ipcRenderer.removeListener>[1],
+        );
+    },
+    exchangeDeepLink: (url: string) => ipcRenderer.invoke('auth:exchangeDeepLink', url),
   },
 
   // Collaboration operations (project & shop order sharing, presence)
@@ -736,7 +746,10 @@ export interface ElectronAPI {
   };
   auth: {
     signIn: (email: string, password: string) => Promise<{ success: boolean; error?: string }>;
-    signUp: (email: string, password: string) => Promise<{ success: boolean; error?: string }>;
+    signUp: (
+      email: string,
+      password: string,
+    ) => Promise<{ success: boolean; error?: string; emailConfirmationRequired?: boolean }>;
     signOut: () => Promise<{ success: boolean; error?: string }>;
     resetPassword: (email: string) => Promise<{ success: boolean; error?: string }>;
     getState: () => Promise<{
@@ -744,6 +757,10 @@ export interface ElectronAPI {
       userId: string | null;
       email: string | null;
     }>;
+    onDeepLink: (callback: (url: string) => void) => () => void;
+    exchangeDeepLink: (
+      url: string,
+    ) => Promise<{ success: boolean; error?: string; hasSession?: boolean }>;
   };
   backup: {
     create: (reason?: string) => Promise<{

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -399,6 +399,7 @@ contextBridge.exposeInMainWorld('api', {
         );
     },
     exchangeDeepLink: (url: string) => ipcRenderer.invoke('auth:exchangeDeepLink', url),
+    updatePassword: (password: string) => ipcRenderer.invoke('auth:updatePassword', password),
   },
 
   // Collaboration operations (project & shop order sharing, presence)
@@ -758,9 +759,13 @@ export interface ElectronAPI {
       email: string | null;
     }>;
     onDeepLink: (callback: (url: string) => void) => () => void;
-    exchangeDeepLink: (
-      url: string,
-    ) => Promise<{ success: boolean; error?: string; hasSession?: boolean }>;
+    exchangeDeepLink: (url: string) => Promise<{
+      success: boolean;
+      error?: string;
+      type?: 'signup' | 'recovery' | 'invite';
+      hasSession?: boolean;
+    }>;
+    updatePassword: (password: string) => Promise<{ success: boolean; error?: string }>;
   };
   backup: {
     create: (reason?: string) => Promise<{

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -243,6 +243,31 @@ export default function App() {
     initSync();
   }, []);
 
+  // Handle email verification deep links (showstack://auth/callback#access_token=...&type=signup)
+  useEffect(() => {
+    const unlisten = window.api.auth.onDeepLink(async (url: string) => {
+      logger.info('[App] Processing auth deep link');
+      try {
+        const result = await window.api.auth.exchangeDeepLink(url);
+        if (result.success) {
+          const authState = useAuthStore.getState();
+          await Promise.allSettled([
+            authState.refreshAuthState(),
+            authState.refreshLicenseStatus(),
+            authState.refreshSyncStatus(),
+          ]);
+        } else {
+          logger.warn('[App] Deep link exchange failed', { error: result.error });
+        }
+      } catch (error) {
+        logger.error('[App] Deep link handler error', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    });
+    return unlisten;
+  }, []);
+
   // Track app lifecycle with telemetry
   useEffect(() => {
     const appStartTime = Date.now();

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -243,7 +243,7 @@ export default function App() {
     initSync();
   }, []);
 
-  // Handle email verification deep links (showstack://auth/callback#access_token=...&type=signup)
+  // Handle auth deep links (email confirmation, password reset, invite)
   useEffect(() => {
     const unlisten = window.api.auth.onDeepLink(async (url: string) => {
       logger.info('[App] Processing auth deep link');
@@ -251,11 +251,18 @@ export default function App() {
         const result = await window.api.auth.exchangeDeepLink(url);
         if (result.success) {
           const authState = useAuthStore.getState();
-          await Promise.allSettled([
-            authState.refreshAuthState(),
-            authState.refreshLicenseStatus(),
-            authState.refreshSyncStatus(),
-          ]);
+          if (result.type === 'recovery' || result.type === 'invite') {
+            // OTP verified — user must now set a password
+            useAuthStore.setState({ pendingDeepLinkType: result.type });
+            authState.openAuthModal('set-password');
+          } else {
+            // Email confirmation — fully authenticated, just refresh state
+            await Promise.allSettled([
+              authState.refreshAuthState(),
+              authState.refreshLicenseStatus(),
+              authState.refreshSyncStatus(),
+            ]);
+          }
         } else {
           logger.warn('[App] Deep link exchange failed', { error: result.error });
         }

--- a/apps/desktop/src/renderer/src/components/auth/AuthModal.tsx
+++ b/apps/desktop/src/renderer/src/components/auth/AuthModal.tsx
@@ -11,6 +11,7 @@ import { useAuthStore } from '../../store/authStore';
 import { LoginForm } from './LoginForm';
 import { SignUpForm } from './SignUpForm';
 import { PasswordResetForm } from './PasswordResetForm';
+import { SetPasswordForm } from './SetPasswordForm';
 
 export function AuthModal() {
   const {
@@ -73,14 +74,16 @@ export function AuthModal() {
 
       {/* Modal */}
       <div className="relative bg-white rounded-lg shadow-xl w-full max-w-md mx-4 overflow-hidden">
-        {/* Close Button */}
-        <button
-          onClick={closeAuthModal}
-          disabled={isLoading}
-          className="absolute top-4 right-4 text-gray-400 hover:text-gray-600 disabled:opacity-50"
-        >
-          <X className="h-5 w-5" />
-        </button>
+        {/* Close Button — hidden during set-password (user must complete this step) */}
+        {authModalView !== 'set-password' && (
+          <button
+            onClick={closeAuthModal}
+            disabled={isLoading}
+            className="absolute top-4 right-4 text-gray-400 hover:text-gray-600 disabled:opacity-50"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        )}
 
         {/* Header with Logo */}
         <div className="pt-6 pb-2 px-6 text-center">
@@ -105,10 +108,12 @@ export function AuthModal() {
           {authModalView === 'reset' && (
             <PasswordResetForm onSwitchToLogin={() => setAuthModalView('login')} />
           )}
+
+          {authModalView === 'set-password' && <SetPasswordForm />}
         </div>
 
-        {/* Demo Mode Button (first-launch only) */}
-        {isFirstLaunchPrompt && (
+        {/* Demo Mode Button (first-launch only, not shown during set-password) */}
+        {isFirstLaunchPrompt && authModalView !== 'set-password' && (
           <div className="px-6 pb-4">
             <div className="relative flex items-center justify-center my-2">
               <div className="border-t border-gray-200 w-full" />

--- a/apps/desktop/src/renderer/src/components/auth/SetPasswordForm.tsx
+++ b/apps/desktop/src/renderer/src/components/auth/SetPasswordForm.tsx
@@ -9,6 +9,7 @@
 import { useState, useEffect } from 'react';
 import { Lock, Eye, EyeOff, Loader2, CheckCircle } from 'lucide-react';
 import { useAuthStore } from '../../store/authStore';
+import { PASSWORD_MIN_LENGTH } from '@showstack/shared';
 
 export function SetPasswordForm() {
   const { updatePassword, closeAuthModal, isLoading, error, clearError, pendingDeepLinkType } =
@@ -28,7 +29,7 @@ export function SetPasswordForm() {
 
   const isInvite = pendingDeepLinkType === 'invite';
 
-  const passwordMinLength = password.length >= 8;
+  const passwordMinLength = password.length >= PASSWORD_MIN_LENGTH;
   const passwordHasNumber = /\d/.test(password);
   const passwordsMatch = password === confirmPassword && password.length > 0;
   const isValidPassword = passwordMinLength && passwordHasNumber;
@@ -118,7 +119,7 @@ export function SetPasswordForm() {
               <span
                 className={`w-1.5 h-1.5 rounded-full ${passwordMinLength ? 'bg-green-500' : 'bg-gray-300'}`}
               />
-              At least 8 characters
+              At least {PASSWORD_MIN_LENGTH} characters
             </div>
             <div
               className={`text-xs flex items-center gap-1 ${passwordHasNumber ? 'text-green-600' : 'text-gray-400'}`}

--- a/apps/desktop/src/renderer/src/components/auth/SetPasswordForm.tsx
+++ b/apps/desktop/src/renderer/src/components/auth/SetPasswordForm.tsx
@@ -1,0 +1,183 @@
+/**
+ * Set Password Form Component
+ *
+ * Shown after a recovery (password reset) or invite deep link is verified.
+ * The user is already authenticated via verifyOtp at this point — they just
+ * need to set (or reset) their password to complete the flow.
+ */
+
+import { useState } from 'react';
+import { Lock, Eye, EyeOff, Loader2, CheckCircle } from 'lucide-react';
+import { useAuthStore } from '../../store/authStore';
+
+export function SetPasswordForm() {
+  const { updatePassword, isLoading, error, clearError, pendingDeepLinkType } = useAuthStore();
+
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [success, setSuccess] = useState(false);
+
+  const isInvite = pendingDeepLinkType === 'invite';
+
+  const passwordMinLength = password.length >= 8;
+  const passwordHasNumber = /\d/.test(password);
+  const passwordsMatch = password === confirmPassword && password.length > 0;
+  const isValidPassword = passwordMinLength && passwordHasNumber;
+  const canSubmit = isValidPassword && passwordsMatch;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!canSubmit) return;
+
+    const result = await updatePassword(password);
+    if (result) {
+      setSuccess(true);
+    }
+  };
+
+  const handlePasswordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setPassword(e.target.value);
+    if (error) clearError();
+  };
+
+  if (success) {
+    return (
+      <div className="text-center py-4">
+        <CheckCircle className="h-12 w-12 text-green-500 mx-auto mb-4" />
+        <h2 className="text-xl font-semibold text-gray-900 mb-2">You're all set!</h2>
+        <p className="text-sm text-gray-500">
+          Your password has been {isInvite ? 'created' : 'reset'}.
+          <br />
+          You're now signed in to ShowStack.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="text-center mb-6">
+        <h2 className="text-xl font-semibold text-gray-900">
+          {isInvite ? 'Create Your Password' : 'Set New Password'}
+        </h2>
+        <p className="text-sm text-gray-500 mt-1">
+          {isInvite
+            ? 'Choose a password to complete your account setup'
+            : 'Choose a new password for your account'}
+        </p>
+      </div>
+
+      {/* Password Field */}
+      <div>
+        <label htmlFor="set-password" className="block text-sm font-medium text-gray-700 mb-1">
+          {isInvite ? 'Password' : 'New Password'}
+        </label>
+        <div className="relative">
+          <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+            <Lock className="h-4 w-4 text-gray-400" />
+          </div>
+          <input
+            id="set-password"
+            type={showPassword ? 'text' : 'password'}
+            value={password}
+            onChange={handlePasswordChange}
+            placeholder="Create a password"
+            className="block w-full pl-10 pr-10 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-blue-500 focus:border-blue-500 text-sm"
+            disabled={isLoading}
+            autoComplete="new-password"
+            autoFocus
+          />
+          <button
+            type="button"
+            onClick={() => setShowPassword(!showPassword)}
+            className="absolute inset-y-0 right-0 pr-3 flex items-center"
+          >
+            {showPassword ? (
+              <EyeOff className="h-4 w-4 text-gray-400 hover:text-gray-600" />
+            ) : (
+              <Eye className="h-4 w-4 text-gray-400 hover:text-gray-600" />
+            )}
+          </button>
+        </div>
+
+        {/* Password Requirements */}
+        {password.length > 0 && (
+          <div className="mt-2 space-y-1">
+            <div
+              className={`text-xs flex items-center gap-1 ${passwordMinLength ? 'text-green-600' : 'text-gray-400'}`}
+            >
+              <span
+                className={`w-1.5 h-1.5 rounded-full ${passwordMinLength ? 'bg-green-500' : 'bg-gray-300'}`}
+              />
+              At least 8 characters
+            </div>
+            <div
+              className={`text-xs flex items-center gap-1 ${passwordHasNumber ? 'text-green-600' : 'text-gray-400'}`}
+            >
+              <span
+                className={`w-1.5 h-1.5 rounded-full ${passwordHasNumber ? 'bg-green-500' : 'bg-gray-300'}`}
+              />
+              Contains a number
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Confirm Password Field */}
+      <div>
+        <label
+          htmlFor="set-confirm-password"
+          className="block text-sm font-medium text-gray-700 mb-1"
+        >
+          Confirm Password
+        </label>
+        <div className="relative">
+          <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+            <Lock className="h-4 w-4 text-gray-400" />
+          </div>
+          <input
+            id="set-confirm-password"
+            type={showPassword ? 'text' : 'password'}
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            placeholder="Confirm your password"
+            className={`block w-full pl-10 pr-3 py-2 border rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-blue-500 focus:border-blue-500 text-sm ${
+              confirmPassword && !passwordsMatch ? 'border-red-300' : 'border-gray-300'
+            }`}
+            disabled={isLoading}
+            autoComplete="new-password"
+          />
+        </div>
+        {confirmPassword && !passwordsMatch && (
+          <p className="mt-1 text-xs text-red-600">Passwords do not match</p>
+        )}
+      </div>
+
+      {/* Error Message */}
+      {error && (
+        <div className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-md p-2">
+          {error}
+        </div>
+      )}
+
+      {/* Submit Button */}
+      <button
+        type="submit"
+        disabled={isLoading || !canSubmit}
+        className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {isLoading ? (
+          <>
+            <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+            Saving...
+          </>
+        ) : isInvite ? (
+          'Create Password'
+        ) : (
+          'Set New Password'
+        )}
+      </button>
+    </form>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/auth/SetPasswordForm.tsx
+++ b/apps/desktop/src/renderer/src/components/auth/SetPasswordForm.tsx
@@ -6,17 +6,25 @@
  * need to set (or reset) their password to complete the flow.
  */
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Lock, Eye, EyeOff, Loader2, CheckCircle } from 'lucide-react';
 import { useAuthStore } from '../../store/authStore';
 
 export function SetPasswordForm() {
-  const { updatePassword, isLoading, error, clearError, pendingDeepLinkType } = useAuthStore();
+  const { updatePassword, closeAuthModal, isLoading, error, clearError, pendingDeepLinkType } =
+    useAuthStore();
 
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
   const [success, setSuccess] = useState(false);
+
+  useEffect(() => {
+    if (success) {
+      const timer = setTimeout(() => closeAuthModal(), 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [success, closeAuthModal]);
 
   const isInvite = pendingDeepLinkType === 'invite';
 

--- a/apps/desktop/src/renderer/src/components/auth/index.ts
+++ b/apps/desktop/src/renderer/src/components/auth/index.ts
@@ -5,4 +5,5 @@
 export { LoginForm } from './LoginForm';
 export { SignUpForm } from './SignUpForm';
 export { PasswordResetForm } from './PasswordResetForm';
+export { SetPasswordForm } from './SetPasswordForm';
 export { AuthModal } from './AuthModal';

--- a/apps/desktop/src/renderer/src/components/shop-order/PageRenderer.tsx
+++ b/apps/desktop/src/renderer/src/components/shop-order/PageRenderer.tsx
@@ -163,15 +163,13 @@ export function PageRenderer({ section, project, pageSettings, pageNumber }: Pag
   useEffect(() => {
     const loadLogo = async () => {
       // Try to find logo path from ShopOrderProject or parent Project
-      let logoPath = project.logo_path || (project as any).logo_storage_path;
+      let logoPath = project.logo_path || project.logo_storage_path;
 
       // If no logo in ShopOrderProject, check parent project
-      if (!logoPath && (project as any).parent_project_id) {
+      if (!logoPath && project.parent_project_id) {
         logger.info('[PageRenderer] No logo in ShopOrderProject, checking parent project...');
         try {
-          const parentProject = await window.api.projects.getById(
-            (project as any).parent_project_id,
-          );
+          const parentProject = await window.api.projects.getById(project.parent_project_id);
           if (parentProject?.logo_path) {
             logger.info('[PageRenderer] Found logo in parent project:', parentProject.logo_path);
             logoPath = parentProject.logo_path;
@@ -211,7 +209,7 @@ export function PageRenderer({ section, project, pageSettings, pageNumber }: Pag
     };
 
     loadLogo();
-  }, [project.logo_path, (project as any).logo_storage_path, (project as any).parent_project_id]);
+  }, [project.logo_path, project.logo_storage_path, project.parent_project_id]);
 
   function getDataFieldValue(fieldType: DataFieldType): string {
     const formatDate = (timestamp?: string | number): string => {

--- a/apps/desktop/src/renderer/src/components/shop-order/ShopOrderFileMenu.tsx
+++ b/apps/desktop/src/renderer/src/components/shop-order/ShopOrderFileMenu.tsx
@@ -13,6 +13,8 @@ export function ShopOrderFileMenu({ className = '', onNewProject }: PrepFileMenu
     isDirty,
     isSaving,
     isOpening,
+    errorMessage,
+    clearError,
     getCurrentFileName,
     newFile,
     openFile,
@@ -142,6 +144,16 @@ export function ShopOrderFileMenu({ className = '', onNewProject }: PrepFileMenu
         <div className="text-sm text-gray-600 dark:text-gray-400 flex items-center gap-2">
           <div className="animate-spin h-4 w-4 border-2 border-blue-500 border-t-transparent rounded-full" />
           Opening...
+        </div>
+      )}
+
+      {errorMessage && (
+        <div
+          className="text-sm text-red-600 dark:text-red-400 flex items-center gap-1 cursor-pointer"
+          onClick={clearError}
+          title="Click to dismiss"
+        >
+          ⚠ {errorMessage}
         </div>
       )}
     </div>

--- a/apps/desktop/src/renderer/src/pages/modules/ShopOrderBuilder.tsx
+++ b/apps/desktop/src/renderer/src/pages/modules/ShopOrderBuilder.tsx
@@ -16,7 +16,7 @@ import { PrintPreview } from '../../components/shop-order/PrintPreview';
 import { DeveloperPanel } from '../../components/common/DeveloperPanel';
 import { telemetry } from '../../services/telemetry';
 import { formatPhoneNumber } from '../../utils/phoneFormatter';
-import type { PrepSection, Discipline, PrepProject } from '../../types/shopOrder';
+import type { ShopOrderSection, Discipline, ShopOrderProject } from '../../types/shopOrder';
 import { useShopOrderMenuHandlers } from '../../hooks/useShopOrderMenuHandlers';
 import { useFixtureStore } from '../../store/fixtureStore';
 import { useGroupStore } from '../../store/groupStore';
@@ -50,7 +50,7 @@ export function ShopOrderBuilder() {
   const [showNewProjectDialog, setShowNewProjectDialog] = useState(false);
   const [showAddSectionDialog, setShowAddSectionDialog] = useState(false);
   const [showEditSectionDialog, setShowEditSectionDialog] = useState(false);
-  const [sectionToEdit, setSectionToEdit] = useState<PrepSection | null>(null);
+  const [sectionToEdit, setSectionToEdit] = useState<ShopOrderSection | null>(null);
 
   // State for inline editing
   const [editingField, setEditingField] = useState<string | null>(null);
@@ -242,7 +242,7 @@ export function ShopOrderBuilder() {
     await loadProject(projectId);
   };
 
-  const _handleEditSection = (section: PrepSection) => {
+  const _handleEditSection = (section: ShopOrderSection) => {
     setSectionToEdit(section);
     setShowEditSectionDialog(true);
   };
@@ -539,7 +539,7 @@ export function ShopOrderBuilder() {
     })();
 
     // Helper to get field value (from parent if linked, otherwise from prep project)
-    const getFieldValue = (field: keyof PrepProject): string => {
+    const getFieldValue = (field: keyof ShopOrderProject): string => {
       if (isLinked && parentProject) {
         // Map prep project fields to parent project fields
         switch (field) {
@@ -592,11 +592,11 @@ export function ShopOrderBuilder() {
     };
 
     // Helper to check if a specific field is read-only (pulling from parent)
-    const isFieldReadOnly = (field: keyof PrepProject): boolean => {
+    const isFieldReadOnly = (field: keyof ShopOrderProject): boolean => {
       if (!isLinked || !parentProject) return false;
 
       // These fields are read-only when linked (fields that pull from parent)
-      const parentFields: (keyof PrepProject)[] = [
+      const parentFields: (keyof ShopOrderProject)[] = [
         'gm_name',
         'gm_email',
         'gm_phone',
@@ -623,7 +623,11 @@ export function ShopOrderBuilder() {
     };
 
     // Helper to render an editable field inline (no label wrapper)
-    const renderInlineField = (field: keyof PrepProject, placeholder = '+ Add', className = '') => {
+    const renderInlineField = (
+      field: keyof ShopOrderProject,
+      placeholder = '+ Add',
+      className = '',
+    ) => {
       const value = getFieldValue(field);
       const isEditing = editingField === field;
       const fieldIsReadOnly = isFieldReadOnly(field);
@@ -657,7 +661,11 @@ export function ShopOrderBuilder() {
     };
 
     // Helper to render a date field with calendar picker on double-click
-    const renderDateField = (field: keyof PrepProject, placeholder = '+ Add', className = '') => {
+    const renderDateField = (
+      field: keyof ShopOrderProject,
+      placeholder = '+ Add',
+      className = '',
+    ) => {
       const value = getFieldValue(field);
       const isEditing = editingField === field;
 
@@ -728,7 +736,7 @@ export function ShopOrderBuilder() {
     };
 
     // Helper to render an editable field with label (for backwards compatibility)
-    const _renderField = (label: string, field: keyof PrepProject, placeholder = '+ Add') => {
+    const _renderField = (label: string, field: keyof ShopOrderProject, placeholder = '+ Add') => {
       const value = getFieldValue(field);
       const isEditing = editingField === field;
       const fieldIsReadOnly = isFieldReadOnly(field);

--- a/apps/desktop/src/renderer/src/services/__tests__/telemetry.test.ts
+++ b/apps/desktop/src/renderer/src/services/__tests__/telemetry.test.ts
@@ -17,6 +17,7 @@ vi.mock('posthog-js', () => ({
     identify: vi.fn(),
     capture: vi.fn(),
     reset: vi.fn(),
+    shutdown: vi.fn().mockResolvedValue(undefined),
   },
 }));
 
@@ -475,13 +476,13 @@ describe('TelemetryService', () => {
   });
 
   describe('Shutdown', () => {
-    it('should flush events and reset PostHog', async () => {
+    it('should flush events and shut down PostHog', async () => {
       (telemetry as any).posthogInitialized = true;
 
       await telemetry.track('test_event');
       await telemetry.shutdown();
 
-      expect(posthog.reset).toHaveBeenCalled();
+      expect(posthog.shutdown).toHaveBeenCalledWith(3000);
     });
 
     it('should handle shutdown when PostHog is not initialized', async () => {
@@ -489,7 +490,7 @@ describe('TelemetryService', () => {
 
       await telemetry.shutdown();
 
-      expect(posthog.reset).not.toHaveBeenCalled();
+      expect(posthog.shutdown).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/desktop/src/renderer/src/services/__tests__/telemetry.test.ts
+++ b/apps/desktop/src/renderer/src/services/__tests__/telemetry.test.ts
@@ -41,6 +41,7 @@ describe('TelemetryService', () => {
 
     // Reset telemetry state
     (telemetry as any).localEvents = [];
+    (telemetry as any).unsyncedCount = 0;
     (telemetry as any).posthogInitialized = false;
   });
 

--- a/apps/desktop/src/renderer/src/services/telemetry.ts
+++ b/apps/desktop/src/renderer/src/services/telemetry.ts
@@ -629,15 +629,17 @@ class TelemetryService {
       }
     }
 
-    // Reset PostHog if initialized
+    // Shut down PostHog — flushes any queued events before disconnecting.
+    // posthog.shutdown() is preferred over posthog.reset() on quit because
+    // reset() clears identity without flushing, potentially losing pending events.
     if (this.posthogInitialized) {
       try {
-        posthog.reset();
+        await posthog.shutdown(3000); // 3s timeout so quit isn't delayed
         if (import.meta.env.DEV) {
-          console.log('[Telemetry] PostHog reset successfully');
+          console.log('[Telemetry] PostHog shut down successfully');
         }
       } catch (error) {
-        console.error('[Telemetry] Failed to reset PostHog:', error);
+        console.error('[Telemetry] Failed to shut down PostHog:', error);
       }
     }
   }

--- a/apps/desktop/src/renderer/src/services/telemetry.ts
+++ b/apps/desktop/src/renderer/src/services/telemetry.ts
@@ -130,7 +130,8 @@ class TelemetryService {
   private readonly STORAGE_KEY = 'showstack-telemetry-events';
   private readonly BATCH_SIZE = 50;
   private readonly FLUSH_INTERVAL = 60000; // 1 minute
-  private readonly MAX_LOCAL_EVENTS = 1000; // Prevent memory issues
+  private readonly MAX_LOCAL_EVENTS = 1000; // Total events cap (synced + unsynced)
+  private readonly MAX_UNSYNCED_EVENTS = 500; // Cap on unsynced events when offline
   private flushTimer: number | null = null;
   private sessionId: string;
   private localEvents: StoredEvent[] = [];
@@ -439,14 +440,25 @@ class TelemetryService {
 
     this.localEvents.push(storedEvent);
 
-    // Enforce maximum local events limit
-    if (this.localEvents.length > this.MAX_LOCAL_EVENTS) {
-      // Remove oldest synced event first (more efficient)
+    // Enforce cap on unsynced events to prevent unbounded growth when offline
+    const unsyncedCount = this.localEvents.filter((e) => !e.synced).length;
+    if (unsyncedCount > this.MAX_UNSYNCED_EVENTS) {
+      // Drop oldest unsynced event
+      const oldestUnsyncedIndex = this.localEvents.findIndex((e) => !e.synced);
+      if (oldestUnsyncedIndex > -1) {
+        this.localEvents.splice(oldestUnsyncedIndex, 1);
+        if (import.meta.env.DEV) {
+          console.warn(
+            `[Telemetry] MAX_UNSYNCED_EVENTS (${this.MAX_UNSYNCED_EVENTS}) reached — oldest unsynced event dropped`,
+          );
+        }
+      }
+    } else if (this.localEvents.length > this.MAX_LOCAL_EVENTS) {
+      // Enforce total cap: remove oldest synced event first
       const syncedIndex = this.localEvents.findIndex((e) => e.synced);
       if (syncedIndex > -1) {
         this.localEvents.splice(syncedIndex, 1);
       } else {
-        // If no synced events, remove oldest event
         this.localEvents.shift();
       }
     }

--- a/apps/desktop/src/renderer/src/services/telemetry.ts
+++ b/apps/desktop/src/renderer/src/services/telemetry.ts
@@ -135,6 +135,7 @@ class TelemetryService {
   private flushTimer: number | null = null;
   private sessionId: string;
   private localEvents: StoredEvent[] = [];
+  private unsyncedCount = 0;
   private posthogInitialized = false;
   private posthogInitPromise: Promise<void> | null = null;
   private eventQueue: Array<() => void> = [];
@@ -246,7 +247,7 @@ class TelemetryService {
     await this.storeLocal(telemetryEvent);
 
     // Auto-flush if batch size reached
-    if (this.localEvents.filter((e) => !e.synced).length >= this.BATCH_SIZE) {
+    if (this.unsyncedCount >= this.BATCH_SIZE) {
       // Wait for PostHog initialization to complete before flushing
       if (this.posthogInitPromise) {
         await this.posthogInitPromise;
@@ -374,6 +375,7 @@ class TelemetryService {
       unsyncedEvents.forEach((event) => {
         event.synced = true;
       });
+      this.unsyncedCount -= unsyncedEvents.length;
 
       this.saveLocalEvents();
 
@@ -439,14 +441,15 @@ class TelemetryService {
     };
 
     this.localEvents.push(storedEvent);
+    this.unsyncedCount++;
 
     // Enforce cap on unsynced events to prevent unbounded growth when offline
-    const unsyncedCount = this.localEvents.filter((e) => !e.synced).length;
-    if (unsyncedCount > this.MAX_UNSYNCED_EVENTS) {
+    if (this.unsyncedCount > this.MAX_UNSYNCED_EVENTS) {
       // Drop oldest unsynced event
       const oldestUnsyncedIndex = this.localEvents.findIndex((e) => !e.synced);
       if (oldestUnsyncedIndex > -1) {
         this.localEvents.splice(oldestUnsyncedIndex, 1);
+        this.unsyncedCount--;
         if (import.meta.env.DEV) {
           console.warn(
             `[Telemetry] MAX_UNSYNCED_EVENTS (${this.MAX_UNSYNCED_EVENTS}) reached — oldest unsynced event dropped`,
@@ -559,6 +562,7 @@ class TelemetryService {
       console.error('Failed to load local telemetry events:', error);
       this.localEvents = [];
     }
+    this.unsyncedCount = this.localEvents.filter((e) => !e.synced).length;
   }
 
   /**

--- a/apps/desktop/src/renderer/src/store/__tests__/shopOrderStore.test.ts
+++ b/apps/desktop/src/renderer/src/store/__tests__/shopOrderStore.test.ts
@@ -88,8 +88,8 @@ describe('shopOrderStore.createProject', () => {
       const payload = prepProjectsCreate.mock.calls[0][0];
       // logo_url must be a valid URL or '' per schema — local paths must not be passed
       expect(payload.logo_url).toBe('');
-      // The path is preserved separately for future storage resolution
-      expect(payload.logo_storage_path).toBe('/Users/designer/Documents/logo.png');
+      // The path is preserved in the unified logo_path field
+      expect(payload.logo_path).toBe('/Users/designer/Documents/logo.png');
     });
 
     it('does not set logo_url when there is no parent project', async () => {

--- a/apps/desktop/src/renderer/src/store/authStore.ts
+++ b/apps/desktop/src/renderer/src/store/authStore.ts
@@ -338,7 +338,6 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         ]);
         set({
           isLoading: false,
-          showAuthModal: false,
           pendingDeepLinkType: null,
         });
         return true;

--- a/apps/desktop/src/renderer/src/store/authStore.ts
+++ b/apps/desktop/src/renderer/src/store/authStore.ts
@@ -7,6 +7,7 @@
 
 import { create } from 'zustand';
 import { logger } from '../utils/logger';
+import { validatePassword } from '@showstack/shared';
 
 /**
  * Sync status from PowerSync
@@ -321,8 +322,9 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 
   // Set new password (after recovery/invite deep link verification)
   updatePassword: async (password: string) => {
-    if (password.length < 8) {
-      set({ error: 'Password must be at least 8 characters' });
+    const passwordError = validatePassword(password);
+    if (passwordError) {
+      set({ error: passwordError });
       return false;
     }
     set({ isLoading: true, error: null });

--- a/apps/desktop/src/renderer/src/store/authStore.ts
+++ b/apps/desktop/src/renderer/src/store/authStore.ts
@@ -57,14 +57,16 @@ export interface AuthState {
 
   // UI state
   showAuthModal: boolean;
-  authModalView: 'login' | 'signup' | 'reset';
+  authModalView: 'login' | 'signup' | 'reset' | 'set-password';
   isFirstLaunchPrompt: boolean;
+  pendingDeepLinkType: 'recovery' | 'invite' | null;
 
   // Actions
   signIn: (email: string, password: string) => Promise<boolean>;
   signUp: (email: string, password: string) => Promise<boolean>;
   signOut: () => Promise<void>;
   resetPassword: (email: string) => Promise<boolean>;
+  updatePassword: (password: string) => Promise<boolean>;
   refreshAuthState: () => Promise<void>;
   refreshSyncStatus: () => Promise<void>;
   refreshLicenseStatus: () => Promise<void>;
@@ -74,9 +76,9 @@ export interface AuthState {
   activateDemoMode: () => Promise<void>;
 
   // UI actions
-  openAuthModal: (view?: 'login' | 'signup' | 'reset') => void;
+  openAuthModal: (view?: 'login' | 'signup' | 'reset' | 'set-password') => void;
   closeAuthModal: () => void;
-  setAuthModalView: (view: 'login' | 'signup' | 'reset') => void;
+  setAuthModalView: (view: 'login' | 'signup' | 'reset' | 'set-password') => void;
   setFirstLaunchPrompt: (value: boolean) => void;
   clearError: () => void;
 }
@@ -180,6 +182,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   showAuthModal: false,
   authModalView: 'login',
   isFirstLaunchPrompt: false,
+  pendingDeepLinkType: null,
 
   // Sign in
   signIn: async (email: string, password: string) => {
@@ -316,6 +319,42 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     }
   },
 
+  // Set new password (after recovery/invite deep link verification)
+  updatePassword: async (password: string) => {
+    if (password.length < 8) {
+      set({ error: 'Password must be at least 8 characters' });
+      return false;
+    }
+    set({ isLoading: true, error: null });
+
+    try {
+      const result = await window.api.auth.updatePassword(password);
+
+      if (result.success) {
+        await Promise.allSettled([
+          get().refreshAuthState(),
+          get().refreshLicenseStatus(),
+          get().refreshSyncStatus(),
+        ]);
+        set({
+          isLoading: false,
+          showAuthModal: false,
+          pendingDeepLinkType: null,
+        });
+        return true;
+      } else {
+        set({ isLoading: false, error: result.error || 'Password update failed' });
+        return false;
+      }
+    } catch (error) {
+      set({
+        isLoading: false,
+        error: error instanceof Error ? error.message : 'Password update failed',
+      });
+      return false;
+    }
+  },
+
   // Refresh auth state from main process
   refreshAuthState: async () => {
     try {
@@ -405,7 +444,12 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   },
 
   closeAuthModal: () => {
-    set({ showAuthModal: false, error: null, isFirstLaunchPrompt: false });
+    set({
+      showAuthModal: false,
+      error: null,
+      isFirstLaunchPrompt: false,
+      pendingDeepLinkType: null,
+    });
   },
 
   setAuthModalView: (view) => {

--- a/apps/desktop/src/renderer/src/store/shopOrderFileStore.ts
+++ b/apps/desktop/src/renderer/src/store/shopOrderFileStore.ts
@@ -9,6 +9,7 @@ interface ShopOrderFileStore {
   isSaving: boolean;
   isOpening: boolean;
   lastSavedAt: number | null;
+  errorMessage: string | null;
 
   // Actions
   setFilePath: (path: string | null) => void;
@@ -16,6 +17,7 @@ interface ShopOrderFileStore {
   setDirty: (dirty: boolean) => void;
   setSaving: (saving: boolean) => void;
   setOpening: (opening: boolean) => void;
+  clearError: () => void;
   newFile: (projectName: string) => void;
   openFile: (
     onSuccess?: (projectId: string, projectName: string) => Promise<void>,
@@ -33,6 +35,7 @@ export const useShopOrderFileStore = create<ShopOrderFileStore>((set, get) => ({
   isSaving: false,
   isOpening: false,
   lastSavedAt: null,
+  errorMessage: null,
 
   // Set file path
   setFilePath: (path) => set({ currentFilePath: path }),
@@ -48,6 +51,9 @@ export const useShopOrderFileStore = create<ShopOrderFileStore>((set, get) => ({
 
   // Set opening state
   setOpening: (opening) => set({ isOpening: opening }),
+
+  // Clear error message
+  clearError: () => set({ errorMessage: null }),
 
   // Get current filename
   getCurrentFileName: () => {
@@ -97,8 +103,7 @@ export const useShopOrderFileStore = create<ShopOrderFileStore>((set, get) => ({
 
       const result = await window.api.prep.file.import(filePath);
       if (!result.success) {
-        alert(result.error || 'Failed to open file');
-        set({ isOpening: false });
+        set({ isOpening: false, errorMessage: result.error || 'Failed to open file' });
         return false;
       }
 
@@ -119,8 +124,7 @@ export const useShopOrderFileStore = create<ShopOrderFileStore>((set, get) => ({
       return true;
     } catch (error) {
       logger.error('Error opening file:', error);
-      alert('Failed to open shop order');
-      set({ isOpening: false });
+      set({ isOpening: false, errorMessage: 'Failed to open shop order' });
       return false;
     }
   },
@@ -149,8 +153,7 @@ export const useShopOrderFileStore = create<ShopOrderFileStore>((set, get) => ({
       return true;
     } catch (error) {
       logger.error('Error saving file:', error);
-      alert('Failed to save shop order');
-      set({ isSaving: false });
+      set({ isSaving: false, errorMessage: 'Failed to save shop order' });
       return false;
     }
   },
@@ -179,8 +182,7 @@ export const useShopOrderFileStore = create<ShopOrderFileStore>((set, get) => ({
       return true;
     } catch (error) {
       logger.error('Error saving file:', error);
-      alert('Failed to save shop order');
-      set({ isSaving: false });
+      set({ isSaving: false, errorMessage: 'Failed to save shop order' });
       return false;
     }
   },

--- a/apps/desktop/src/renderer/src/store/shopOrderStore.ts
+++ b/apps/desktop/src/renderer/src/store/shopOrderStore.ts
@@ -184,10 +184,10 @@ export const useShopOrderStore = create<ShopOrderStore>((set, get) => ({
             const raw = {
               parent_project_id: data.parent_project_id,
               venue: parentProject.venue,
-              // logo_path is a local file path, not a URL — pass as storage path only;
-              // logo_url must be a valid URL or empty string per schema validation
+              // Map parent project logo to the unified logo_path field.
+              // logo_url must be empty or a valid HTTP URL per schema — local paths are not valid.
+              logo_path: parentProject.logo_path,
               logo_url: '',
-              logo_storage_path: parentProject.logo_path,
               // Map designers
               ld_name: parentProject.lighting_designer,
               ld_email: parentProject.lighting_designer_email,

--- a/apps/desktop/src/renderer/src/types/shopOrder.ts
+++ b/apps/desktop/src/renderer/src/types/shopOrder.ts
@@ -69,7 +69,8 @@ export interface ShopOrderProject {
   // Additional discipline contacts (stored as JSON)
   additional_contacts?: AdditionalContact[];
 
-  // Logo
+  // Logo — logo_path is the primary local-file field; logo_storage_path is kept for legacy backcompat
+  logo_path?: string;
   logo_url?: string;
   logo_storage_path?: string;
 

--- a/apps/desktop/src/renderer/src/utils/__tests__/revisionUtils.test.ts
+++ b/apps/desktop/src/renderer/src/utils/__tests__/revisionUtils.test.ts
@@ -12,7 +12,7 @@ import {
   parseSpareSnapshot,
   getDeltaIndicator,
 } from '../revisionUtils';
-import type { PrepEquipmentItem, RevisionQuantities, SpareSnapshot } from '../../types/shopOrder';
+import type { ShopOrderItem, RevisionQuantities, SpareSnapshot } from '../../types/shopOrder';
 
 /**
  * Revision Utilities Tests
@@ -22,8 +22,8 @@ import type { PrepEquipmentItem, RevisionQuantities, SpareSnapshot } from '../..
  */
 
 describe('revisionUtils - Table-Based Revision Tracking', () => {
-  // Helper to create a mock PrepEquipmentItem
-  const createMockItem = (overrides?: Partial<PrepEquipmentItem>): PrepEquipmentItem => ({
+  // Helper to create a mock ShopOrderItem
+  const createMockItem = (overrides?: Partial<ShopOrderItem>): ShopOrderItem => ({
     id: 'item-1',
     section_id: 'section-1',
     description: 'LED Par 64',

--- a/apps/desktop/src/renderer/src/utils/revisionUtils.ts
+++ b/apps/desktop/src/renderer/src/utils/revisionUtils.ts
@@ -1,12 +1,12 @@
 import { logger } from './logger';
-import type { PrepEquipmentItem, PrepSection, ItemChange, ChangeType } from '../types/shopOrder';
+import type { ShopOrderItem, ShopOrderSection, ItemChange, ChangeType } from '../types/shopOrder';
 
 /**
  * Snapshot of project state for revision comparison
  */
 export interface ProjectSnapshot {
-  items: PrepEquipmentItem[];
-  sections: PrepSection[];
+  items: ShopOrderItem[];
+  sections: ShopOrderSection[];
   timestamp: number;
 }
 
@@ -16,7 +16,7 @@ export interface ProjectSnapshot {
 export function detectChanges(
   previousSnapshot: ProjectSnapshot,
   currentSnapshot: ProjectSnapshot,
-  sectionsMap: Map<string, PrepSection>,
+  sectionsMap: Map<string, ShopOrderSection>,
 ): ItemChange[] {
   const changes: ItemChange[] = [];
 
@@ -63,11 +63,11 @@ export function detectChanges(
       });
     } else {
       // Check for modifications
-      const modifications: Partial<PrepEquipmentItem> = {};
-      const oldValues: Partial<PrepEquipmentItem> = {};
+      const modifications: Partial<ShopOrderItem> = {};
+      const oldValues: Partial<ShopOrderItem> = {};
 
       // Compare relevant fields
-      const fieldsToCompare: (keyof PrepEquipmentItem)[] = [
+      const fieldsToCompare: (keyof ShopOrderItem)[] = [
         'description',
         'active_qty',
         'spare_qty',
@@ -79,8 +79,8 @@ export function detectChanges(
 
       for (const field of fieldsToCompare) {
         if (prevItem[field] !== currItem[field]) {
-          modifications[field] = currItem[field] as any;
-          oldValues[field] = prevItem[field] as any;
+          (modifications as ShopOrderItem)[field] = currItem[field];
+          (oldValues as ShopOrderItem)[field] = prevItem[field];
         }
       }
 
@@ -112,8 +112,8 @@ export function detectChanges(
  * Create a snapshot of current project state
  */
 export function createSnapshot(
-  items: PrepEquipmentItem[],
-  sections: PrepSection[],
+  items: ShopOrderItem[],
+  sections: ShopOrderSection[],
 ): ProjectSnapshot {
   return {
     items: items.map((item) => ({ ...item })), // Deep copy
@@ -152,10 +152,8 @@ export function formatChange(change: ItemChange): string {
   } else if (change.change_type === 'modification') {
     const mods: string[] = [];
     if (change.old_values && change.new_values) {
-      for (const key of Object.keys(change.new_values)) {
-        mods.push(
-          `${key}: ${(change.old_values as any)[key]} → ${(change.new_values as any)[key]}`,
-        );
+      for (const key of Object.keys(change.new_values) as Array<keyof ShopOrderItem>) {
+        mods.push(`${key}: ${change.old_values[key]} → ${change.new_values[key]}`);
       }
     }
     details = mods.length > 0 ? ` (${mods.join(', ')})` : '';
@@ -195,7 +193,7 @@ export function stringifyRevisionQuantities(quantities: RevisionQuantities): str
 /**
  * Get active quantity for a specific revision
  */
-export function getRevisionQuantity(item: PrepEquipmentItem, revisionNumber: number): number {
+export function getRevisionQuantity(item: ShopOrderItem, revisionNumber: number): number {
   const quantities = parseRevisionQuantities(item.revision_quantities);
   return quantities[revisionNumber] || 0;
 }
@@ -204,10 +202,10 @@ export function getRevisionQuantity(item: PrepEquipmentItem, revisionNumber: num
  * Set active quantity for a specific revision
  */
 export function setRevisionQuantity(
-  item: PrepEquipmentItem,
+  item: ShopOrderItem,
   revisionNumber: number,
   quantity: number,
-): PrepEquipmentItem {
+): ShopOrderItem {
   const quantities = parseRevisionQuantities(item.revision_quantities);
   quantities[revisionNumber] = quantity;
   return {
@@ -219,7 +217,7 @@ export function setRevisionQuantity(
 /**
  * Get all revision numbers for an item
  */
-export function getItemRevisions(item: PrepEquipmentItem): number[] {
+export function getItemRevisions(item: ShopOrderItem): number[] {
   const quantities = parseRevisionQuantities(item.revision_quantities);
   return Object.keys(quantities)
     .map(Number)
@@ -229,7 +227,7 @@ export function getItemRevisions(item: PrepEquipmentItem): number[] {
 /**
  * Calculate total quantity (max of all revisions + spare)
  */
-export function calculateTotalQuantity(item: PrepEquipmentItem): number {
+export function calculateTotalQuantity(item: ShopOrderItem): number {
   const quantities = parseRevisionQuantities(item.revision_quantities);
   const maxActive = Math.max(...Object.values(quantities), 0);
   return maxActive + (item.spare_qty || 0);
@@ -238,7 +236,7 @@ export function calculateTotalQuantity(item: PrepEquipmentItem): number {
 /**
  * Calculate rental quantity (total - venue)
  */
-export function calculateRentalQuantity(item: PrepEquipmentItem): number {
+export function calculateRentalQuantity(item: ShopOrderItem): number {
   const total = calculateTotalQuantity(item);
   return total - (item.venue_qty || 0);
 }
@@ -247,7 +245,7 @@ export function calculateRentalQuantity(item: PrepEquipmentItem): number {
  * Detect changes between two revisions using revision_quantities
  */
 export function detectRevisionChanges(
-  items: PrepEquipmentItem[],
+  items: ShopOrderItem[],
   fromRevision: number,
   toRevision: number,
   previousSpareSnapshot?: SpareSnapshot,
@@ -312,7 +310,7 @@ export function detectRevisionChanges(
 /**
  * Create spare snapshot for a revision
  */
-export function createSpareSnapshot(items: PrepEquipmentItem[]): SpareSnapshot {
+export function createSpareSnapshot(items: ShopOrderItem[]): SpareSnapshot {
   const snapshot: SpareSnapshot = {};
   for (const item of items) {
     snapshot[item.id] = item.spare_qty || 0;
@@ -337,7 +335,7 @@ export function parseSpareSnapshot(jsonString?: string): SpareSnapshot {
  * Get DELTA indicator for print view (+/-/~)
  */
 export function getDeltaIndicator(
-  item: PrepEquipmentItem,
+  item: ShopOrderItem,
   currentRevision: number,
   previousRevision?: number,
 ): string {

--- a/docs/development/lighting_project_status.md
+++ b/docs/development/lighting_project_status.md
@@ -55,21 +55,6 @@ These items are either actively deferred or waiting on a dependency. Address bef
 - ⬜ **Auto-updater maintenance gate** — Block updates released after `maintenanceEndDate` on a license.
 - ⬜ **Supabase dashboard** — Add `showstack://*` to Auth → URL Configuration → Redirect URLs (required for email verification deep link to complete). _Manual step — cannot be done in code._
 
-### Telemetry (Issue #62 — partial)
-
-- ⬜ Batch flush on app quit — ensure events are not lost on clean shutdown
-- ⬜ Retry backoff improvements for failed sync attempts
-
-### Backup Service (Issue #79 — partial)
-
-- ⬜ SHA-256 integrity checksums on backup metadata
-- ⬜ Auto-backup hooks before destructive operations (project delete, migrations)
-
-### Security / Auth Follow-ups (Issue #81 — partial)
-
-- ⬜ Audit session token storage for compliance requirements
-- ⬜ Review `demo_mode` bypass paths for license checks
-
 ### Developer / Admin
 
 - ⬜ **Feature flag system** — Connect Developer Mode toggle to a feature flag system for controlled rollouts / A/B testing. (Issue #35, 95% complete — flags layer missing)
@@ -224,6 +209,9 @@ _Note: Supersedes Issue #40 (Maintenance Menu) and Issue #29 (Shop Order from Sy
 - ✅ **Issue #65 — Shop order error handling** — Replaced `alert()` calls in `shopOrderFileStore` with `errorMessage` state; `ShopOrderFileMenu` displays errors inline with click-to-dismiss.
 - ✅ **Issue #79 — Backup compression** — Backups now stored as `.db.gz` (gzip via `stream/promises` pipeline); restore transparently decompresses; legacy uncompressed `.db` backups still supported.
 - ✅ **Issue #84 — Logo URL mapping for shop orders** — `logo_path` field added to `ShopOrderProject` type; store maps parent project `logo_path` to the correct field instead of silently dropping it; `PageRenderer` uses typed fields without `as any`.
+- ✅ **Issue #62 — Telemetry batch flush on quit** — `telemetry.shutdown()` now calls `posthog.shutdown(3000)` instead of `posthog.reset()`, flushing queued events before the Electron process exits (3 s timeout prevents hangs). PostHog SDK handles network retry backoff internally — no additional implementation needed.
+- ✅ **Issue #79 — Backup integrity checksums** — `BackupService` computes SHA-256 checksums of both `.db.gz` files after each backup and persists them in metadata; checksums are verified before restore and abort with an error on mismatch. Auto-backup hook added to `ShopOrderProjectService.delete()` matching the existing `ProjectService.delete()` pattern.
+- ✅ **Issue #81 — Session token & demo mode audit** — Supabase SDK stores session tokens in Electron's sandboxed `localStorage` (acceptable for desktop). `demo_mode` is properly gated: `canSync: false`, `canCollaborate: false`, explicit downgrade protection in `LicenseService`. No code changes required.
 
 ---
 

--- a/docs/development/lighting_project_status.md
+++ b/docs/development/lighting_project_status.md
@@ -1,19 +1,16 @@
 # ShowStack — Lighting Edition Status
 
-**Last Updated:** March 11, 2026
+**Last Updated:** March 12, 2026
 **Edition Price:** $249/year
 **Target Users:** Lighting Designers, Production Electricians, Master Electricians
 **Competes With:** LightWright 6 ($845 one-time)
-**Overall Completion:** ~90%
+**Overall Completion:** ~91%
 
 ---
 
 ## ⚠️ Priority Flags
 
-Issues requiring immediate attention before 1.0:
-
-- **#81 — Security follow-ups from PR #80 (licensing)** — Supabase email verification enforcement must be confirmed; unclaimed license RLS policy creates a visibility window if email verification is not required. Rate-limiting on `license:getStatus` IPC (renderer can hammer it). _Security/abuse concern — verify before launch._
-- **#62 — Telemetry: unbounded event growth** — If network is down for an extended period, unsynced telemetry events can grow without bound. High-priority item per the issue. _Data integrity risk — address before beta._
+All pre-1.0 priority flags resolved. ✅
 
 ---
 
@@ -45,49 +42,31 @@ These items are either actively deferred or waiting on a dependency. Address bef
 - ⬜ **Network Topology Visualization** — Visual network layout diagram for infrastructure. (Issue #19)
 - ⬜ **Real-time Port Status Monitoring** — Ping/connectivity checks, port up/down status, SNMP integration, status dashboard. (Issue #20)
 
-### Shop Orders (Post-Migration Improvements)
+### Shop Orders
 
-Non-critical enhancements identified during PR #63 and #64 review:
-
-**Should Fix Soon (Issue #65):**
-
-- ⬜ Standardize error handling (use toast notifications consistently; remove bare `alert()` calls)
 - ⬜ Add integration tests for critical shop order workflows
 - ⬜ Virtual scrolling for large tables (500+ items)
-- ⬜ Extract configuration constants to a separate file
 - ⬜ E2E tests with Playwright for shop order flow
-
-**Medium Priority (Issue #64):**
-
-- ⬜ Type safety improvements — remove `as any` in `revisionUtils.ts:81-82`
 - ⬜ Performance optimization for large revision sets
-- ⬜ Additional unit test coverage
-
-**Logo URL mapping (Issue #84):**
-
-- ⬜ Map parent project `logo_path` (local FS path) to a usable URL/base64 when creating a shop order from a project. Currently silently drops the logo.
 
 ### Cloud Services
 
 - ⬜ **E-commerce webhook → Supabase Edge Function** — Auto-fulfill license purchases from Stripe/Shopify.
 - ⬜ **Auto-updater maintenance gate** — Block updates released after `maintenanceEndDate` on a license.
+- ⬜ **Supabase dashboard** — Add `showstack://*` to Auth → URL Configuration → Redirect URLs (required for email verification deep link to complete). _Manual step — cannot be done in code._
 
-### Telemetry (Issue #62)
+### Telemetry (Issue #62 — partial)
 
-- ⬜ Add max unsynced events limit to prevent unbounded growth when offline (🔴 High Priority per issue)
 - ⬜ Batch flush on app quit — ensure events are not lost on clean shutdown
 - ⬜ Retry backoff improvements for failed sync attempts
 
-### Backup Service (Issue #79)
+### Backup Service (Issue #79 — partial)
 
-- ⬜ Backup compression (gzip/zstd) — 10 backups currently = 20× database size
 - ⬜ SHA-256 integrity checksums on backup metadata
 - ⬜ Auto-backup hooks before destructive operations (project delete, migrations)
 
-### Security / Auth Follow-ups (Issue #81)
+### Security / Auth Follow-ups (Issue #81 — partial)
 
-- ⬜ Confirm Supabase email verification is enforced (RLS on unclaimed licenses depends on it)
-- ⬜ Rate-limit `license:getStatus` IPC handler to prevent renderer hammering
 - ⬜ Audit session token storage for compliance requirements
 - ⬜ Review `demo_mode` bypass paths for license checks
 
@@ -236,13 +215,22 @@ _Note: Supersedes Issue #40 (Maintenance Menu) and Issue #29 (Shop Order from Sy
 - ✅ **Multi-user collaboration (PR #85)** — Invite/remove/accept/decline via Supabase RPCs; real-time presence; RLS + license gate (migrations 005–016).
 - ✅ **PowerSync write-path (PR #87)** — Projects and shop orders written to PowerSync on create/update/delete; fixes TOCTOU ownership race (Issue #86, closed). Student-tier cloud sync eligibility still TBD.
 
+### Pre-1.0 Fixes (branch `feature/pre-1.0-fixes`, March 12, 2026)
+
+- ✅ **Issue #81 — Email verification deep link** — `showstack://` custom URL scheme registered; main process receives `open-url`/`second-instance` callbacks and forwards to renderer via `auth:deepLink` IPC. New `auth:exchangeDeepLink` handler calls `supabase.auth.setSession()` to complete verification. `signUp` now returns `emailConfirmationRequired` flag. Renderer refreshes auth/license/sync state on successful exchange. _Supabase dashboard redirect URL still requires manual configuration — see pending items._
+- ✅ **Issue #81 — `license:getStatus` rate limiting** — IPC handler caches result for 2 seconds to prevent renderer hammering.
+- ✅ **Issue #62 — Telemetry unbounded growth** — Added `MAX_UNSYNCED_EVENTS = 500` cap; oldest unsynced event dropped when offline queue exceeds limit (separate from the 1,000 total cap).
+- ✅ **Issue #64 — Type safety in revisionUtils** — Replaced all `PrepEquipmentItem`/`PrepSection` references (types were renamed) with `ShopOrderItem`/`ShopOrderSection`; removed all `as any` casts in revision diff logic.
+- ✅ **Issue #65 — Shop order error handling** — Replaced `alert()` calls in `shopOrderFileStore` with `errorMessage` state; `ShopOrderFileMenu` displays errors inline with click-to-dismiss.
+- ✅ **Issue #79 — Backup compression** — Backups now stored as `.db.gz` (gzip via `stream/promises` pipeline); restore transparently decompresses; legacy uncompressed `.db` backups still supported.
+- ✅ **Issue #84 — Logo URL mapping for shop orders** — `logo_path` field added to `ShopOrderProject` type; store maps parent project `logo_path` to the correct field instead of silently dropping it; `PageRenderer` uses typed fields without `as any`.
+
 ---
 
 ## 📋 Known Technical Debt
 
 - `useModuleAccess.ts` may need renaming to `useEditionAccess.ts` for clarity.
 - ESLint warning count is exactly at the CI threshold (855). Reducing to 0 is a tracked goal.
-- Shop order `alert()` calls should migrate to toast notifications (Issue #65).
 - Issue #51 (Equipment Manager export) — CSV, Eos, GrandMA2, GrandMA3 exports are all TODO stubs. Menu is wired; implementations still needed.
 - Issue #40 (Maintenance Menu) closed — superseded by Smart Groups. Per-column maintenance menu and 4-tab notes dialog not implemented; re-open if user feedback demands.
 - Issue #29 (Shop Order from System Docs) closed — superseded by Smart Groups Phase 4.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2881,16 +2881,16 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.11.0.tgz",
-      "integrity": "sha512-n6oQX6mYkG8TRPuPXmbPidkUbsSRalhmaaVAQxvH1IkQy63cwsH+kOjB3e4cpCDHg0aSvsiX9bQ4s2VB6mGWUQ==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.0.tgz",
+      "integrity": "sha512-46BZJYJjc/WwmKjsvDFykHtXrtomsCIrwYQPOP7VfMJoZY2bsDF9oROBABR3paDjDcmkUye1Pb1BqdcdiipaWA==",
       "license": "Apache-2.0",
       "dependencies": {
         "debug": "^4.4.3",
         "extract-zip": "^2.0.1",
         "progress": "^2.0.3",
         "proxy-agent": "^6.5.0",
-        "semver": "^7.7.3",
+        "semver": "^7.7.4",
         "tar-fs": "^3.1.1",
         "yargs": "^17.7.2"
       },
@@ -2902,9 +2902,9 @@
       }
     },
     "node_modules/@puppeteer/browsers/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -5075,9 +5075,9 @@
       }
     },
     "node_modules/b4a": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
-      "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "react-native-b4a": "*"
@@ -5112,11 +5112,10 @@
       }
     },
     "node_modules/bare-fs": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.2.tgz",
-      "integrity": "sha512-veTnRzkb6aPHOvSKIOy60KzURfBdUflr5VReI+NSaPL6xf+XLdONQgZgpYvUuZLVQ8dCqxpBAudaOM1+KpAUxw==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.5.tgz",
+      "integrity": "sha512-XvwYM6VZqKoqDll8BmSww5luA5eflDzY0uEFfBJtFKe4PAAtxBjU3YIxzIBzhyaEQBy1VXEQBto4cpN5RZJw+w==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "bare-events": "^2.5.4",
         "bare-path": "^3.0.0",
@@ -5137,11 +5136,10 @@
       }
     },
     "node_modules/bare-os": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz",
-      "integrity": "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.0.tgz",
+      "integrity": "sha512-Dc9/SlwfxkXIGYhvMQNUtKaXCaGkZYGcd1vuNUUADVqzu4/vQfvnMkYYOUnt2VwQ2AqKr/8qAVFRtwETljgeFg==",
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "bare": ">=1.14.0"
       }
@@ -5151,19 +5149,18 @@
       "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
       "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "bare-os": "^3.0.1"
       }
     },
     "node_modules/bare-stream": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz",
-      "integrity": "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.8.1.tgz",
+      "integrity": "sha512-bSeR8RfvbRwDpD7HWZvn8M3uYNDrk7m9DQjYOFkENZlXW8Ju/MPaqUPQq5LqJ3kyjEm07siTaAQ7wBKCU59oHg==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
-        "streamx": "^2.21.0"
+        "streamx": "^2.21.0",
+        "teex": "^1.0.1"
       },
       "peerDependencies": {
         "bare-buffer": "*",
@@ -5183,7 +5180,6 @@
       "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
       "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "bare-path": "^3.0.0"
       }
@@ -5713,9 +5709,9 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-12.0.1.tgz",
-      "integrity": "sha512-fGg+6jr0xjQhzpy5N4ErZxQ4wF7KLEvhGZXD6EgvZKDhu7iOhZXnZhcDxPJDcwTcrD48NPzOCo84RP2lv3Z+Cg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
+      "integrity": "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==",
       "license": "Apache-2.0",
       "dependencies": {
         "mitt": "^3.0.1",
@@ -6255,9 +6251,9 @@
       "optional": true
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1534754",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1534754.tgz",
-      "integrity": "sha512-26T91cV5dbOYnXdJi5qQHoTtUoNEqwkHcAyu/IKtjIAxiEqPMrDiRkDOPWVsGfNZGmlQVHQbZRSjD8sxagWVsQ==",
+      "version": "0.0.1581282",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
+      "integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
       "license": "BSD-3-Clause"
     },
     "node_modules/didyoumean": {
@@ -6477,9 +6473,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "39.2.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-39.2.1.tgz",
-      "integrity": "sha512-5oSki3qzLBsJAcXl0yWOLRArkufugbXd1qBb2UNZRrrKkYiVhM8GLE+KE3P16PC8UxGxGqCCfaB3Y1TK1dUuHg==",
+      "version": "39.8.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-39.8.2.tgz",
+      "integrity": "sha512-uwNJHeqm8pzQEZf/KX4XM1fJctZpHcA0Za/MlP9mOg0FAWHbKo6yRC33QbdfLX7PeNjYZC3I3nnVhE5L2CLqxw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -7457,9 +7453,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -10787,18 +10783,18 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "24.34.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.34.0.tgz",
-      "integrity": "sha512-Sdpl/zsYOsagZ4ICoZJPGZw8d9gZmK5DcxVal11dXi/1/t2eIXHjCf5NfmhDg5XnG9Nye+yo/LqMzIxie2rHTw==",
+      "version": "24.39.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.39.1.tgz",
+      "integrity": "sha512-68Zc9QpcVvfxp2C+3UL88TyUogEAn5tSylXidbEuEXvhiqK1+v65zeBU5ubinAgEHMGr3dcSYqvYrGtdzsPI3w==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.11.0",
-        "chromium-bidi": "12.0.1",
+        "@puppeteer/browsers": "2.13.0",
+        "chromium-bidi": "14.0.0",
         "cosmiconfig": "^9.0.0",
-        "devtools-protocol": "0.0.1534754",
-        "puppeteer-core": "24.34.0",
-        "typed-query-selector": "^2.12.0"
+        "devtools-protocol": "0.0.1581282",
+        "puppeteer-core": "24.39.1",
+        "typed-query-selector": "^2.12.1"
       },
       "bin": {
         "puppeteer": "lib/cjs/puppeteer/node/cli.js"
@@ -10808,18 +10804,18 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "24.34.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.34.0.tgz",
-      "integrity": "sha512-24evawO+mUGW4mvS2a2ivwLdX3gk8zRLZr9HP+7+VT2vBQnm0oh9jJEZmUE3ePJhRkYlZ93i7OMpdcoi2qNCLg==",
+      "version": "24.39.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.39.1.tgz",
+      "integrity": "sha512-AMqQIKoEhPS6CilDzw0Gd1brLri3emkC+1N2J6ZCCuY1Cglo56M63S0jOeBZDQlemOiRd686MYVMl9ELJBzN3A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.11.0",
-        "chromium-bidi": "12.0.1",
+        "@puppeteer/browsers": "2.13.0",
+        "chromium-bidi": "14.0.0",
         "debug": "^4.4.3",
-        "devtools-protocol": "0.0.1534754",
-        "typed-query-selector": "^2.12.0",
-        "webdriver-bidi-protocol": "0.3.10",
-        "ws": "^8.18.3"
+        "devtools-protocol": "0.0.1581282",
+        "typed-query-selector": "^2.12.1",
+        "webdriver-bidi-protocol": "0.4.1",
+        "ws": "^8.19.0"
       },
       "engines": {
         "node": ">=18"
@@ -11928,9 +11924,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
-      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
       "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0",
@@ -11942,12 +11938,13 @@
       }
     },
     "node_modules/tar-stream": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
-      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
+      "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
       "license": "MIT",
       "dependencies": {
         "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
       }
@@ -11960,6 +11957,15 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
       }
     },
     "node_modules/temp": {
@@ -12063,9 +12069,9 @@
       }
     },
     "node_modules/text-decoder": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
-      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.4"
@@ -12913,9 +12919,9 @@
       }
     },
     "node_modules/typed-query-selector": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
-      "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.1.tgz",
+      "integrity": "sha512-uzR+FzI8qrUEIu96oaeBJmd9E7CFEiQ3goA5qCVgc4s5llSubcfGHq9yUstZx/k4s9dXHVKsE35YWoFyvEqEHA==",
       "license": "MIT"
     },
     "node_modules/typescript": {
@@ -12969,9 +12975,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.22.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
-      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "version": "7.24.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.1.tgz",
+      "integrity": "sha512-5xoBibbmnjlcR3jdqtY2Lnx7WbrD/tHlT01TmvqZUFVc9Q1w4+j5hbnapTqbcXITMH1ovjq/W7BkqBilHiVAaA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -13310,9 +13316,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/webdriver-bidi-protocol": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.3.10.tgz",
-      "integrity": "sha512-5LAE43jAVLOhB/QqX4bwSiv0Hg1HBfMmOuwBSXHdvg4GMGu9Y0lIq7p4R/yySu6w74WmaR4GM4H9t2IwLW7hgw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
+      "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
       "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
@@ -13448,9 +13454,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/packages/shared/src/auth/passwordPolicy.ts
+++ b/packages/shared/src/auth/passwordPolicy.ts
@@ -1,0 +1,20 @@
+/**
+ * Password policy constants and validator — single source of truth for both
+ * the main process (IPC handler) and the renderer (SetPasswordForm).
+ */
+
+export const PASSWORD_MIN_LENGTH = 8;
+export const PASSWORD_REQUIRES_NUMBER = true;
+
+/**
+ * Returns an error message string if the password is invalid, or null if valid.
+ */
+export function validatePassword(password: string): string | null {
+  if (!password || password.length < PASSWORD_MIN_LENGTH) {
+    return `Password must be at least ${PASSWORD_MIN_LENGTH} characters`;
+  }
+  if (PASSWORD_REQUIRES_NUMBER && !/\d/.test(password)) {
+    return 'Password must contain at least one number';
+  }
+  return null;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -13,3 +13,6 @@ export const SHARED_VERSION = '0.1.0-alpha';
 
 // Validation schemas and utilities
 export * from './validation';
+
+// Auth utilities
+export * from './auth/passwordPolicy';


### PR DESCRIPTION
## Summary

- **Issue #62** — Telemetry batch flush on quit: replaced `posthog.reset()` with `posthog.shutdown(3000)` so queued events are flushed before Electron exits; unbounded queue growth capped at 500 unsynced events
- **Issue #79** — Backup integrity: SHA-256 checksums computed and stored in backup metadata after each backup; verified before restore (aborts on mismatch); auto-backup hook added to `ShopOrderProjectService.delete()` to match `ProjectService`
- **Issue #81** — Email verification deep link: `showstack://` URL scheme registered; `auth:exchangeDeepLink` IPC handler supports both hash-fragment (`setSession`) and query-string (`verifyOtp`) Supabase token formats; password reset and invite flows route to new `SetPasswordForm`; `license:getStatus` rate-limited at 2 s; session token and demo mode audited (no code changes required)
- **Issue #64** — Type safety in `revisionUtils`: replaced all `PrepEquipmentItem`/`PrepSection` references with `ShopOrderItem`/`ShopOrderSection`; removed all `as any` casts
- **Issue #65** — Shop order error handling: replaced `alert()` calls with inline `errorMessage` state
- **Issue #84** — Logo URL mapping for shop orders: `logo_path` wired correctly through the store and `PageRenderer`

## Test plan

- [ ] All existing tests pass (`npm run test:run` — 1,933+ tests)
- [ ] TypeScript clean (`npx tsc --noEmit`)
- [ ] Sign in, trigger password reset email, click link → app opens and shows Set Password form
- [ ] Accept a collaboration invite email → app opens and prompts for password
- [ ] Create and delete a shop order project → verify a backup file is written before delete
- [ ] Backup and restore a project → confirm restore succeeds only when checksums match

🤖 Generated with [Claude Code](https://claude.com/claude-code)