### PR TITLE
feat: MVR export (#30)

### DIFF
--- a/apps/desktop/src/main/ipc/mvr.ts
+++ b/apps/desktop/src/main/ipc/mvr.ts
@@ -101,14 +101,16 @@ export function registerMvrHandlers(): void {
    * Opens a native save dialog, writes the ZIP, returns a summary.
    */
   ipcMain.handle('mvr:export', async (_event, projectId: string): Promise<MvrExportIpcResult> => {
+    const failure = (extra: Partial<MvrExportIpcResult> = {}): MvrExportIpcResult => ({
+      success: false,
+      fixtureCount: 0,
+      layerCount: 0,
+      gdtfBundled: 0,
+      ...extra,
+    });
+
     if (typeof projectId !== 'string' || !projectId) {
-      return {
-        success: false,
-        error: 'No project ID provided',
-        fixtureCount: 0,
-        layerCount: 0,
-        gdtfBundled: 0,
-      };
+      return failure({ error: 'No project ID provided' });
     }
 
     const project = getProjectById(projectId);
@@ -124,11 +126,11 @@ export function registerMvrHandlers(): void {
     });
 
     if (dialogResult.canceled || !dialogResult.filePath) {
-      return { success: false, canceled: true, fixtureCount: 0, layerCount: 0, gdtfBundled: 0 };
+      return failure({ canceled: true });
     }
 
     try {
-      const result = mvrExportService.export(projectId, dialogResult.filePath, projectName);
+      const result = await mvrExportService.export(projectId, dialogResult.filePath, projectName);
       logger.info('MVR export IPC complete', {
         fixtureCount: result.fixtureCount,
         layerCount: result.layerCount,
@@ -138,7 +140,7 @@ export function registerMvrHandlers(): void {
     } catch (err) {
       const error = err instanceof Error ? err.message : String(err);
       logger.error('MVR export failed', { projectId, error });
-      return { success: false, error, fixtureCount: 0, layerCount: 0, gdtfBundled: 0 };
+      return failure({ error });
     }
   });
 

--- a/apps/desktop/src/main/ipc/mvr.ts
+++ b/apps/desktop/src/main/ipc/mvr.ts
@@ -1,6 +1,8 @@
 import { ipcMain, dialog } from 'electron';
 import { mvrService } from '../services/MvrService';
+import { mvrExportService, MvrExportResult } from '../services/MvrExportService';
 import { createFixture } from '../database/queries/fixtures';
+import { getProjectById } from '../database/queries/projects';
 import { logger } from '../utils/logger';
 
 export interface MvrImportResult {
@@ -12,8 +14,13 @@ export interface MvrImportResult {
   warnings: string[];
 }
 
+export interface MvrExportIpcResult extends MvrExportResult {
+  canceled?: boolean;
+}
+
 export function registerMvrHandlers(): void {
   ipcMain.removeHandler('mvr:import');
+  ipcMain.removeHandler('mvr:export');
 
   /**
    * Open a native file dialog for an .mvr file, parse it, and bulk-create
@@ -86,6 +93,52 @@ export function registerMvrHandlers(): void {
       const error = err instanceof Error ? err.message : String(err);
       logger.error('MVR import failed', { filePath, error });
       return { success: false, error, created: 0, gdtfResolved: 0, warnings: [] };
+    }
+  });
+
+  /**
+   * Export project fixtures to an MVR file.
+   * Opens a native save dialog, writes the ZIP, returns a summary.
+   */
+  ipcMain.handle('mvr:export', async (_event, projectId: string): Promise<MvrExportIpcResult> => {
+    if (typeof projectId !== 'string' || !projectId) {
+      return {
+        success: false,
+        error: 'No project ID provided',
+        fixtureCount: 0,
+        layerCount: 0,
+        gdtfBundled: 0,
+      };
+    }
+
+    const project = getProjectById(projectId);
+    const projectName = project?.name ?? 'ShowStack Export';
+
+    const dialogResult = await dialog.showSaveDialog({
+      title: 'Export MVR File',
+      defaultPath: `${projectName.replace(/[^a-z0-9_\-\s]/gi, '_')}.mvr`,
+      filters: [
+        { name: 'My Virtual Rig', extensions: ['mvr'] },
+        { name: 'All Files', extensions: ['*'] },
+      ],
+    });
+
+    if (dialogResult.canceled || !dialogResult.filePath) {
+      return { success: false, canceled: true, fixtureCount: 0, layerCount: 0, gdtfBundled: 0 };
+    }
+
+    try {
+      const result = mvrExportService.export(projectId, dialogResult.filePath, projectName);
+      logger.info('MVR export IPC complete', {
+        fixtureCount: result.fixtureCount,
+        layerCount: result.layerCount,
+        gdtfBundled: result.gdtfBundled,
+      });
+      return result;
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      logger.error('MVR export failed', { projectId, error });
+      return { success: false, error, fixtureCount: 0, layerCount: 0, gdtfBundled: 0 };
     }
   });
 

--- a/apps/desktop/src/main/services/MvrExportService.ts
+++ b/apps/desktop/src/main/services/MvrExportService.ts
@@ -32,6 +32,8 @@ const xmlBuilder = new XMLBuilder({
   suppressEmptyNode: true,
 });
 
+const MM_TO_METERS = 0.001;
+
 /**
  * Convert ShowStack manufacturer+model to GDTFSpec filename format.
  * Spaces → underscores; format: {Manufacturer}@{Model}@Rev.gdtf
@@ -44,9 +46,9 @@ function toGdtfSpec(manufacturer: string, model: string): string {
 
 /**
  * Look up the cached GDTF file path for a fixture from gdtf_cache.
- * Returns the file path if found, null otherwise.
+ * Returns the file path if found and accessible, null otherwise.
  */
-function lookupCachedGdtfPath(manufacturer: string, model: string): string | null {
+async function lookupCachedGdtfPath(manufacturer: string, model: string): Promise<string | null> {
   const db = getAppDatabase();
   const id = `${manufacturer}/${model}`;
 
@@ -65,14 +67,15 @@ function lookupCachedGdtfPath(manufacturer: string, model: string): string | nul
   if (!row?.file_path) return null;
 
   try {
-    if (fs.existsSync(row.file_path)) return row.file_path;
+    await fs.promises.access(row.file_path);
+    return row.file_path;
   } catch (err) {
     logger.warn('Error checking GDTF file existence', {
       path: row.file_path,
       error: err instanceof Error ? err.message : String(err),
     });
+    return null;
   }
-  return null;
 }
 
 export class MvrExportService {
@@ -97,15 +100,19 @@ export class MvrExportService {
     // Collect GDTF files to bundle (deduplicated by spec filename)
     const gdtfFiles = new Map<string, string>(); // specFilename → local file path
 
-    // Build Layer elements
-    const layers = Array.from(byPosition.entries()).map(([posName, posFixtures]) => {
-      const fixtures = posFixtures.map((f) => this.buildFixtureElement(f, gdtfFiles));
-      return {
-        '@_name': posName,
-        '@_uuid': this.pseudoUuid(posName),
-        ChildList: fixtures.length > 0 ? { Fixture: fixtures } : undefined,
-      };
-    });
+    // Build Layer elements (async to allow non-blocking GDTF path lookups)
+    const layers = await Promise.all(
+      Array.from(byPosition.entries()).map(async ([posName, posFixtures]) => {
+        const fixtureElements = await Promise.all(
+          posFixtures.map((f) => this.buildFixtureElement(f, gdtfFiles)),
+        );
+        return {
+          '@_name': posName,
+          '@_uuid': this.pseudoUuid(posName),
+          ChildList: fixtureElements.length > 0 ? { Fixture: fixtureElements } : undefined,
+        };
+      }),
+    );
 
     // Build the full XML document object
     const doc = {
@@ -170,7 +177,10 @@ export class MvrExportService {
     return result;
   }
 
-  private buildFixtureElement(f: Fixture, gdtfFiles: Map<string, string>): Record<string, unknown> {
+  private async buildFixtureElement(
+    f: Fixture,
+    gdtfFiles: Map<string, string>,
+  ): Promise<Record<string, unknown>> {
     const el: Record<string, unknown> = {
       '@_name': f.type ?? f.model ?? 'Fixture',
       '@_uuid': f.id,
@@ -185,7 +195,7 @@ export class MvrExportService {
       }
       // Register GDTF file for bundling if available in cache
       if (!gdtfFiles.has(specFilename)) {
-        const cachedPath = lookupCachedGdtfPath(f.manufacturer, f.model);
+        const cachedPath = await lookupCachedGdtfPath(f.manufacturer, f.model);
         if (cachedPath) {
           gdtfFiles.set(specFilename, cachedPath);
         }
@@ -193,7 +203,7 @@ export class MvrExportService {
     }
 
     // DMX address (absolute: (universe-1)*512 + dmx_address)
-    if (f.universe != null && f.dmx_address != null) {
+    if (f.universe != null && f.universe > 0 && f.dmx_address != null && f.dmx_address > 0) {
       const absoluteAddr = (f.universe - 1) * 512 + f.dmx_address;
       el.Addresses = {
         Address: {
@@ -208,12 +218,10 @@ export class MvrExportService {
 
     // Optional: 3D position from VW coordinates
     if (f.vw_x_coordinate != null && f.vw_y_coordinate != null && f.vw_z_coordinate != null) {
-      // MVR uses metres; VW coordinates are typically in mm — convert
-      const scale = 0.001;
       el.Position = {
-        '@_x': (f.vw_x_coordinate * scale).toFixed(4),
-        '@_y': (f.vw_y_coordinate * scale).toFixed(4),
-        '@_z': (f.vw_z_coordinate * scale).toFixed(4),
+        '@_x': (f.vw_x_coordinate * MM_TO_METERS).toFixed(4),
+        '@_y': (f.vw_y_coordinate * MM_TO_METERS).toFixed(4),
+        '@_z': (f.vw_z_coordinate * MM_TO_METERS).toFixed(4),
       };
     }
 

--- a/apps/desktop/src/main/services/MvrExportService.ts
+++ b/apps/desktop/src/main/services/MvrExportService.ts
@@ -1,0 +1,229 @@
+/**
+ * MvrExportService — generates MVR (My Virtual Rig) export files.
+ *
+ * MVR is a ZIP archive containing:
+ *   GeneralSceneDescription.xml  — fixture and scene data
+ *   {Manufacturer}@{Model}@Rev.gdtf  — bundled GDTF files (when cached locally)
+ *
+ * Fixtures are grouped into Layers by position (lighting position → MVR Layer).
+ * DMX addresses are converted to MVR's absolute format: (universe-1)*512 + dmx_address.
+ */
+
+import AdmZip from 'adm-zip';
+import * as fs from 'fs';
+import * as path from 'path';
+import { XMLBuilder } from 'fast-xml-parser';
+import { getAllFixtures, Fixture } from '../database/queries/fixtures';
+import { getAppDatabase } from '../database';
+import { logger } from '../utils/logger';
+
+export interface MvrExportResult {
+  success: boolean;
+  fixtureCount: number;
+  layerCount: number;
+  gdtfBundled: number;
+  error?: string;
+}
+
+const xmlBuilder = new XMLBuilder({
+  ignoreAttributes: false,
+  attributeNamePrefix: '@_',
+  format: true,
+  indentBy: '  ',
+  suppressEmptyNode: true,
+});
+
+/**
+ * Convert ShowStack manufacturer+model to GDTFSpec filename format.
+ * Spaces → underscores; format: {Manufacturer}@{Model}@Rev.gdtf
+ */
+function toGdtfSpec(manufacturer: string, model: string): string {
+  const mfr = manufacturer.trim().replace(/\s+/g, '_');
+  const mdl = model.trim().replace(/\s+/g, '_');
+  return `${mfr}@${mdl}@Rev.gdtf`;
+}
+
+/**
+ * Look up the cached GDTF file path for a fixture from gdtf_cache.
+ * Returns the file path if found, null otherwise.
+ */
+function lookupCachedGdtfPath(manufacturer: string, model: string): string | null {
+  const db = getAppDatabase();
+  const id = `${manufacturer}/${model}`;
+
+  let row = db.prepare('SELECT file_path FROM gdtf_cache WHERE id = ?').get(id) as
+    | { file_path: string }
+    | undefined;
+
+  if (!row) {
+    row = db
+      .prepare(
+        'SELECT file_path FROM gdtf_cache WHERE LOWER(manufacturer) = LOWER(?) AND LOWER(model) = LOWER(?)',
+      )
+      .get(manufacturer, model) as { file_path: string } | undefined;
+  }
+
+  if (!row?.file_path) return null;
+
+  try {
+    if (fs.existsSync(row.file_path)) return row.file_path;
+  } catch {
+    // ignore
+  }
+  return null;
+}
+
+export class MvrExportService {
+  /**
+   * Export all fixtures from a project to an MVR file at the given output path.
+   */
+  export(projectId: string, outputPath: string, projectName: string): MvrExportResult {
+    const fixtures = getAllFixtures(projectId).filter((f) => f.status !== 'hidden');
+
+    // Group fixtures by position → one MVR Layer per position
+    const byPosition = new Map<string, Fixture[]>();
+    for (const f of fixtures) {
+      const pos = f.position?.trim() || 'Unassigned';
+      if (!byPosition.has(pos)) byPosition.set(pos, []);
+      byPosition.get(pos)!.push(f);
+    }
+
+    // Collect GDTF files to bundle (deduplicated by spec filename)
+    const gdtfFiles = new Map<string, string>(); // specFilename → local file path
+
+    // Build Layer elements
+    const layers = Array.from(byPosition.entries()).map(([posName, posFixtures]) => {
+      const fixtures = posFixtures.map((f) => this.buildFixtureElement(f, gdtfFiles));
+      return {
+        '@_name': posName,
+        '@_uuid': this.pseudoUuid(posName),
+        ChildList: fixtures.length > 0 ? { Fixture: fixtures } : undefined,
+      };
+    });
+
+    // Build the full XML document object
+    const doc = {
+      '?xml': { '@_version': '1.0', '@_encoding': 'UTF-8' },
+      GeneralSceneDescription: {
+        '@_verMajor': '1',
+        '@_verMinor': '6',
+        UserData: {
+          Data: {
+            '@_provider': 'ShowStack',
+            '@_ver': '1.0',
+            '@_projectName': projectName,
+          },
+        },
+        Scene: {
+          Layers: {
+            Layer: layers,
+          },
+        },
+      },
+    };
+
+    const xml = xmlBuilder.build(doc);
+
+    // Create the ZIP
+    const zip = new AdmZip();
+    zip.addFile('GeneralSceneDescription.xml', Buffer.from(xml, 'utf8'));
+
+    // Bundle GDTF files
+    let gdtfBundled = 0;
+    for (const [specFilename, filePath] of gdtfFiles) {
+      try {
+        const gdtfData = fs.readFileSync(filePath);
+        zip.addFile(specFilename, gdtfData);
+        gdtfBundled++;
+      } catch (err) {
+        logger.warn('Failed to bundle GDTF file', {
+          specFilename,
+          filePath,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    zip.writeZip(outputPath);
+
+    const result: MvrExportResult = {
+      success: true,
+      fixtureCount: fixtures.length,
+      layerCount: byPosition.size,
+      gdtfBundled,
+    };
+
+    logger.info('MVR export complete', {
+      fixtureCount: result.fixtureCount,
+      layerCount: result.layerCount,
+      gdtfBundled: result.gdtfBundled,
+    });
+    return result;
+  }
+
+  private buildFixtureElement(f: Fixture, gdtfFiles: Map<string, string>): Record<string, unknown> {
+    const el: Record<string, unknown> = {
+      '@_name': f.type ?? f.model ?? 'Fixture',
+      '@_uuid': f.id,
+    };
+
+    // GDTFSpec + GDTFMode — only when manufacturer and model are set
+    if (f.manufacturer?.trim() && f.model?.trim()) {
+      const specFilename = toGdtfSpec(f.manufacturer, f.model);
+      el.GDTFSpec = specFilename;
+      if (f.mode?.trim()) {
+        el.GDTFMode = f.mode;
+      }
+      // Register GDTF file for bundling if available in cache
+      if (!gdtfFiles.has(specFilename)) {
+        const cachedPath = lookupCachedGdtfPath(f.manufacturer, f.model);
+        if (cachedPath) {
+          gdtfFiles.set(specFilename, cachedPath);
+        }
+      }
+    }
+
+    // DMX address (absolute: (universe-1)*512 + dmx_address)
+    if (f.universe != null && f.dmx_address != null) {
+      const absoluteAddr = (f.universe - 1) * 512 + f.dmx_address;
+      el.Addresses = {
+        Address: {
+          '@_break': '0',
+          '#text': String(absoluteAddr),
+        },
+      };
+    }
+
+    if (f.channel != null) el.FixtureID = String(f.channel);
+    if (f.unit_number != null) el.UnitNumber = f.unit_number;
+
+    // Optional: 3D position from VW coordinates
+    if (f.vw_x_coordinate != null && f.vw_y_coordinate != null && f.vw_z_coordinate != null) {
+      // MVR uses metres; VW coordinates are typically in mm — convert
+      const scale = 0.001;
+      el.Position = {
+        '@_x': (f.vw_x_coordinate * scale).toFixed(4),
+        '@_y': (f.vw_y_coordinate * scale).toFixed(4),
+        '@_z': (f.vw_z_coordinate * scale).toFixed(4),
+      };
+    }
+
+    return el;
+  }
+
+  /**
+   * Generate a stable pseudo-UUID from a string (deterministic, not cryptographic).
+   * Used for Layer UUIDs so re-exports produce the same file.
+   */
+  private pseudoUuid(seed: string): string {
+    let h = 0x811c9dc5;
+    for (let i = 0; i < seed.length; i++) {
+      h ^= seed.charCodeAt(i);
+      h = (h * 0x01000193) >>> 0;
+    }
+    const hex = h.toString(16).padStart(8, '0');
+    return `${hex.slice(0, 8)}-${hex.slice(0, 4)}-4${hex.slice(1, 4)}-8${hex.slice(1, 4)}-${hex}${hex.slice(0, 4)}`;
+  }
+}
+
+export const mvrExportService = new MvrExportService();

--- a/apps/desktop/src/main/services/MvrExportService.ts
+++ b/apps/desktop/src/main/services/MvrExportService.ts
@@ -79,7 +79,11 @@ export class MvrExportService {
   /**
    * Export all fixtures from a project to an MVR file at the given output path.
    */
-  export(projectId: string, outputPath: string, projectName: string): MvrExportResult {
+  async export(
+    projectId: string,
+    outputPath: string,
+    projectName: string,
+  ): Promise<MvrExportResult> {
     const fixtures = getAllFixtures(projectId).filter((f) => f.status !== 'hidden');
 
     // Group fixtures by position → one MVR Layer per position
@@ -134,7 +138,7 @@ export class MvrExportService {
     let gdtfBundled = 0;
     for (const [specFilename, filePath] of gdtfFiles) {
       try {
-        const gdtfData = fs.readFileSync(filePath);
+        const gdtfData = await fs.promises.readFile(filePath);
         zip.addFile(specFilename, gdtfData);
         gdtfBundled++;
       } catch (err) {
@@ -146,7 +150,7 @@ export class MvrExportService {
       }
     }
 
-    zip.writeZip(outputPath);
+    await zip.writeZipPromise(outputPath);
 
     const result: MvrExportResult = {
       success: true,

--- a/apps/desktop/src/main/services/MvrExportService.ts
+++ b/apps/desktop/src/main/services/MvrExportService.ts
@@ -12,9 +12,12 @@
 import AdmZip from 'adm-zip';
 import * as fs from 'fs';
 import { XMLBuilder } from 'fast-xml-parser';
+import { z } from 'zod';
 import { getAllFixtures, Fixture } from '../database/queries/fixtures';
 import { getAppDatabase } from '../database';
 import { logger } from '../utils/logger';
+
+const GdtfCacheRowSchema = z.object({ file_path: z.string() });
 
 export interface MvrExportResult {
   success: boolean;
@@ -52,26 +55,27 @@ async function lookupCachedGdtfPath(manufacturer: string, model: string): Promis
   const db = getAppDatabase();
   const id = `${manufacturer}/${model}`;
 
-  let row = db.prepare('SELECT file_path FROM gdtf_cache WHERE id = ?').get(id) as
-    | { file_path: string }
-    | undefined;
+  let rowData: unknown = db.prepare('SELECT file_path FROM gdtf_cache WHERE id = ?').get(id);
 
-  if (!row) {
-    row = db
+  if (!rowData) {
+    rowData = db
       .prepare(
         'SELECT file_path FROM gdtf_cache WHERE manufacturer = ? COLLATE NOCASE AND model = ? COLLATE NOCASE',
       )
-      .get(manufacturer, model) as { file_path: string } | undefined;
+      .get(manufacturer, model);
   }
 
-  if (!row?.file_path) return null;
+  const parsed = GdtfCacheRowSchema.safeParse(rowData);
+  if (!parsed.success) return null;
+
+  const { file_path } = parsed.data;
 
   try {
-    await fs.promises.access(row.file_path);
-    return row.file_path;
+    await fs.promises.access(file_path);
+    return file_path;
   } catch (err) {
     logger.warn('Error checking GDTF file existence', {
-      path: row.file_path,
+      path: file_path,
       error: err instanceof Error ? err.message : String(err),
     });
     return null;

--- a/apps/desktop/src/main/services/MvrExportService.ts
+++ b/apps/desktop/src/main/services/MvrExportService.ts
@@ -114,7 +114,7 @@ export class MvrExportService {
         return {
           '@_name': posName,
           '@_uuid': this.pseudoUuid(posName),
-          ChildList: fixtureElements.length > 0 ? { Fixture: fixtureElements } : undefined,
+          ChildList: { Fixture: fixtureElements },
         };
       }),
     );

--- a/apps/desktop/src/main/services/MvrExportService.ts
+++ b/apps/desktop/src/main/services/MvrExportService.ts
@@ -188,14 +188,16 @@ export class MvrExportService {
 
     // GDTFSpec + GDTFMode — only when manufacturer and model are set
     if (f.manufacturer?.trim() && f.model?.trim()) {
-      const specFilename = toGdtfSpec(f.manufacturer, f.model);
+      const manufacturer = f.manufacturer.trim();
+      const model = f.model.trim();
+      const specFilename = toGdtfSpec(manufacturer, model);
       el.GDTFSpec = specFilename;
       if (f.mode?.trim()) {
-        el.GDTFMode = f.mode;
+        el.GDTFMode = f.mode.trim();
       }
       // Register GDTF file for bundling if available in cache
       if (!gdtfFiles.has(specFilename)) {
-        const cachedPath = await lookupCachedGdtfPath(f.manufacturer, f.model);
+        const cachedPath = await lookupCachedGdtfPath(manufacturer, model);
         if (cachedPath) {
           gdtfFiles.set(specFilename, cachedPath);
         }
@@ -233,10 +235,14 @@ export class MvrExportService {
    * Used for Layer UUIDs so re-exports produce the same file.
    */
   private pseudoUuid(seed: string): string {
-    let h = 0x811c9dc5;
+    // FNV-1a 32-bit hash constants
+    const FNV_OFFSET_BASIS = 0x811c9dc5;
+    const FNV_PRIME = 0x01000193;
+
+    let h = FNV_OFFSET_BASIS;
     for (let i = 0; i < seed.length; i++) {
       h ^= seed.charCodeAt(i);
-      h = (h * 0x01000193) >>> 0;
+      h = (h * FNV_PRIME) >>> 0;
     }
     const hex = h.toString(16).padStart(8, '0');
     return `${hex}-0000-4000-8000-000000000000`;

--- a/apps/desktop/src/main/services/MvrExportService.ts
+++ b/apps/desktop/src/main/services/MvrExportService.ts
@@ -57,7 +57,7 @@ function lookupCachedGdtfPath(manufacturer: string, model: string): string | nul
   if (!row) {
     row = db
       .prepare(
-        'SELECT file_path FROM gdtf_cache WHERE LOWER(manufacturer) = LOWER(?) AND LOWER(model) = LOWER(?)',
+        'SELECT file_path FROM gdtf_cache WHERE manufacturer = ? COLLATE NOCASE AND model = ? COLLATE NOCASE',
       )
       .get(manufacturer, model) as { file_path: string } | undefined;
   }

--- a/apps/desktop/src/main/services/MvrExportService.ts
+++ b/apps/desktop/src/main/services/MvrExportService.ts
@@ -12,6 +12,7 @@
 import AdmZip from 'adm-zip';
 import * as fs from 'fs';
 import { XMLBuilder } from 'fast-xml-parser';
+import { v5 as uuidv5 } from 'uuid';
 import { z } from 'zod';
 import { getAllFixtures, Fixture } from '../database/queries/fixtures';
 import { getAppDatabase } from '../database';
@@ -235,21 +236,13 @@ export class MvrExportService {
   }
 
   /**
-   * Generate a stable pseudo-UUID from a string (deterministic, not cryptographic).
+   * Generate a stable, deterministic UUID from a seed string using UUIDv5.
    * Used for Layer UUIDs so re-exports produce the same file.
    */
   private pseudoUuid(seed: string): string {
-    // FNV-1a 32-bit hash constants
-    const FNV_OFFSET_BASIS = 0x811c9dc5;
-    const FNV_PRIME = 0x01000193;
-
-    let h = FNV_OFFSET_BASIS;
-    for (let i = 0; i < seed.length; i++) {
-      h ^= seed.charCodeAt(i);
-      h = (h * FNV_PRIME) >>> 0;
-    }
-    const hex = h.toString(16).padStart(8, '0');
-    return `${hex}-0000-4000-8000-000000000000`;
+    // Fixed namespace for MVR layer UUIDs (randomly generated constant).
+    const MVR_LAYER_NAMESPACE = '9e95318b-3407-49a6-89a4-615d800b28e5';
+    return uuidv5(seed, MVR_LAYER_NAMESPACE);
   }
 }
 

--- a/apps/desktop/src/main/services/MvrExportService.ts
+++ b/apps/desktop/src/main/services/MvrExportService.ts
@@ -134,21 +134,24 @@ export class MvrExportService {
     const zip = new AdmZip();
     zip.addFile('GeneralSceneDescription.xml', Buffer.from(xml, 'utf8'));
 
-    // Bundle GDTF files
-    let gdtfBundled = 0;
-    for (const [specFilename, filePath] of gdtfFiles) {
-      try {
-        const gdtfData = await fs.promises.readFile(filePath);
-        zip.addFile(specFilename, gdtfData);
-        gdtfBundled++;
-      } catch (err) {
-        logger.warn('Failed to bundle GDTF file', {
-          specFilename,
-          filePath,
-          error: err instanceof Error ? err.message : String(err),
-        });
-      }
-    }
+    // Bundle GDTF files in parallel
+    const bundleResults = await Promise.all(
+      Array.from(gdtfFiles.entries()).map(async ([specFilename, filePath]) => {
+        try {
+          const gdtfData = await fs.promises.readFile(filePath);
+          zip.addFile(specFilename, gdtfData);
+          return true;
+        } catch (err) {
+          logger.warn('Failed to bundle GDTF file', {
+            specFilename,
+            filePath,
+            error: err instanceof Error ? err.message : String(err),
+          });
+          return false;
+        }
+      }),
+    );
+    const gdtfBundled = bundleResults.filter(Boolean).length;
 
     await zip.writeZipPromise(outputPath);
 

--- a/apps/desktop/src/main/services/MvrExportService.ts
+++ b/apps/desktop/src/main/services/MvrExportService.ts
@@ -134,7 +134,7 @@ export class MvrExportService {
         },
         Scene: {
           Layers: {
-            Layer: layers,
+            Layer: layers.length > 0 ? layers : undefined,
           },
         },
       },

--- a/apps/desktop/src/main/services/MvrExportService.ts
+++ b/apps/desktop/src/main/services/MvrExportService.ts
@@ -11,7 +11,6 @@
 
 import AdmZip from 'adm-zip';
 import * as fs from 'fs';
-import * as path from 'path';
 import { XMLBuilder } from 'fast-xml-parser';
 import { getAllFixtures, Fixture } from '../database/queries/fixtures';
 import { getAppDatabase } from '../database';
@@ -67,8 +66,11 @@ function lookupCachedGdtfPath(manufacturer: string, model: string): string | nul
 
   try {
     if (fs.existsSync(row.file_path)) return row.file_path;
-  } catch {
-    // ignore
+  } catch (err) {
+    logger.warn('Error checking GDTF file existence', {
+      path: row.file_path,
+      error: err instanceof Error ? err.message : String(err),
+    });
   }
   return null;
 }
@@ -222,7 +224,7 @@ export class MvrExportService {
       h = (h * 0x01000193) >>> 0;
     }
     const hex = h.toString(16).padStart(8, '0');
-    return `${hex.slice(0, 8)}-${hex.slice(0, 4)}-4${hex.slice(1, 4)}-8${hex.slice(1, 4)}-${hex}${hex.slice(0, 4)}`;
+    return `${hex}-0000-4000-8000-000000000000`;
   }
 }
 

--- a/apps/desktop/src/main/services/MvrService.ts
+++ b/apps/desktop/src/main/services/MvrService.ts
@@ -223,7 +223,7 @@ export class MvrService {
     if (!row) {
       row = db
         .prepare(
-          'SELECT modes_json FROM gdtf_cache WHERE LOWER(manufacturer) = LOWER(?) AND LOWER(model) = LOWER(?)',
+          'SELECT modes_json FROM gdtf_cache WHERE manufacturer = ? COLLATE NOCASE AND model = ? COLLATE NOCASE',
         )
         .get(manufacturer, model) as { modes_json: string } | undefined;
     }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -411,9 +411,10 @@ contextBridge.exposeInMainWorld('api', {
     },
   },
 
-  // MVR import
+  // MVR import/export
   mvr: {
     import: (projectId: string) => ipcRenderer.invoke('mvr:import', projectId),
+    export: (projectId: string) => ipcRenderer.invoke('mvr:export', projectId),
   },
 
   // Authentication operations
@@ -829,6 +830,14 @@ export interface ElectronAPI {
       created: number;
       gdtfResolved: number;
       warnings: string[];
+    }>;
+    export: (projectId: string) => Promise<{
+      success: boolean;
+      error?: string;
+      canceled?: boolean;
+      fixtureCount: number;
+      layerCount: number;
+      gdtfBundled: number;
     }>;
   };
   auth: {

--- a/apps/desktop/src/renderer/src/components/fixture/Toolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/fixture/Toolbar.tsx
@@ -12,6 +12,7 @@ interface ToolbarProps {
   onDuplicate?: () => void;
   onExportCSV?: () => void;
   onImportMvr?: () => void;
+  onExportMvr?: () => void;
   onUserColumnSettings: () => void;
   columnVisibility: ColumnVisibility;
   onColumnVisibilityChange: (visibility: ColumnVisibility) => void;
@@ -34,6 +35,7 @@ export function Toolbar({
   onDuplicate,
   onExportCSV,
   onImportMvr,
+  onExportMvr,
   onUserColumnSettings,
   columnVisibility,
   onColumnVisibilityChange,
@@ -128,6 +130,16 @@ export function Toolbar({
             title="Import fixtures from an MVR file"
           >
             Import MVR
+          </button>
+        )}
+
+        {onExportMvr && (
+          <button
+            onClick={onExportMvr}
+            className="px-3 py-1.5 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 rounded text-sm font-medium transition flex-shrink-0"
+            title="Export fixtures to an MVR file"
+          >
+            Export MVR
           </button>
         )}
 

--- a/apps/desktop/src/renderer/src/pages/modules/EquipmentManager.tsx
+++ b/apps/desktop/src/renderer/src/pages/modules/EquipmentManager.tsx
@@ -1020,7 +1020,10 @@ export function EquipmentManager({ initialTab = 'fixtures' }: EquipmentManagerPr
     if (mvrBannerTimerRef.current) clearTimeout(mvrBannerTimerRef.current);
     if (result.canceled) return;
     if (result.success) {
-      const gdtfNote = result.gdtfBundled > 0 ? `, ${result.gdtfBundled} GDTF files bundled` : '';
+      const gdtfNote =
+        result.gdtfBundled > 0
+          ? `, ${result.gdtfBundled} GDTF file${result.gdtfBundled !== 1 ? 's' : ''} bundled`
+          : '';
       setMvrBanner({
         type: 'success',
         message: `MVR export: ${result.fixtureCount} fixtures in ${result.layerCount} layer${result.layerCount !== 1 ? 's' : ''}${gdtfNote}.`,

--- a/apps/desktop/src/renderer/src/pages/modules/EquipmentManager.tsx
+++ b/apps/desktop/src/renderer/src/pages/modules/EquipmentManager.tsx
@@ -1013,6 +1013,24 @@ export function EquipmentManager({ initialTab = 'fixtures' }: EquipmentManagerPr
     }
   };
 
+  const handleExportMvr = async () => {
+    const projectId = routeProjectId;
+    if (!projectId) return;
+    const result = await window.api.mvr.export(projectId);
+    if (mvrBannerTimerRef.current) clearTimeout(mvrBannerTimerRef.current);
+    if (result.canceled) return;
+    if (result.success) {
+      const gdtfNote = result.gdtfBundled > 0 ? `, ${result.gdtfBundled} GDTF files bundled` : '';
+      setMvrBanner({
+        type: 'success',
+        message: `MVR export: ${result.fixtureCount} fixtures in ${result.layerCount} layer${result.layerCount !== 1 ? 's' : ''}${gdtfNote}.`,
+      });
+    } else {
+      setMvrBanner({ type: 'error', message: result.error ?? 'MVR export failed.' });
+    }
+    mvrBannerTimerRef.current = setTimeout(() => setMvrBanner(null), 6000);
+  };
+
   const handleImportMvr = async () => {
     const projectId = routeProjectId;
     if (!projectId) return;
@@ -1170,6 +1188,7 @@ export function EquipmentManager({ initialTab = 'fixtures' }: EquipmentManagerPr
               onUnhideSelected={handleUnhideSelected}
               onDuplicate={activeTab === 'fixtures' ? handleDuplicate : undefined}
               onImportMvr={activeTab === 'fixtures' ? handleImportMvr : undefined}
+              onExportMvr={activeTab === 'fixtures' ? handleExportMvr : undefined}
               onExportCSV={activeTab === 'fixtures' ? handleExportCSV : undefined}
               onUserColumnSettings={() => setIsUserColumnSettingsOpen(true)}
               columnVisibility={columnVisibility}

--- a/apps/desktop/src/renderer/src/pages/modules/EquipmentManager.tsx
+++ b/apps/desktop/src/renderer/src/pages/modules/EquipmentManager.tsx
@@ -1020,13 +1020,13 @@ export function EquipmentManager({ initialTab = 'fixtures' }: EquipmentManagerPr
     if (mvrBannerTimerRef.current) clearTimeout(mvrBannerTimerRef.current);
     if (result.canceled) return;
     if (result.success) {
+      const pluralize = (count: number, singular: string) =>
+        `${count} ${singular}${count !== 1 ? 's' : ''}`;
       const gdtfNote =
-        result.gdtfBundled > 0
-          ? `, ${result.gdtfBundled} GDTF file${result.gdtfBundled !== 1 ? 's' : ''} bundled`
-          : '';
+        result.gdtfBundled > 0 ? `, ${pluralize(result.gdtfBundled, 'GDTF file')} bundled` : '';
       setMvrBanner({
         type: 'success',
-        message: `MVR export: ${result.fixtureCount} fixture${result.fixtureCount !== 1 ? 's' : ''} in ${result.layerCount} layer${result.layerCount !== 1 ? 's' : ''}${gdtfNote}.`,
+        message: `MVR export: ${pluralize(result.fixtureCount, 'fixture')} in ${pluralize(result.layerCount, 'layer')}${gdtfNote}.`,
       });
     } else {
       setMvrBanner({ type: 'error', message: result.error ?? 'MVR export failed.' });

--- a/apps/desktop/src/renderer/src/pages/modules/EquipmentManager.tsx
+++ b/apps/desktop/src/renderer/src/pages/modules/EquipmentManager.tsx
@@ -1026,7 +1026,7 @@ export function EquipmentManager({ initialTab = 'fixtures' }: EquipmentManagerPr
           : '';
       setMvrBanner({
         type: 'success',
-        message: `MVR export: ${result.fixtureCount} fixtures in ${result.layerCount} layer${result.layerCount !== 1 ? 's' : ''}${gdtfNote}.`,
+        message: `MVR export: ${result.fixtureCount} fixture${result.fixtureCount !== 1 ? 's' : ''} in ${result.layerCount} layer${result.layerCount !== 1 ? 's' : ''}${gdtfNote}.`,
       });
     } else {
       setMvrBanner({ type: 'error', message: result.error ?? 'MVR export failed.' });


### PR DESCRIPTION
## Summary

- **`MvrExportService`**: groups fixtures by position into MVR Layers, builds `GeneralSceneDescription.xml` via `XMLBuilder`, creates a `.mvr` ZIP. GDTF files from local cache are bundled automatically for any fixture with a matched manufacturer/model. VW coordinates (mm → metres) written as `<Position>` when present. Layer UUIDs are deterministic so re-exports produce stable files.
- **`mvr:export` IPC**: native save dialog pre-named with the project name, returns `{ fixtureCount, layerCount, gdtfBundled }`
- **Preload**: `window.api.mvr.export` wired with full type definition
- **Toolbar**: "Export MVR" button (fixtures tab only, mirrors "Import MVR")
- **EquipmentManager**: `handleExportMvr` with success/error banner — e.g. "MVR export: 47 fixtures in 8 layers, 12 GDTF files bundled."

No new dependencies — uses `adm-zip` and `fast-xml-parser` already in tree.

## Test plan

- [ ] Export a project with patched fixtures — verify `.mvr` opens in Vectorworks / grandMA3 onPC
- [ ] Verify fixtures with manufacturer/model have GDTF files bundled in the ZIP
- [ ] Verify fixtures without GDTF data export cleanly (no GDTFSpec element)
- [ ] Verify fixtures grouped into layers by position
- [ ] Verify DMX addresses are absolute (`(universe-1)*512 + dmx_address`)
- [ ] Cancel the save dialog — verify no banner appears
- [ ] Export with no fixtures — verify graceful result

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)