### PR TITLE
feat: network access prerequisites — IP/VLAN validation (Issue #17) + port status monitoring (Issue #20)

### DIFF
--- a/apps/desktop/src/main/ipc/infrastructure.ts
+++ b/apps/desktop/src/main/ipc/infrastructure.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { ipcMain, dialog } from 'electron';
+import { ipcMain, dialog, IpcMainInvokeEvent } from 'electron';
 import { writeFileSync, readFileSync } from 'fs';
 import {
   getPortLinkages,
@@ -449,7 +449,7 @@ export function registerInfrastructureHandlers(): void {
   ipcMain.handle(
     'infrastructure:getPortStatusReport',
     async (
-      _event,
+      _event: IpcMainInvokeEvent,
       projectId: string,
       equipment: Array<{ id: string; ip_address?: string | null }>,
     ) => {

--- a/apps/desktop/src/main/ipc/infrastructure.ts
+++ b/apps/desktop/src/main/ipc/infrastructure.ts
@@ -15,6 +15,7 @@ import {
   CSVFieldMapping,
 } from '../database/queries/infrastructure';
 import { infrastructureService } from '../services/InfrastructureService';
+import { portStatusMonitor } from '../services/PortStatusMonitorService';
 import { errorHandler } from '../errors';
 import { DatabaseError, ValidationError } from '../errors';
 import { logger } from '../utils/logger';
@@ -443,6 +444,27 @@ export function registerInfrastructureHandlers(): void {
       );
     }
   });
+
+  // Get port reachability status for all equipment in a project (Issue #20)
+  ipcMain.handle(
+    'infrastructure:getPortStatusReport',
+    async (
+      _event,
+      projectId: string,
+      equipment: Array<{ id: string; ip_address?: string | null }>,
+    ) => {
+      try {
+        return await portStatusMonitor.checkAll(projectId, equipment);
+      } catch (error) {
+        logger.error('Failed to get port status report:', {
+          operation: 'infrastructure:getPortStatusReport',
+          projectId,
+          error: error instanceof Error ? error.message : error,
+        });
+        throw error;
+      }
+    },
+  );
 
   logger.info('✅ Infrastructure IPC handlers registered');
 }

--- a/apps/desktop/src/main/services/PortStatusMonitorService.ts
+++ b/apps/desktop/src/main/services/PortStatusMonitorService.ts
@@ -71,7 +71,7 @@ class PortStatusMonitorServiceClass {
   /**
    * Check a single IP address via TCP connect.
    */
-  async checkOne(equipmentId: string, ip: string): Promise<PortStatusResult> {
+  checkOne(equipmentId: string, ip: string): Promise<PortStatusResult> {
     const start = Date.now();
 
     return new Promise((resolve) => {

--- a/apps/desktop/src/main/services/PortStatusMonitorService.ts
+++ b/apps/desktop/src/main/services/PortStatusMonitorService.ts
@@ -26,6 +26,7 @@ export type { PortStatusResult };
 const PROBE_PORT = 80;
 const CONNECT_TIMEOUT_MS = 2_000;
 const PORT_STATUS_TTL_MS = 8_000;
+const BATCH_SIZE = 20; // max concurrent TCP sockets per check cycle
 
 interface CacheEntry {
   results: PortStatusResult[];
@@ -71,7 +72,6 @@ class PortStatusMonitorServiceClass {
         }
 
         // Process in batches to avoid exhausting OS file descriptors on large rigs.
-        const BATCH_SIZE = 20;
         const results: PortStatusResult[] = [];
         for (let i = 0; i < addressable.length; i += BATCH_SIZE) {
           const batch = addressable.slice(i, i + BATCH_SIZE);

--- a/apps/desktop/src/main/services/PortStatusMonitorService.ts
+++ b/apps/desktop/src/main/services/PortStatusMonitorService.ts
@@ -16,14 +16,9 @@
 
 import * as net from 'net';
 import { logger } from '../utils/logger';
+import { PortStatusResult } from '@showstack/shared';
 
-export interface PortStatusResult {
-  equipment_id: string;
-  ip: string;
-  status: 'reachable' | 'unreachable' | 'timeout';
-  latency_ms?: number;
-  last_checked: number;
-}
+export type { PortStatusResult };
 
 // Port to probe — HTTP is a reasonable choice: refused quickly by most
 // network devices even when not running a web server, so we get a fast

--- a/apps/desktop/src/main/services/PortStatusMonitorService.ts
+++ b/apps/desktop/src/main/services/PortStatusMonitorService.ts
@@ -1,0 +1,120 @@
+/**
+ * PortStatusMonitorService
+ *
+ * Checks TCP reachability of infrastructure equipment by IP address.
+ * Uses net.createConnection() — no ping binary required, no special
+ * OS entitlements needed on macOS or Windows.
+ *
+ * Reachability logic:
+ *   - ECONNREFUSED → 'reachable' (host responded; that port just isn't open)
+ *   - Timeout (2s)  → 'timeout'
+ *   - Other error   → 'unreachable'
+ *
+ * Results are cached per project for PORT_STATUS_TTL_MS to avoid
+ * hammering the network on every render.
+ */
+
+import * as net from 'net';
+import { logger } from '../utils/logger';
+
+export interface PortStatusResult {
+  equipment_id: string;
+  ip: string;
+  status: 'reachable' | 'unreachable' | 'timeout';
+  latency_ms?: number;
+  last_checked: number;
+}
+
+// Port to probe — HTTP is a reasonable choice: refused quickly by most
+// network devices even when not running a web server, so we get a fast
+// ECONNREFUSED rather than a firewall-induced timeout.
+const PROBE_PORT = 80;
+const CONNECT_TIMEOUT_MS = 2_000;
+const PORT_STATUS_TTL_MS = 8_000;
+
+interface CacheEntry {
+  results: PortStatusResult[];
+  expiresAt: number;
+}
+
+class PortStatusMonitorServiceClass {
+  private cache = new Map<string, CacheEntry>();
+
+  /**
+   * Check reachability of all equipment IPs for the given project.
+   * Results are cached for PORT_STATUS_TTL_MS; a cache hit returns immediately.
+   */
+  async checkAll(
+    projectId: string,
+    equipment: Array<{ id: string; ip_address?: string | null }>,
+  ): Promise<PortStatusResult[]> {
+    const cached = this.cache.get(projectId);
+    if (cached && Date.now() < cached.expiresAt) {
+      return cached.results;
+    }
+
+    const addressable = equipment.filter((e) => e.ip_address);
+
+    if (addressable.length === 0) {
+      const empty: PortStatusResult[] = [];
+      this.cache.set(projectId, { results: empty, expiresAt: Date.now() + PORT_STATUS_TTL_MS });
+      return empty;
+    }
+
+    const results = await Promise.all(addressable.map((e) => this.checkOne(e.id, e.ip_address!)));
+
+    this.cache.set(projectId, { results, expiresAt: Date.now() + PORT_STATUS_TTL_MS });
+    logger.debug('Port status check complete', { projectId, count: results.length });
+    return results;
+  }
+
+  /**
+   * Check a single IP address via TCP connect.
+   */
+  async checkOne(equipmentId: string, ip: string): Promise<PortStatusResult> {
+    const start = Date.now();
+
+    return new Promise((resolve) => {
+      const socket = net.createConnection({ host: ip, port: PROBE_PORT });
+      let settled = false;
+
+      const finish = (status: PortStatusResult['status']) => {
+        if (settled) return;
+        settled = true;
+        socket.destroy();
+        resolve({
+          equipment_id: equipmentId,
+          ip,
+          status,
+          latency_ms: status === 'reachable' ? Date.now() - start : undefined,
+          last_checked: Date.now(),
+        });
+      };
+
+      const timer = setTimeout(() => finish('timeout'), CONNECT_TIMEOUT_MS);
+
+      socket.on('connect', () => {
+        clearTimeout(timer);
+        finish('reachable');
+      });
+
+      socket.on('error', (err: NodeJS.ErrnoException) => {
+        clearTimeout(timer);
+        // ECONNREFUSED means the host is up — it just rejected the connection.
+        finish(err.code === 'ECONNREFUSED' ? 'reachable' : 'unreachable');
+      });
+    });
+  }
+
+  /** Evict a project's cache entry. Exposed for testing. */
+  clearCache(projectId?: string): void {
+    if (projectId) {
+      this.cache.delete(projectId);
+    } else {
+      this.cache.clear();
+    }
+  }
+}
+
+export const portStatusMonitor = new PortStatusMonitorServiceClass();
+export { PortStatusMonitorServiceClass };

--- a/apps/desktop/src/main/services/PortStatusMonitorService.ts
+++ b/apps/desktop/src/main/services/PortStatusMonitorService.ts
@@ -78,10 +78,14 @@ class PortStatusMonitorServiceClass {
       const socket = net.createConnection({ host: ip, port: PROBE_PORT });
       let settled = false;
 
+      const timer = setTimeout(() => finish('timeout'), CONNECT_TIMEOUT_MS);
+
       const finish = (status: PortStatusResult['status']) => {
         if (settled) return;
         settled = true;
+        clearTimeout(timer);
         socket.destroy();
+        socket.removeAllListeners();
         resolve({
           equipment_id: equipmentId,
           ip,
@@ -91,15 +95,9 @@ class PortStatusMonitorServiceClass {
         });
       };
 
-      const timer = setTimeout(() => finish('timeout'), CONNECT_TIMEOUT_MS);
-
-      socket.on('connect', () => {
-        clearTimeout(timer);
-        finish('reachable');
-      });
+      socket.on('connect', () => finish('reachable'));
 
       socket.on('error', (err: NodeJS.ErrnoException) => {
-        clearTimeout(timer);
         // ECONNREFUSED means the host is up — it just rejected the connection.
         finish(err.code === 'ECONNREFUSED' ? 'reachable' : 'unreachable');
       });

--- a/apps/desktop/src/main/services/PortStatusMonitorService.ts
+++ b/apps/desktop/src/main/services/PortStatusMonitorService.ts
@@ -45,23 +45,28 @@ class PortStatusMonitorServiceClass {
     projectId: string,
     equipment: Array<{ id: string; ip_address?: string | null }>,
   ): Promise<PortStatusResult[]> {
-    const cached = this.cache.get(projectId);
+    const addressable = equipment.filter((e) => e.ip_address);
+    const signature = addressable
+      .map((e) => e.ip_address!)
+      .sort()
+      .join(',');
+    const cacheKey = `${projectId}:${signature}`;
+
+    const cached = this.cache.get(cacheKey);
     if (cached && Date.now() < cached.expiresAt) {
       return cached.results;
     }
 
-    const inFlight = this.inFlightChecks.get(projectId);
+    const inFlight = this.inFlightChecks.get(cacheKey);
     if (inFlight) {
       return inFlight;
     }
 
     const checkPromise = (async (): Promise<PortStatusResult[]> => {
       try {
-        const addressable = equipment.filter((e) => e.ip_address);
-
         if (addressable.length === 0) {
           const results: PortStatusResult[] = [];
-          this.cache.set(projectId, { results, expiresAt: Date.now() + PORT_STATUS_TTL_MS });
+          this.cache.set(cacheKey, { results, expiresAt: Date.now() + PORT_STATUS_TTL_MS });
           return results;
         }
 
@@ -76,15 +81,15 @@ class PortStatusMonitorServiceClass {
           results.push(...batchResults);
         }
 
-        this.cache.set(projectId, { results, expiresAt: Date.now() + PORT_STATUS_TTL_MS });
+        this.cache.set(cacheKey, { results, expiresAt: Date.now() + PORT_STATUS_TTL_MS });
         logger.debug('Port status check complete', { projectId, count: results.length });
         return results;
       } finally {
-        this.inFlightChecks.delete(projectId);
+        this.inFlightChecks.delete(cacheKey);
       }
     })();
 
-    this.inFlightChecks.set(projectId, checkPromise);
+    this.inFlightChecks.set(cacheKey, checkPromise);
     return checkPromise;
   }
 
@@ -124,10 +129,12 @@ class PortStatusMonitorServiceClass {
     });
   }
 
-  /** Evict a project's cache entry. Exposed for testing. */
+  /** Evict all cache entries for a project (or everything). Exposed for testing. */
   clearCache(projectId?: string): void {
     if (projectId) {
-      this.cache.delete(projectId);
+      for (const key of this.cache.keys()) {
+        if (key.startsWith(`${projectId}:`)) this.cache.delete(key);
+      }
     } else {
       this.cache.clear();
     }

--- a/apps/desktop/src/main/services/PortStatusMonitorService.ts
+++ b/apps/desktop/src/main/services/PortStatusMonitorService.ts
@@ -71,15 +71,22 @@ class PortStatusMonitorServiceClass {
           return results;
         }
 
-        // Process in batches to avoid exhausting OS file descriptors on large rigs.
-        const results: PortStatusResult[] = [];
-        for (let i = 0; i < addressable.length; i += BATCH_SIZE) {
-          const batch = addressable.slice(i, i + BATCH_SIZE);
-          const batchResults = await Promise.all(
-            batch.map((e) => this.checkOne(e.id, e.ip_address!)),
-          );
-          results.push(...batchResults);
+        // Check each unique IP once, then fan results back to all equipment.
+        const uniqueIps = [...new Set(addressable.map((e) => e.ip_address!))];
+        const ipStatusMap = new Map<string, Omit<PortStatusResult, 'equipment_id'>>();
+
+        for (let i = 0; i < uniqueIps.length; i += BATCH_SIZE) {
+          const batchIps = uniqueIps.slice(i, i + BATCH_SIZE);
+          const batchResults = await Promise.all(batchIps.map((ip) => this.checkOne(ip, ip)));
+          for (const { equipment_id: _ip, ...status } of batchResults) {
+            ipStatusMap.set(status.ip, status);
+          }
         }
+
+        const results: PortStatusResult[] = addressable.map((e) => ({
+          equipment_id: e.id,
+          ...ipStatusMap.get(e.ip_address!)!,
+        }));
 
         this.cache.set(cacheKey, { results, expiresAt: Date.now() + PORT_STATUS_TTL_MS });
         logger.debug('Port status check complete', { projectId, count: results.length });

--- a/apps/desktop/src/main/services/PortStatusMonitorService.ts
+++ b/apps/desktop/src/main/services/PortStatusMonitorService.ts
@@ -34,10 +34,12 @@ interface CacheEntry {
 
 class PortStatusMonitorServiceClass {
   private cache = new Map<string, CacheEntry>();
+  private inFlightChecks = new Map<string, Promise<PortStatusResult[]>>();
 
   /**
    * Check reachability of all equipment IPs for the given project.
    * Results are cached for PORT_STATUS_TTL_MS; a cache hit returns immediately.
+   * Concurrent callers for the same project share a single in-flight check.
    */
   async checkAll(
     projectId: string,
@@ -48,24 +50,42 @@ class PortStatusMonitorServiceClass {
       return cached.results;
     }
 
-    const addressable = equipment.filter((e) => e.ip_address);
-
-    if (addressable.length === 0) {
-      return [];
+    const inFlight = this.inFlightChecks.get(projectId);
+    if (inFlight) {
+      return inFlight;
     }
 
-    // Process in batches to avoid exhausting OS file descriptors on large rigs.
-    const BATCH_SIZE = 20;
-    const results: PortStatusResult[] = [];
-    for (let i = 0; i < addressable.length; i += BATCH_SIZE) {
-      const batch = addressable.slice(i, i + BATCH_SIZE);
-      const batchResults = await Promise.all(batch.map((e) => this.checkOne(e.id, e.ip_address!)));
-      results.push(...batchResults);
-    }
+    const checkPromise = (async (): Promise<PortStatusResult[]> => {
+      try {
+        const addressable = equipment.filter((e) => e.ip_address);
 
-    this.cache.set(projectId, { results, expiresAt: Date.now() + PORT_STATUS_TTL_MS });
-    logger.debug('Port status check complete', { projectId, count: results.length });
-    return results;
+        if (addressable.length === 0) {
+          const results: PortStatusResult[] = [];
+          this.cache.set(projectId, { results, expiresAt: Date.now() + PORT_STATUS_TTL_MS });
+          return results;
+        }
+
+        // Process in batches to avoid exhausting OS file descriptors on large rigs.
+        const BATCH_SIZE = 20;
+        const results: PortStatusResult[] = [];
+        for (let i = 0; i < addressable.length; i += BATCH_SIZE) {
+          const batch = addressable.slice(i, i + BATCH_SIZE);
+          const batchResults = await Promise.all(
+            batch.map((e) => this.checkOne(e.id, e.ip_address!)),
+          );
+          results.push(...batchResults);
+        }
+
+        this.cache.set(projectId, { results, expiresAt: Date.now() + PORT_STATUS_TTL_MS });
+        logger.debug('Port status check complete', { projectId, count: results.length });
+        return results;
+      } finally {
+        this.inFlightChecks.delete(projectId);
+      }
+    })();
+
+    this.inFlightChecks.set(projectId, checkPromise);
+    return checkPromise;
   }
 
   /**

--- a/apps/desktop/src/main/services/PortStatusMonitorService.ts
+++ b/apps/desktop/src/main/services/PortStatusMonitorService.ts
@@ -54,7 +54,14 @@ class PortStatusMonitorServiceClass {
       return [];
     }
 
-    const results = await Promise.all(addressable.map((e) => this.checkOne(e.id, e.ip_address!)));
+    // Process in batches to avoid exhausting OS file descriptors on large rigs.
+    const BATCH_SIZE = 20;
+    const results: PortStatusResult[] = [];
+    for (let i = 0; i < addressable.length; i += BATCH_SIZE) {
+      const batch = addressable.slice(i, i + BATCH_SIZE);
+      const batchResults = await Promise.all(batch.map((e) => this.checkOne(e.id, e.ip_address!)));
+      results.push(...batchResults);
+    }
 
     this.cache.set(projectId, { results, expiresAt: Date.now() + PORT_STATUS_TTL_MS });
     logger.debug('Port status check complete', { projectId, count: results.length });

--- a/apps/desktop/src/main/services/PortStatusMonitorService.ts
+++ b/apps/desktop/src/main/services/PortStatusMonitorService.ts
@@ -51,9 +51,7 @@ class PortStatusMonitorServiceClass {
     const addressable = equipment.filter((e) => e.ip_address);
 
     if (addressable.length === 0) {
-      const empty: PortStatusResult[] = [];
-      this.cache.set(projectId, { results: empty, expiresAt: Date.now() + PORT_STATUS_TTL_MS });
-      return empty;
+      return [];
     }
 
     const results = await Promise.all(addressable.map((e) => this.checkOne(e.id, e.ip_address!)));

--- a/apps/desktop/src/main/services/__tests__/PortStatusMonitorService.test.ts
+++ b/apps/desktop/src/main/services/__tests__/PortStatusMonitorService.test.ts
@@ -77,7 +77,7 @@ describe('PortStatusMonitorService', () => {
   it('returns timeout when socket does not respond within timeout', async () => {
     vi.useFakeTimers();
     const socket = { on: vi.fn(), destroy: vi.fn(), removeAllListeners: vi.fn() };
-    vi.mocked(net.createConnection).mockReturnValue(socket as any);
+    vi.mocked(net.createConnection).mockReturnValue(socket as unknown as net.Socket);
 
     const checkPromise = service.checkOne('eq-timeout', '10.0.0.99');
     await vi.advanceTimersByTimeAsync(2001);

--- a/apps/desktop/src/main/services/__tests__/PortStatusMonitorService.test.ts
+++ b/apps/desktop/src/main/services/__tests__/PortStatusMonitorService.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as net from 'net';
+
+vi.mock('../../utils/logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// We mock net after import so we can control socket behaviour per-test.
+vi.mock('net');
+
+import { PortStatusMonitorServiceClass } from '../PortStatusMonitorService';
+
+// Helper: build a fake socket that fires one event after a tick
+function makeFakeSocket(event: 'connect' | 'error', err?: NodeJS.ErrnoException) {
+  const listeners: Record<string, ((...args: unknown[]) => void)[]> = {};
+  const socket = {
+    on: vi.fn((ev: string, cb: (...args: unknown[]) => void) => {
+      listeners[ev] = listeners[ev] ?? [];
+      listeners[ev].push(cb);
+      return socket;
+    }),
+    destroy: vi.fn(),
+  };
+  // Fire the event asynchronously so the promise has time to attach listeners
+  setTimeout(() => {
+    for (const cb of listeners[event] ?? []) {
+      if (event === 'error') cb(err);
+      else cb();
+    }
+  }, 0);
+  return socket;
+}
+
+describe('PortStatusMonitorService', () => {
+  let service: PortStatusMonitorServiceClass;
+
+  beforeEach(() => {
+    service = new PortStatusMonitorServiceClass();
+    vi.mocked(net.createConnection).mockReset();
+  });
+
+  it('returns reachable when socket connects', async () => {
+    vi.mocked(net.createConnection).mockReturnValue(makeFakeSocket('connect') as any);
+
+    const [result] = await service.checkAll('proj-1', [{ id: 'eq-1', ip_address: '10.0.0.1' }]);
+    expect(result.status).toBe('reachable');
+    expect(result.equipment_id).toBe('eq-1');
+    expect(result.ip).toBe('10.0.0.1');
+  });
+
+  it('returns reachable on ECONNREFUSED (host is up, port is closed)', async () => {
+    const err = Object.assign(new Error('refused'), { code: 'ECONNREFUSED' });
+    vi.mocked(net.createConnection).mockReturnValue(makeFakeSocket('error', err) as any);
+
+    const [result] = await service.checkAll('proj-2', [{ id: 'eq-2', ip_address: '10.0.0.2' }]);
+    expect(result.status).toBe('reachable');
+  });
+
+  it('returns unreachable on ENETUNREACH', async () => {
+    const err = Object.assign(new Error('no route'), { code: 'ENETUNREACH' });
+    vi.mocked(net.createConnection).mockReturnValue(makeFakeSocket('error', err) as any);
+
+    const [result] = await service.checkAll('proj-3', [{ id: 'eq-3', ip_address: '10.0.0.3' }]);
+    expect(result.status).toBe('unreachable');
+  });
+
+  it('skips equipment without ip_address', async () => {
+    const results = await service.checkAll('proj-4', [
+      { id: 'eq-no-ip', ip_address: null },
+      { id: 'eq-no-ip-2' },
+    ]);
+    expect(results).toHaveLength(0);
+    expect(net.createConnection).not.toHaveBeenCalled();
+  });
+
+  it('returns cached results within TTL', async () => {
+    vi.mocked(net.createConnection).mockReturnValue(makeFakeSocket('connect') as any);
+
+    // First call populates cache
+    await service.checkAll('proj-5', [{ id: 'eq-5', ip_address: '10.0.0.5' }]);
+    const callCount = vi.mocked(net.createConnection).mock.calls.length;
+
+    // Second call within TTL should use cache
+    await service.checkAll('proj-5', [{ id: 'eq-5', ip_address: '10.0.0.5' }]);
+    expect(vi.mocked(net.createConnection).mock.calls.length).toBe(callCount);
+  });
+
+  it('re-checks after cache is cleared', async () => {
+    vi.mocked(net.createConnection).mockReturnValue(makeFakeSocket('connect') as any);
+
+    await service.checkAll('proj-6', [{ id: 'eq-6', ip_address: '10.0.0.6' }]);
+    service.clearCache('proj-6');
+    await service.checkAll('proj-6', [{ id: 'eq-6', ip_address: '10.0.0.6' }]);
+
+    expect(vi.mocked(net.createConnection).mock.calls.length).toBe(2);
+  });
+});

--- a/apps/desktop/src/main/services/__tests__/PortStatusMonitorService.test.ts
+++ b/apps/desktop/src/main/services/__tests__/PortStatusMonitorService.test.ts
@@ -109,4 +109,18 @@ describe('PortStatusMonitorService', () => {
 
     expect(vi.mocked(net.createConnection).mock.calls.length).toBe(2);
   });
+
+  it('deduplicates concurrent checkAll calls for the same project', async () => {
+    vi.mocked(net.createConnection).mockReturnValue(makeFakeSocket('connect') as any);
+
+    // Fire two concurrent calls without awaiting the first
+    const [r1, r2] = await Promise.all([
+      service.checkAll('proj-7', [{ id: 'eq-7', ip_address: '10.0.0.7' }]),
+      service.checkAll('proj-7', [{ id: 'eq-7', ip_address: '10.0.0.7' }]),
+    ]);
+
+    // Only one socket connection should have been made
+    expect(vi.mocked(net.createConnection).mock.calls.length).toBe(1);
+    expect(r1).toBe(r2);
+  });
 });

--- a/apps/desktop/src/main/services/__tests__/PortStatusMonitorService.test.ts
+++ b/apps/desktop/src/main/services/__tests__/PortStatusMonitorService.test.ts
@@ -41,7 +41,9 @@ describe('PortStatusMonitorService', () => {
   });
 
   it('returns reachable when socket connects', async () => {
-    vi.mocked(net.createConnection).mockReturnValue(makeFakeSocket('connect') as any);
+    vi.mocked(net.createConnection).mockReturnValue(
+      makeFakeSocket('connect') as unknown as net.Socket,
+    );
 
     const [result] = await service.checkAll('proj-1', [{ id: 'eq-1', ip_address: '10.0.0.1' }]);
     expect(result.status).toBe('reachable');
@@ -51,7 +53,9 @@ describe('PortStatusMonitorService', () => {
 
   it('returns reachable on ECONNREFUSED (host is up, port is closed)', async () => {
     const err = Object.assign(new Error('refused'), { code: 'ECONNREFUSED' });
-    vi.mocked(net.createConnection).mockReturnValue(makeFakeSocket('error', err) as any);
+    vi.mocked(net.createConnection).mockReturnValue(
+      makeFakeSocket('error', err) as unknown as net.Socket,
+    );
 
     const [result] = await service.checkAll('proj-2', [{ id: 'eq-2', ip_address: '10.0.0.2' }]);
     expect(result.status).toBe('reachable');
@@ -59,7 +63,9 @@ describe('PortStatusMonitorService', () => {
 
   it('returns unreachable on ENETUNREACH', async () => {
     const err = Object.assign(new Error('no route'), { code: 'ENETUNREACH' });
-    vi.mocked(net.createConnection).mockReturnValue(makeFakeSocket('error', err) as any);
+    vi.mocked(net.createConnection).mockReturnValue(
+      makeFakeSocket('error', err) as unknown as net.Socket,
+    );
 
     const [result] = await service.checkAll('proj-3', [{ id: 'eq-3', ip_address: '10.0.0.3' }]);
     expect(result.status).toBe('unreachable');
@@ -89,7 +95,9 @@ describe('PortStatusMonitorService', () => {
   });
 
   it('returns cached results within TTL', async () => {
-    vi.mocked(net.createConnection).mockReturnValue(makeFakeSocket('connect') as any);
+    vi.mocked(net.createConnection).mockReturnValue(
+      makeFakeSocket('connect') as unknown as net.Socket,
+    );
 
     // First call populates cache
     await service.checkAll('proj-5', [{ id: 'eq-5', ip_address: '10.0.0.5' }]);
@@ -101,7 +109,9 @@ describe('PortStatusMonitorService', () => {
   });
 
   it('re-checks after cache is cleared', async () => {
-    vi.mocked(net.createConnection).mockReturnValue(makeFakeSocket('connect') as any);
+    vi.mocked(net.createConnection).mockReturnValue(
+      makeFakeSocket('connect') as unknown as net.Socket,
+    );
 
     await service.checkAll('proj-6', [{ id: 'eq-6', ip_address: '10.0.0.6' }]);
     service.clearCache('proj-6');
@@ -111,7 +121,9 @@ describe('PortStatusMonitorService', () => {
   });
 
   it('deduplicates concurrent checkAll calls for the same project', async () => {
-    vi.mocked(net.createConnection).mockReturnValue(makeFakeSocket('connect') as any);
+    vi.mocked(net.createConnection).mockReturnValue(
+      makeFakeSocket('connect') as unknown as net.Socket,
+    );
 
     // Fire two concurrent calls without awaiting the first
     const [r1, r2] = await Promise.all([

--- a/apps/desktop/src/main/services/__tests__/PortStatusMonitorService.test.ts
+++ b/apps/desktop/src/main/services/__tests__/PortStatusMonitorService.test.ts
@@ -20,6 +20,7 @@ function makeFakeSocket(event: 'connect' | 'error', err?: NodeJS.ErrnoException)
       return socket;
     }),
     destroy: vi.fn(),
+    removeAllListeners: vi.fn(),
   };
   // Fire the event asynchronously so the promise has time to attach listeners
   setTimeout(() => {

--- a/apps/desktop/src/main/services/__tests__/PortStatusMonitorService.test.ts
+++ b/apps/desktop/src/main/services/__tests__/PortStatusMonitorService.test.ts
@@ -74,6 +74,20 @@ describe('PortStatusMonitorService', () => {
     expect(net.createConnection).not.toHaveBeenCalled();
   });
 
+  it('returns timeout when socket does not respond within timeout', async () => {
+    vi.useFakeTimers();
+    const socket = { on: vi.fn(), destroy: vi.fn(), removeAllListeners: vi.fn() };
+    vi.mocked(net.createConnection).mockReturnValue(socket as any);
+
+    const checkPromise = service.checkOne('eq-timeout', '10.0.0.99');
+    await vi.advanceTimersByTimeAsync(2001);
+    const result = await checkPromise;
+
+    expect(result.status).toBe('timeout');
+    expect(result.equipment_id).toBe('eq-timeout');
+    vi.useRealTimers();
+  });
+
   it('returns cached results within TTL', async () => {
     vi.mocked(net.createConnection).mockReturnValue(makeFakeSocket('connect') as any);
 

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -4,6 +4,7 @@ import type {
   ShopOrderMember,
   PresenceMember,
 } from '../shared/types/collaboration.types';
+import type { PortStatusResult } from '../shared/types/network.types';
 
 // Define the Fixture type (will match renderer types)
 interface Fixture {
@@ -750,15 +751,7 @@ export interface ElectronAPI {
     getPortStatusReport: (
       projectId: string,
       equipment: Array<{ id: string; ip_address?: string | null }>,
-    ) => Promise<
-      Array<{
-        equipment_id: string;
-        ip: string;
-        status: 'reachable' | 'unreachable' | 'timeout';
-        latency_ms?: number;
-        last_checked: number;
-      }>
-    >;
+    ) => Promise<PortStatusResult[]>;
   };
   phaseTemplates: {
     getAll: (projectId: string) => Promise<any[]>;

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -328,6 +328,10 @@ contextBridge.exposeInMainWorld('api', {
     readCSVHeaders: (filePath: string) =>
       ipcRenderer.invoke('infrastructure:readCSVHeaders', filePath),
     showImportDialog: () => ipcRenderer.invoke('infrastructure:showImportDialog'),
+    getPortStatusReport: (
+      projectId: string,
+      equipment: Array<{ id: string; ip_address?: string | null }>,
+    ) => ipcRenderer.invoke('infrastructure:getPortStatusReport', projectId, equipment),
   },
 
   // Phase Template operations
@@ -743,6 +747,18 @@ export interface ElectronAPI {
     ) => Promise<{ success: boolean; imported: number; errors: string[] }>;
     readCSVHeaders: (filePath: string) => Promise<{ success: boolean; headers: string[] }>;
     showImportDialog: () => Promise<{ success: boolean; filePath?: string; canceled?: boolean }>;
+    getPortStatusReport: (
+      projectId: string,
+      equipment: Array<{ id: string; ip_address?: string | null }>,
+    ) => Promise<
+      Array<{
+        equipment_id: string;
+        ip: string;
+        status: 'reachable' | 'unreachable' | 'timeout';
+        latency_ms?: number;
+        last_checked: number;
+      }>
+    >;
   };
   phaseTemplates: {
     getAll: (projectId: string) => Promise<any[]>;

--- a/apps/desktop/src/renderer/src/components/infrastructure/AddInfrastructureDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/infrastructure/AddInfrastructureDialog.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { InfrastructureEquipment, PortAssignment } from '../../types/infrastructure';
 import { PortAssignmentEditor } from './PortAssignmentEditor';
 import { logger } from '../../utils/logger';
+import { isValidIPv4 } from '@showstack/shared';
 
 interface AddInfrastructureDialogProps {
   isOpen: boolean;
@@ -20,6 +21,7 @@ export function AddInfrastructureDialog({ isOpen, onClose, onAdd }: AddInfrastru
     'network',
   );
   const [ipAddress, setIpAddress] = useState('');
+  const [ipAddressError, setIpAddressError] = useState('');
   const [macAddress, setMacAddress] = useState('');
   const [hostname, setHostname] = useState('');
   const [location, setLocation] = useState('');
@@ -64,6 +66,7 @@ export function AddInfrastructureDialog({ isOpen, onClose, onAdd }: AddInfrastru
       setQuantity(1);
       setCategory('network');
       setIpAddress('');
+      setIpAddressError('');
       setMacAddress('');
       setHostname('');
       setLocation('');
@@ -191,9 +194,17 @@ export function AddInfrastructureDialog({ isOpen, onClose, onAdd }: AddInfrastru
                 type="text"
                 value={ipAddress}
                 onChange={(e) => setIpAddress(e.target.value)}
+                onBlur={() =>
+                  setIpAddressError(
+                    ipAddress && !isValidIPv4(ipAddress) ? 'Invalid IP address' : '',
+                  )
+                }
                 className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
                 placeholder="e.g., 10.0.1.100"
               />
+              {ipAddressError && (
+                <p className="text-xs text-red-600 dark:text-red-400 mt-1">{ipAddressError}</p>
+              )}
             </div>
 
             {/* MAC Address */}

--- a/apps/desktop/src/renderer/src/components/infrastructure/EditInfrastructureDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/infrastructure/EditInfrastructureDialog.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { InfrastructureEquipment, PortAssignment } from '../../types/infrastructure';
 import { PortAssignmentEditor } from './PortAssignmentEditor';
 import { logger } from '../../utils/logger';
+import { isValidIPv4 } from '@showstack/shared';
 
 interface EditInfrastructureDialogProps {
   isOpen: boolean;
@@ -24,6 +25,7 @@ export function EditInfrastructureDialog({
     'network',
   );
   const [ipAddress, setIpAddress] = useState('');
+  const [ipAddressError, setIpAddressError] = useState('');
   const [macAddress, setMacAddress] = useState('');
   const [hostname, setHostname] = useState('');
   const [location, setLocation] = useState('');
@@ -41,6 +43,7 @@ export function EditInfrastructureDialog({
       setQuantity(equipment.quantity || 1);
       setCategory(equipment.category || 'network');
       setIpAddress(equipment.ip_address || '');
+      setIpAddressError('');
       setMacAddress(equipment.mac_address || '');
       setHostname(equipment.hostname || '');
       setLocation(equipment.location || '');
@@ -197,9 +200,17 @@ export function EditInfrastructureDialog({
                 type="text"
                 value={ipAddress}
                 onChange={(e) => setIpAddress(e.target.value)}
+                onBlur={() =>
+                  setIpAddressError(
+                    ipAddress && !isValidIPv4(ipAddress) ? 'Invalid IP address' : '',
+                  )
+                }
                 className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
                 placeholder="e.g., 10.0.1.100"
               />
+              {ipAddressError && (
+                <p className="text-xs text-red-600 dark:text-red-400 mt-1">{ipAddressError}</p>
+              )}
             </div>
 
             {/* MAC Address */}

--- a/apps/desktop/src/renderer/src/components/infrastructure/PortAssignmentEditor.tsx
+++ b/apps/desktop/src/renderer/src/components/infrastructure/PortAssignmentEditor.tsx
@@ -5,6 +5,7 @@ import { useProjectStore } from '../../store/projectStore';
 import { useFixtureStore } from '../../store/fixtureStore';
 import { useInfrastructureStore } from '../../store/infrastructureStore';
 import { Link, AlertCircle } from 'lucide-react';
+import { isValidVLAN } from '@showstack/shared';
 
 interface PortAssignmentEditorProps {
   equipmentId?: string; // ID of current equipment being edited
@@ -28,6 +29,7 @@ export function PortAssignmentEditor({
   const [linkValidation, setLinkValidation] = useState<
     Record<number, { valid: boolean; error?: string }>
   >({});
+  const [vlanErrors, setVlanErrors] = useState<Record<number, string>>({});
 
   // Initialize port assignments when port count changes
   const handlePortCountChange = (newCount: number) => {
@@ -361,9 +363,24 @@ export function PortAssignmentEditor({
                                 vlan: e.target.value ? parseInt(e.target.value) : undefined,
                               })
                             }
+                            onBlur={() => {
+                              if (pa.vlan !== undefined && !isValidVLAN(pa.vlan)) {
+                                setVlanErrors((prev) => ({
+                                  ...prev,
+                                  [pa.port]: 'VLAN must be between 1 and 4094',
+                                }));
+                              } else {
+                                setVlanErrors((prev) => ({ ...prev, [pa.port]: '' }));
+                              }
+                            }}
                             className="w-full px-2 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
                             placeholder="e.g., 10"
                           />
+                          {vlanErrors[pa.port] && (
+                            <p className="text-xs text-red-600 dark:text-red-400 mt-1">
+                              {vlanErrors[pa.port]}
+                            </p>
+                          )}
                         </div>
                       )}
 

--- a/apps/desktop/src/renderer/src/components/infrastructure/PortUsageIndicator.tsx
+++ b/apps/desktop/src/renderer/src/components/infrastructure/PortUsageIndicator.tsx
@@ -1,14 +1,9 @@
 import { useEffect, useState } from 'react';
 import { logger } from '../../utils/logger';
 import { Activity, AlertCircle, Wifi, WifiOff } from 'lucide-react';
+import { PortStatusResult } from '@showstack/shared';
 
-export interface PortStatusResult {
-  equipment_id: string;
-  ip: string;
-  status: 'reachable' | 'unreachable' | 'timeout';
-  latency_ms?: number;
-  last_checked: number;
-}
+export type { PortStatusResult };
 
 export interface PortUsageStats {
   total_ports: number;

--- a/apps/desktop/src/renderer/src/components/infrastructure/PortUsageIndicator.tsx
+++ b/apps/desktop/src/renderer/src/components/infrastructure/PortUsageIndicator.tsx
@@ -1,6 +1,14 @@
 import { useEffect, useState } from 'react';
 import { logger } from '../../utils/logger';
-import { Activity, AlertCircle } from 'lucide-react';
+import { Activity, AlertCircle, Wifi, WifiOff } from 'lucide-react';
+
+export interface PortStatusResult {
+  equipment_id: string;
+  ip: string;
+  status: 'reachable' | 'unreachable' | 'timeout';
+  latency_ms?: number;
+  last_checked: number;
+}
 
 export interface PortUsageStats {
   total_ports: number;
@@ -19,12 +27,14 @@ interface PortUsageIndicatorProps {
   equipmentId: string;
   compact?: boolean; // Show compact version
   showDetails?: boolean; // Show detailed breakdown
+  connectivityStatus?: PortStatusResult; // Optional reachability result for this equipment
 }
 
 export function PortUsageIndicator({
   equipmentId,
   compact = false,
   showDetails = true,
+  connectivityStatus,
 }: PortUsageIndicatorProps) {
   const [stats, setStats] = useState<PortUsageStats | null>(null);
   const [loading, setLoading] = useState(true);
@@ -65,6 +75,25 @@ export function PortUsageIndicator({
     return 'bg-green-500';
   };
 
+  const ConnectivityBadge = () => {
+    if (!connectivityStatus) return null;
+    if (connectivityStatus.status === 'reachable') {
+      return (
+        <span
+          title={`Reachable${connectivityStatus.latency_ms !== undefined ? ` (${connectivityStatus.latency_ms}ms)` : ''}`}
+        >
+          <Wifi className="w-3.5 h-3.5 text-green-500" />
+        </span>
+      );
+    }
+    const label = connectivityStatus.status === 'timeout' ? 'Timeout — no response' : 'Unreachable';
+    return (
+      <span title={label}>
+        <WifiOff className="w-3.5 h-3.5 text-red-500" />
+      </span>
+    );
+  };
+
   if (compact) {
     return (
       <div className="flex items-center gap-2">
@@ -75,6 +104,7 @@ export function PortUsageIndicator({
         <span className={`text-xs font-medium ${getUsageColor()}`}>
           ({stats.usage_percentage}%)
         </span>
+        <ConnectivityBadge />
       </div>
     );
   }
@@ -85,7 +115,12 @@ export function PortUsageIndicator({
       <div className="flex items-center gap-3">
         <div className="flex-1">
           <div className="flex justify-between items-center mb-1">
-            <span className="text-xs font-medium text-gray-700 dark:text-gray-300">Port Usage</span>
+            <div className="flex items-center gap-1.5">
+              <span className="text-xs font-medium text-gray-700 dark:text-gray-300">
+                Port Usage
+              </span>
+              <ConnectivityBadge />
+            </div>
             <span className={`text-xs font-medium ${getUsageColor()}`}>
               {stats.usage_percentage}%
             </span>
@@ -157,6 +192,18 @@ export function PortUsageIndicator({
               </div>
             )}
           </div>
+        </div>
+      )}
+
+      {/* Connectivity warning */}
+      {connectivityStatus && connectivityStatus.status !== 'reachable' && (
+        <div className="flex items-center gap-2 text-xs text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 px-2 py-1.5 rounded">
+          <WifiOff className="w-3.5 h-3.5" />
+          <span>
+            {connectivityStatus.status === 'timeout'
+              ? `No response from ${connectivityStatus.ip} (timeout)`
+              : `${connectivityStatus.ip} is unreachable`}
+          </span>
         </div>
       )}
 

--- a/apps/desktop/src/renderer/src/pages/modules/EquipmentManager.tsx
+++ b/apps/desktop/src/renderer/src/pages/modules/EquipmentManager.tsx
@@ -67,6 +67,8 @@ interface EquipmentManagerProps {
 let _sessionColumnVisibility: ColumnVisibility | null = null;
 let _sessionInfrastructureColumnVisibility: InfrastructureColumnVisibility | null = null;
 
+const NETWORK_STATUS_POLL_INTERVAL_MS = 10_000;
+
 export function EquipmentManager({ initialTab = 'fixtures' }: EquipmentManagerProps = {}) {
   const navigate = useNavigate();
   const { projectId: routeProjectId } = useParams<{ projectId?: string; moduleType?: string }>();
@@ -534,7 +536,7 @@ export function EquipmentManager({ initialTab = 'fixtures' }: EquipmentManagerPr
     const poll = async () => {
       await fetchPortStatus();
       if (!cancelled) {
-        networkStatusIntervalRef.current = setTimeout(poll, 10_000);
+        networkStatusIntervalRef.current = setTimeout(poll, NETWORK_STATUS_POLL_INTERVAL_MS);
       }
     };
     poll();

--- a/apps/desktop/src/renderer/src/pages/modules/EquipmentManager.tsx
+++ b/apps/desktop/src/renderer/src/pages/modules/EquipmentManager.tsx
@@ -93,7 +93,7 @@ export function EquipmentManager({ initialTab = 'fixtures' }: EquipmentManagerPr
   const [networkStatusOpen, setNetworkStatusOpen] = useState(false);
   const [portStatusResults, setPortStatusResults] = useState<PortStatusResult[]>([]);
   const [networkStatusLoading, setNetworkStatusLoading] = useState(false);
-  const networkStatusIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const networkStatusIntervalRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [isAddFixtureDialogOpen, setIsAddFixtureDialogOpen] = useState(false);
   const [isAddInfrastructureDialogOpen, setIsAddInfrastructureDialogOpen] = useState(false);
   const [isEditInfrastructureDialogOpen, setIsEditInfrastructureDialogOpen] = useState(false);
@@ -526,15 +526,22 @@ export function EquipmentManager({ initialTab = 'fixtures' }: EquipmentManagerPr
     }
   }, [currentProjectId, infrastructureEquipment]);
 
-  // Auto-refresh network status every 10s when panel is open
+  // Auto-refresh network status every 10s when panel is open.
+  // Uses recursive setTimeout so a slow check never overlaps the next one.
   useEffect(() => {
-    if (networkStatusOpen && activeTab === 'infrastructure') {
-      fetchPortStatus();
-      networkStatusIntervalRef.current = setInterval(fetchPortStatus, 10_000);
-    }
+    if (!networkStatusOpen || activeTab !== 'infrastructure') return;
+    let cancelled = false;
+    const poll = async () => {
+      await fetchPortStatus();
+      if (!cancelled) {
+        networkStatusIntervalRef.current = setTimeout(poll, 10_000);
+      }
+    };
+    poll();
     return () => {
+      cancelled = true;
       if (networkStatusIntervalRef.current) {
-        clearInterval(networkStatusIntervalRef.current);
+        clearTimeout(networkStatusIntervalRef.current);
         networkStatusIntervalRef.current = null;
       }
     };

--- a/apps/desktop/src/renderer/src/pages/modules/EquipmentManager.tsx
+++ b/apps/desktop/src/renderer/src/pages/modules/EquipmentManager.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useRef } from 'react';
+import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { logger } from '../../utils/logger';
 import { VirtualDataGrid } from '../../components/fixture/VirtualDataGrid';
@@ -12,6 +12,7 @@ import { UserColumnSettingsDialog } from '../../components/fixture/UserColumnSet
 import { InfrastructureToolbar } from '../../components/infrastructure/InfrastructureToolbar';
 import { AddInfrastructureDialog } from '../../components/infrastructure/AddInfrastructureDialog';
 import { EditInfrastructureDialog } from '../../components/infrastructure/EditInfrastructureDialog';
+import { PortStatusResult } from '../../components/infrastructure/PortUsageIndicator';
 import {
   ExportHeaderDialog,
   ExportHeaderOptions,
@@ -87,6 +88,12 @@ export function EquipmentManager({ initialTab = 'fixtures' }: EquipmentManagerPr
 
   const [selectedRows, setSelectedRows] = useState<Set<string>>(new Set());
   const [selectedInfrastructure, setSelectedInfrastructure] = useState<Set<string>>(new Set());
+
+  // Network Status panel state (Issue #20)
+  const [networkStatusOpen, setNetworkStatusOpen] = useState(false);
+  const [portStatusResults, setPortStatusResults] = useState<PortStatusResult[]>([]);
+  const [networkStatusLoading, setNetworkStatusLoading] = useState(false);
+  const networkStatusIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const [isAddFixtureDialogOpen, setIsAddFixtureDialogOpen] = useState(false);
   const [isAddInfrastructureDialogOpen, setIsAddInfrastructureDialogOpen] = useState(false);
   const [isEditInfrastructureDialogOpen, setIsEditInfrastructureDialogOpen] = useState(false);
@@ -495,6 +502,42 @@ export function EquipmentManager({ initialTab = 'fixtures' }: EquipmentManagerPr
     };
     savePreference();
   }, [infrastructureColumnVisibility, currentProjectId]);
+
+  // Network Status fetch (Issue #20)
+  const fetchPortStatus = useCallback(async () => {
+    if (!currentProjectId || infrastructureEquipment.length === 0) return;
+    setNetworkStatusLoading(true);
+    try {
+      const results = await window.api.infrastructure.getPortStatusReport(
+        currentProjectId,
+        infrastructureEquipment.map((e) => ({ id: e.id, ip_address: e.ip_address ?? null })),
+      );
+      setPortStatusResults(results as PortStatusResult[]);
+    } catch (error) {
+      logger.error('Failed to fetch port status:', error);
+    } finally {
+      setNetworkStatusLoading(false);
+    }
+  }, [currentProjectId, infrastructureEquipment]);
+
+  // Auto-refresh network status every 10s when panel is open
+  useEffect(() => {
+    if (networkStatusOpen && activeTab === 'infrastructure') {
+      fetchPortStatus();
+      networkStatusIntervalRef.current = setInterval(fetchPortStatus, 10_000);
+    } else {
+      if (networkStatusIntervalRef.current) {
+        clearInterval(networkStatusIntervalRef.current);
+        networkStatusIntervalRef.current = null;
+      }
+    }
+    return () => {
+      if (networkStatusIntervalRef.current) {
+        clearInterval(networkStatusIntervalRef.current);
+        networkStatusIntervalRef.current = null;
+      }
+    };
+  }, [networkStatusOpen, activeTab, fetchPortStatus]);
 
   // Sort handler - supports multi-column sort with Shift key
   const handleSort = (field: string, addToExisting: boolean = false) => {
@@ -1470,6 +1513,74 @@ export function EquipmentManager({ initialTab = 'fixtures' }: EquipmentManagerPr
               </table>
             </div>
           </main>
+
+          {/* Network Status Panel (Issue #20) */}
+          <div className="flex-shrink-0 border-t border-gray-200 dark:border-gray-700">
+            <button
+              onClick={() => setNetworkStatusOpen((o) => !o)}
+              className="w-full px-4 py-2 flex items-center justify-between text-xs font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition"
+            >
+              <span>Network Status</span>
+              <span>{networkStatusOpen ? '▼' : '▶'}</span>
+            </button>
+            {networkStatusOpen && (
+              <div className="px-4 pb-3 bg-gray-50 dark:bg-gray-900">
+                {networkStatusLoading && portStatusResults.length === 0 ? (
+                  <p className="text-xs text-gray-500 dark:text-gray-400 py-2">Checking…</p>
+                ) : portStatusResults.length === 0 ? (
+                  <p className="text-xs text-gray-500 dark:text-gray-400 py-2">
+                    No equipment with IP addresses configured
+                  </p>
+                ) : (
+                  <div className="divide-y divide-gray-200 dark:divide-gray-700">
+                    {portStatusResults.map((r) => {
+                      const eq = infrastructureEquipment.find((e) => e.id === r.equipment_id);
+                      return (
+                        <div
+                          key={r.equipment_id}
+                          className="flex items-center gap-3 py-1.5 text-xs"
+                        >
+                          <span
+                            className={`w-2 h-2 rounded-full flex-shrink-0 ${
+                              r.status === 'reachable'
+                                ? 'bg-green-500'
+                                : r.status === 'timeout'
+                                  ? 'bg-yellow-500'
+                                  : 'bg-red-500'
+                            }`}
+                          />
+                          <span className="font-medium text-gray-900 dark:text-white truncate min-w-0">
+                            {eq?.name ?? r.equipment_id}
+                          </span>
+                          <span className="text-gray-500 dark:text-gray-400 font-mono flex-shrink-0">
+                            {r.ip}
+                          </span>
+                          <span
+                            className={`flex-shrink-0 ${
+                              r.status === 'reachable'
+                                ? 'text-green-600 dark:text-green-400'
+                                : r.status === 'timeout'
+                                  ? 'text-yellow-600 dark:text-yellow-400'
+                                  : 'text-red-600 dark:text-red-400'
+                            }`}
+                          >
+                            {r.status === 'reachable'
+                              ? r.latency_ms !== undefined
+                                ? `reachable (${r.latency_ms}ms)`
+                                : 'reachable'
+                              : r.status}
+                          </span>
+                          <span className="text-gray-400 dark:text-gray-500 ml-auto flex-shrink-0">
+                            {new Date(r.last_checked).toLocaleTimeString()}
+                          </span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
 
           {/* Status Bar */}
           <footer className="bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 px-4 py-2 flex items-center justify-between text-sm text-gray-600 dark:text-gray-400">

--- a/apps/desktop/src/renderer/src/pages/modules/EquipmentManager.tsx
+++ b/apps/desktop/src/renderer/src/pages/modules/EquipmentManager.tsx
@@ -531,11 +531,6 @@ export function EquipmentManager({ initialTab = 'fixtures' }: EquipmentManagerPr
     if (networkStatusOpen && activeTab === 'infrastructure') {
       fetchPortStatus();
       networkStatusIntervalRef.current = setInterval(fetchPortStatus, 10_000);
-    } else {
-      if (networkStatusIntervalRef.current) {
-        clearInterval(networkStatusIntervalRef.current);
-        networkStatusIntervalRef.current = null;
-      }
     }
     return () => {
       if (networkStatusIntervalRef.current) {

--- a/apps/desktop/src/renderer/src/pages/modules/EquipmentManager.tsx
+++ b/apps/desktop/src/renderer/src/pages/modules/EquipmentManager.tsx
@@ -189,6 +189,12 @@ export function EquipmentManager({ initialTab = 'fixtures' }: EquipmentManagerPr
     return INFRASTRUCTURE_COLUMN_CONFIGS.filter((col) => infrastructureColumnVisibility[col.key]);
   }, [infrastructureColumnVisibility]);
 
+  // O(1) lookup map for Network Status panel
+  const infrastructureEquipmentMap = useMemo(
+    () => new Map(infrastructureEquipment.map((e) => [e.id, e])),
+    [infrastructureEquipment],
+  );
+
   // Helper function to render infrastructure cell value
   const renderInfrastructureCellValue = (equipment: any, columnKey: InfrastructureColumnKey) => {
     const value = equipment[columnKey];
@@ -1534,7 +1540,7 @@ export function EquipmentManager({ initialTab = 'fixtures' }: EquipmentManagerPr
                 ) : (
                   <div className="divide-y divide-gray-200 dark:divide-gray-700">
                     {portStatusResults.map((r) => {
-                      const eq = infrastructureEquipment.find((e) => e.id === r.equipment_id);
+                      const eq = infrastructureEquipmentMap.get(r.equipment_id);
                       return (
                         <div
                           key={r.equipment_id}

--- a/apps/desktop/src/renderer/src/pages/modules/EquipmentManager.tsx
+++ b/apps/desktop/src/renderer/src/pages/modules/EquipmentManager.tsx
@@ -1536,19 +1536,24 @@ export function EquipmentManager({ initialTab = 'fixtures' }: EquipmentManagerPr
                   <div className="divide-y divide-gray-200 dark:divide-gray-700">
                     {portStatusResults.map((r) => {
                       const eq = infrastructureEquipmentMap.get(r.equipment_id);
+                      const statusStyle = {
+                        reachable: {
+                          dot: 'bg-green-500',
+                          text: 'text-green-600 dark:text-green-400',
+                        },
+                        timeout: {
+                          dot: 'bg-yellow-500',
+                          text: 'text-yellow-600 dark:text-yellow-400',
+                        },
+                        unreachable: { dot: 'bg-red-500', text: 'text-red-600 dark:text-red-400' },
+                      }[r.status];
                       return (
                         <div
                           key={r.equipment_id}
                           className="flex items-center gap-3 py-1.5 text-xs"
                         >
                           <span
-                            className={`w-2 h-2 rounded-full flex-shrink-0 ${
-                              r.status === 'reachable'
-                                ? 'bg-green-500'
-                                : r.status === 'timeout'
-                                  ? 'bg-yellow-500'
-                                  : 'bg-red-500'
-                            }`}
+                            className={`w-2 h-2 rounded-full flex-shrink-0 ${statusStyle.dot}`}
                           />
                           <span className="font-medium text-gray-900 dark:text-white truncate min-w-0">
                             {eq?.name ?? r.equipment_id}
@@ -1556,19 +1561,9 @@ export function EquipmentManager({ initialTab = 'fixtures' }: EquipmentManagerPr
                           <span className="text-gray-500 dark:text-gray-400 font-mono flex-shrink-0">
                             {r.ip}
                           </span>
-                          <span
-                            className={`flex-shrink-0 ${
-                              r.status === 'reachable'
-                                ? 'text-green-600 dark:text-green-400'
-                                : r.status === 'timeout'
-                                  ? 'text-yellow-600 dark:text-yellow-400'
-                                  : 'text-red-600 dark:text-red-400'
-                            }`}
-                          >
-                            {r.status === 'reachable'
-                              ? r.latency_ms !== undefined
-                                ? `reachable (${r.latency_ms}ms)`
-                                : 'reachable'
+                          <span className={`flex-shrink-0 ${statusStyle.text}`}>
+                            {r.status === 'reachable' && r.latency_ms !== undefined
+                              ? `reachable (${r.latency_ms}ms)`
                               : r.status}
                           </span>
                           <span className="text-gray-400 dark:text-gray-500 ml-auto flex-shrink-0">

--- a/apps/desktop/src/shared/types/network.types.ts
+++ b/apps/desktop/src/shared/types/network.types.ts
@@ -1,0 +1,1 @@
+export type { PortStatusResult } from '@showstack/shared';

--- a/docs/features/console-integration-plan.md
+++ b/docs/features/console-integration-plan.md
@@ -4,7 +4,7 @@
 **Delivery:** Phased approach with 5 iterative milestones
 **Timeline:** 10 weeks (2.5 months)
 **Effort:** 1 developer full-time
-**Status:** Next up (not yet implemented)
+**Status:** In progress — network prerequisites complete; Phase 1 (Eos OSC) next
 **Created:** January 20, 2026
 **Updated:** March 27, 2026
 **Priority:** High (competitive gap with Lightwright, professional workflow integration)
@@ -54,79 +54,60 @@ Both console integration and IP/VLAN port validation (Issue #17) require network
 - **Shared network utility** — A small `packages/shared/src/utils/networkValidation.ts` covering IPv4 parse/validate and VLAN range check can serve both features (importable from both renderer and main). Write it as part of Phase 1 setup.
 - **Port reachability monitoring** — Before initiating OSC/Telnet connections to a console, and for ongoing infrastructure health (Issue #20), the app needs TCP reachability checks per equipment IP. A `PortStatusMonitorService` (modeled after `HealthChecker.ts`) performs `net.createConnection()` checks with a 2-second timeout and caches results for 5–10 seconds. This serves both Issue #20's status dashboard and console integration's pre-connect validation.
 
-### Recommended Sequencing
+### Completed Steps (branch: `feature/console-network-prereqs`)
 
-Phase 1 of console integration is the natural moment to also close Issue #17:
+**✅ Step 1 — `packages/shared/src/utils/networkValidation.ts`** (shipped)
 
-**Step 1 — Create `packages/shared/src/utils/networkValidation.ts`** (new file):
+- `isValidIPv4`, `parseIPWithPort`, `isValidVLAN` — exported from `@showstack/shared`
+- 18 tests, 100% coverage
 
-```ts
-export function isValidIPv4(value: string): boolean {
-  /* validate all 4 octets are 0-255 */
-}
-export function parseIPWithPort(value: string): { ip: string; port?: number } | null {
-  /* e.g. "192.168.1.100:3032" */
-}
-export function isValidVLAN(value: number): boolean {
-  return value >= 1 && value <= 4094;
-}
-```
+**✅ Step 2 — Zod IP validation in `packages/shared/src/validation/schemas/infrastructure.ts`** (shipped)
 
-**Step 2 — Fix Zod IP regex in `packages/shared/src/validation/schemas/infrastructure.ts`** (line 78):
+- `ip_address`, `subnet_mask`, and `gateway` fields now use `refine(isValidIPv4)` — closes the `999.x.x.x` false-positive
 
-The current regex `/^(?:\d{1,3}\.){3}\d{1,3}$/` allows `999.999.999.999`. Replace with a `refine()` call that delegates to `isValidIPv4()` for proper per-octet 0–255 validation.
+**✅ Step 3 — Inline IP validation in infrastructure dialogs** (shipped)
 
-**Step 3 — Add inline IP validation to infrastructure dialogs** (Issue #17 UI):
+- `EditInfrastructureDialog.tsx` and `AddInfrastructureDialog.tsx`: blur-triggered inline error below IP field
 
-- `apps/desktop/src/renderer/src/components/infrastructure/EditInfrastructureDialog.tsx` (IP Address field, lines 191–201): currently a free-text input with no feedback — add blur handler and inline `<p className="text-xs text-red-600 mt-1">` error when `!isValidIPv4(ipAddress)`
-- `apps/desktop/src/renderer/src/components/infrastructure/AddInfrastructureDialog.tsx`: same IP field — same fix
+**✅ Step 4 — Inline VLAN validation in `PortAssignmentEditor.tsx`** (shipped)
 
-**Step 4 — Add inline VLAN validation to `PortAssignmentEditor.tsx`** (Issue #17 UI):
+- Blur-triggered inline error when VLAN is outside 1–4094
 
-- `apps/desktop/src/renderer/src/components/infrastructure/PortAssignmentEditor.tsx` (VLAN input, lines 349–368): has `type="number" min/max` but shows no error message — add inline `<p className="text-xs text-red-600 mt-1">` error when value is outside 1–4094
+**✅ Step 6 — `apps/desktop/src/main/services/PortStatusMonitorService.ts`** (shipped)
 
-**Step 5 — Wire `parseIPWithPort()` into `ConsoleConnectionDialog.tsx`** (Phase 2):
+- `net.createConnection()` with 2s timeout; ECONNREFUSED = reachable; 8s TTL cache per project
+- 6 tests: connect, ECONNREFUSED, ENETUNREACH, no-IP skip, TTL cache hit, cache-clear re-check
 
-- Validate console IP (+ optional port suffix) on blur before enabling the Connect button
+**✅ Step 7 — `infrastructure:getPortStatusReport` IPC channel** (shipped)
+
+- Added to `ipc/infrastructure.ts`, preload bridge, and type declaration
+
+**✅ Step 8 — `PortUsageIndicator.tsx` connectivity badge** (shipped)
+
+- `connectivityStatus?: PortStatusResult` prop — Wifi/WifiOff icon in compact and full views; inline unreachable warning in full view
+
+**✅ Step 9 — Network Status panel in `EquipmentManager`** (shipped)
+
+- Collapsible section in the Infrastructure tab; per-device color dot, IP, status, latency, last-checked time; auto-refreshes every 10s while open
 
 **UI feedback pattern:** All validation errors follow the same inline pattern — show `<p className="text-xs text-red-600 mt-1">{errorMessage}</p>` on blur or on submit attempt, never as a modal or toast.
 
-**Step 6 — Create `apps/desktop/src/main/services/PortStatusMonitorService.ts`** (new file, Issue #20):
+### Deferred to Phase 2
 
-- Checks each equipment's IP via `net.createConnection()` with a 2-second timeout (no `ping` binary required — avoids macOS/Windows permission complications)
-- Returns `PortStatusResult[]`: `{ equipment_id, ip, status: 'reachable' | 'unreachable' | 'timeout', latency_ms?, last_checked: number }`
-- Caches project-scoped results for 5–10 seconds (follow `HealthChecker.ts` pattern: store result + expiry timestamp, skip re-check if within TTL)
+**Step 5 — Wire `parseIPWithPort()` into `ConsoleConnectionDialog.tsx`**
 
-**Step 7 — Add IPC channel to `apps/desktop/src/main/ipc/infrastructure.ts`** (Issue #20):
+- Validate console IP (+ optional port suffix) on blur before enabling the Connect button
+- Deferred: `ConsoleConnectionDialog.tsx` does not exist yet (Phase 2 deliverable)
 
-- `infrastructure:getPortStatusReport` — calls `PortStatusMonitorService.checkAll(projectId)`, returns cached result within TTL (same pattern as `health.ts` line 15)
-
-**Step 8 — Enhance `PortUsageIndicator.tsx`** (Issue #20 UI):
-
-- Accept optional `connectivityStatus?: PortStatusResult[]` prop
-- When provided, update the `error` bucket to reflect unreachable devices and show a per-device connectivity badge (green dot / red dot) alongside the existing usage bar
-
-**Step 9 — Add Network Status panel to the Infrastructure page** (Issue #20 status dashboard):
-
-- Collapsible "Network Status" section listing each device with its reachability status and last-checked time
-- Auto-refreshes every 10 seconds via `setInterval` calling `window.api.infrastructure.getPortStatusReport(projectId)`
-
-**Step 10 — Wire reachability check into `ConsoleConnectionDialog.tsx`** (Phase 2, Issue #20 × console integration):
+**Step 10 — Reachability pre-check in `ConsoleConnectionDialog.tsx`** (Issue #20 × console integration)
 
 - Before enabling the Connect button, call `infrastructure:getPortStatusReport` and warn if the entered IP is unreachable
 - Non-blocking: user can still attempt to connect; the warning is informational only
+- Deferred: same reason as Step 5
 
-**Test coverage targets for Issue #17:**
+### Remaining test gap
 
-- `packages/shared/src/utils/__tests__/networkValidation.test.ts` — 100% coverage of `isValidIPv4`, `parseIPWithPort`, `isValidVLAN` (edge cases: octet 0/255/256, port 0/65535/65536, VLAN 1/4094/4095)
-- Infrastructure dialog tests — add IP/VLAN validation feedback cases to existing test files for `EditInfrastructureDialog`, `AddInfrastructureDialog`, and `PortAssignmentEditor`
-
-**Test coverage targets for Issue #20:**
-
-- `apps/desktop/src/main/services/__tests__/PortStatusMonitorService.test.ts` — mock `net.createConnection()`; test: reachable (fast connect), unreachable (connection refused), timeout (no response within 2s), TTL cache hit, TTL cache miss/expiry
 - `apps/desktop/src/main/ipc/__tests__/infrastructure.test.ts` — add `infrastructure:getPortStatusReport` handler test (returns cached result, calls service on cache miss)
-
-Both issue #17 and #20 ship in the same PR or back-to-back PRs with minimal additional effort.
 
 ---
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -16,3 +16,6 @@ export * from './validation';
 
 // Auth utilities
 export * from './auth/passwordPolicy';
+
+// Network utilities
+export * from './utils/networkValidation';

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -17,5 +17,6 @@ export * from './validation';
 // Auth utilities
 export * from './auth/passwordPolicy';
 
-// Network utilities
+// Network utilities and types
 export * from './utils/networkValidation';
+export * from './types/network';

--- a/packages/shared/src/types/network.ts
+++ b/packages/shared/src/types/network.ts
@@ -1,0 +1,7 @@
+export interface PortStatusResult {
+  equipment_id: string;
+  ip: string;
+  status: 'reachable' | 'unreachable' | 'timeout';
+  latency_ms?: number;
+  last_checked: number;
+}

--- a/packages/shared/src/utils/__tests__/networkValidation.test.ts
+++ b/packages/shared/src/utils/__tests__/networkValidation.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { isValidIPv4, parseIPWithPort, isValidVLAN } from '../networkValidation';
+
+describe('isValidIPv4', () => {
+  it('accepts valid addresses', () => {
+    expect(isValidIPv4('192.168.1.100')).toBe(true);
+    expect(isValidIPv4('0.0.0.0')).toBe(true);
+    expect(isValidIPv4('255.255.255.255')).toBe(true);
+    expect(isValidIPv4('10.0.0.1')).toBe(true);
+  });
+
+  it('rejects octets > 255', () => {
+    expect(isValidIPv4('256.0.0.1')).toBe(false);
+    expect(isValidIPv4('999.999.999.999')).toBe(false);
+    expect(isValidIPv4('192.168.1.256')).toBe(false);
+  });
+
+  it('rejects wrong number of octets', () => {
+    expect(isValidIPv4('192.168.1')).toBe(false);
+    expect(isValidIPv4('192.168.1.1.1')).toBe(false);
+    expect(isValidIPv4('')).toBe(false);
+  });
+
+  it('rejects non-numeric parts', () => {
+    expect(isValidIPv4('192.168.one.1')).toBe(false);
+    expect(isValidIPv4('192.168.1.x')).toBe(false);
+  });
+
+  it('rejects missing octets', () => {
+    expect(isValidIPv4('192.168..1')).toBe(false);
+  });
+});
+
+describe('parseIPWithPort', () => {
+  it('parses plain IP with no port', () => {
+    expect(parseIPWithPort('192.168.1.100')).toEqual({ ip: '192.168.1.100' });
+  });
+
+  it('parses IP with port', () => {
+    expect(parseIPWithPort('192.168.1.100:3032')).toEqual({ ip: '192.168.1.100', port: 3032 });
+  });
+
+  it('accepts port 0', () => {
+    expect(parseIPWithPort('10.0.0.1:0')).toEqual({ ip: '10.0.0.1', port: 0 });
+  });
+
+  it('accepts port 65535', () => {
+    expect(parseIPWithPort('10.0.0.1:65535')).toEqual({ ip: '10.0.0.1', port: 65535 });
+  });
+
+  it('rejects port 65536', () => {
+    expect(parseIPWithPort('10.0.0.1:65536')).toBeNull();
+  });
+
+  it('returns null for invalid IP', () => {
+    expect(parseIPWithPort('999.0.0.1')).toBeNull();
+    expect(parseIPWithPort('not-an-ip')).toBeNull();
+  });
+
+  it('returns null for non-numeric port', () => {
+    expect(parseIPWithPort('192.168.1.1:abc')).toBeNull();
+  });
+
+  it('handles trailing colon as no port', () => {
+    expect(parseIPWithPort('192.168.1.1:')).toEqual({ ip: '192.168.1.1' });
+  });
+});
+
+describe('isValidVLAN', () => {
+  it('accepts valid VLAN IDs', () => {
+    expect(isValidVLAN(1)).toBe(true);
+    expect(isValidVLAN(4094)).toBe(true);
+    expect(isValidVLAN(100)).toBe(true);
+  });
+
+  it('rejects 0', () => {
+    expect(isValidVLAN(0)).toBe(false);
+  });
+
+  it('rejects 4095', () => {
+    expect(isValidVLAN(4095)).toBe(false);
+  });
+
+  it('rejects negative values', () => {
+    expect(isValidVLAN(-1)).toBe(false);
+  });
+
+  it('rejects non-integers', () => {
+    expect(isValidVLAN(10.5)).toBe(false);
+  });
+});

--- a/packages/shared/src/utils/networkValidation.ts
+++ b/packages/shared/src/utils/networkValidation.ts
@@ -1,0 +1,50 @@
+/**
+ * Network validation utilities
+ *
+ * Used by both main process (PortStatusMonitorService, console integration)
+ * and renderer (infrastructure dialogs, ConsoleConnectionDialog).
+ */
+
+/**
+ * Returns true if value is a valid IPv4 address (each octet 0–255).
+ */
+export function isValidIPv4(value: string): boolean {
+  const parts = value.split('.');
+  if (parts.length !== 4) return false;
+  return parts.every((part) => {
+    if (!/^\d+$/.test(part)) return false;
+    const n = parseInt(part, 10);
+    return n >= 0 && n <= 255;
+  });
+}
+
+/**
+ * Parses an IP address with an optional port suffix (e.g. "192.168.1.100:3032").
+ * Returns null if the IP portion is invalid.
+ */
+export function parseIPWithPort(value: string): { ip: string; port?: number } | null {
+  const lastColon = value.lastIndexOf(':');
+  if (lastColon === -1) {
+    return isValidIPv4(value) ? { ip: value } : null;
+  }
+
+  const ip = value.slice(0, lastColon);
+  const portStr = value.slice(lastColon + 1);
+
+  if (!isValidIPv4(ip)) return null;
+
+  if (portStr === '') return { ip };
+
+  if (!/^\d+$/.test(portStr)) return null;
+  const port = parseInt(portStr, 10);
+  if (port < 0 || port > 65535) return null;
+
+  return { ip, port };
+}
+
+/**
+ * Returns true if value is a valid IEEE 802.1Q VLAN ID (1–4094).
+ */
+export function isValidVLAN(value: number): boolean {
+  return Number.isInteger(value) && value >= 1 && value <= 4094;
+}

--- a/packages/shared/src/validation/schemas/infrastructure.ts
+++ b/packages/shared/src/validation/schemas/infrastructure.ts
@@ -77,19 +77,16 @@ export const InfrastructureEquipmentSchema = extendBaseEntity({
   ip_address: z
     .string()
     .refine((v) => v === '' || isValidIPv4(v), 'Invalid IP address')
-    .optional()
-    .or(z.literal('')),
+    .optional(),
   mac_address: z.string().optional(),
   subnet_mask: z
     .string()
     .refine((v) => v === '' || isValidIPv4(v), 'Invalid subnet mask')
-    .optional()
-    .or(z.literal('')),
+    .optional(),
   gateway: z
     .string()
     .refine((v) => v === '' || isValidIPv4(v), 'Invalid gateway address')
-    .optional()
-    .or(z.literal('')),
+    .optional(),
   vlan_id: z.number().int().min(1).max(4094).optional(),
   hostname: z.string().optional(),
 

--- a/packages/shared/src/validation/schemas/infrastructure.ts
+++ b/packages/shared/src/validation/schemas/infrastructure.ts
@@ -6,6 +6,7 @@
 
 import { z } from 'zod';
 import { extendBaseEntity, OptionalIDSchema } from '../base';
+import { isValidIPv4 } from '../../utils/networkValidation';
 
 /**
  * Port type options
@@ -75,18 +76,18 @@ export const InfrastructureEquipmentSchema = extendBaseEntity({
   // Network information (all optional)
   ip_address: z
     .string()
-    .regex(/^(?:\d{1,3}\.){3}\d{1,3}$/, 'Invalid IP address')
+    .refine((v) => v === '' || isValidIPv4(v), 'Invalid IP address')
     .optional()
     .or(z.literal('')),
   mac_address: z.string().optional(),
   subnet_mask: z
     .string()
-    .regex(/^(?:\d{1,3}\.){3}\d{1,3}$/, 'Invalid subnet mask')
+    .refine((v) => v === '' || isValidIPv4(v), 'Invalid subnet mask')
     .optional()
     .or(z.literal('')),
   gateway: z
     .string()
-    .regex(/^(?:\d{1,3}\.){3}\d{1,3}$/, 'Invalid gateway address')
+    .refine((v) => v === '' || isValidIPv4(v), 'Invalid gateway address')
     .optional()
     .or(z.literal('')),
   vlan_id: z.number().int().min(1).max(4094).optional(),


### PR DESCRIPTION
## Summary

- Add `packages/shared/src/utils/networkValidation.ts` — `isValidIPv4`, `parseIPWithPort`, `isValidVLAN` exported from `@showstack/shared` (18 tests, 100% coverage)
- Fix Zod IP validation in `infrastructure.ts` schema — replace weak regex with `refine(isValidIPv4)` on `ip_address`, `subnet_mask`, and `gateway` fields (closes #17)
- Add blur-triggered inline IP error to `AddInfrastructureDialog` and `EditInfrastructureDialog`
- Add blur-triggered inline VLAN error (1–4094) to `PortAssignmentEditor`
- Add `PortStatusMonitorService` — TCP reachability via `net.createConnection()`, 2s timeout, ECONNREFUSED = reachable, 8s TTL cache per project (6 tests)
- Add `infrastructure:getPortStatusReport` IPC channel + preload bridge + type declaration
- Enhance `PortUsageIndicator` with optional `connectivityStatus` prop — Wifi/WifiOff badge and inline unreachable warning
- Add collapsible Network Status panel to the Equipment Manager infrastructure tab — per-device dot, IP, status, latency, last-checked time, auto-refreshes every 10s (closes #20)

## Deferred to Phase 2

Steps 5 and 10 (wiring `parseIPWithPort` and the reachability pre-check into `ConsoleConnectionDialog.tsx`) are deferred — that component is a Phase 2 deliverable and doesn't exist yet.

## Test plan

- [ ] `npm run test:run` — all tests pass (24 new tests added)
- [ ] `npx tsc --noEmit` — 0 errors
- [ ] Add infrastructure equipment with IP `999.0.0.1` — Zod validation rejects it
- [ ] Add infrastructure equipment with IP `192.168.1.100`, blur the field — no error shown
- [ ] Add infrastructure equipment with IP `192.168.1.999`, blur the field — inline error appears
- [ ] Edit a port assignment, set VLAN to `5000`, blur — inline error appears
- [ ] Open Equipment Manager → Infrastructure tab → expand "Network Status" — panel appears, dots turn green/yellow/red per device reachability, refreshes every 10s

🤖 Generated with [Claude Code](https://claude.com/claude-code)