### PR TITLE
feat: ETC Eos console integration — Phase 1 (OSC backend) + Phase 2 (UI)

### DIFF
--- a/apps/desktop/src/main/console/eos/__tests__/eosCommandBuilder.test.ts
+++ b/apps/desktop/src/main/console/eos/__tests__/eosCommandBuilder.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import { EosCommandBuilder, mapToEosProfile } from '../eosCommandBuilder';
+
+describe('EosCommandBuilder', () => {
+  const builder = new EosCommandBuilder();
+
+  // ─── buildPatchCommand ────────────────────────────────────────────────────
+
+  describe('buildPatchCommand', () => {
+    it('builds a full patch command', () => {
+      const result = builder.buildPatchCommand({
+        channel: '5',
+        universe: 1,
+        dmx_address: 42,
+        type: 'ETC Source Four 26°',
+        position: '1st Electric',
+        unit_number: 5,
+      });
+      expect(result).toBe('Chan 5 Patch 1/42 Type "Source Four 26deg" Label "1st Electric 5"');
+    });
+
+    it('omits patch address when universe/address are missing', () => {
+      const result = builder.buildPatchCommand({
+        channel: '3',
+        type: 'ETC Source Four 19°',
+      });
+      expect(result).toBe('Chan 3 Type "Source Four 19deg"');
+    });
+
+    it('omits type when not provided', () => {
+      const result = builder.buildPatchCommand({
+        channel: '7',
+        universe: 2,
+        dmx_address: 100,
+      });
+      expect(result).toBe('Chan 7 Patch 2/100');
+    });
+
+    it('omits label when both position and unit_number are missing', () => {
+      const result = builder.buildPatchCommand({
+        channel: '1',
+        universe: 1,
+        dmx_address: 1,
+        type: 'Dimmer',
+      });
+      expect(result).toBe('Chan 1 Patch 1/1 Type "Dimmer"');
+    });
+
+    it('returns null when channel is missing', () => {
+      expect(builder.buildPatchCommand({ universe: 1, dmx_address: 1 })).toBeNull();
+    });
+
+    it('returns null when channel is null', () => {
+      expect(builder.buildPatchCommand({ channel: null })).toBeNull();
+    });
+
+    it('preserves unknown fixture types as-is', () => {
+      const result = builder.buildPatchCommand({
+        channel: '1',
+        type: 'My Custom Fixture',
+      });
+      expect(result).toBe('Chan 1 Type "My Custom Fixture"');
+    });
+
+    it('accepts numeric channel values', () => {
+      const result = builder.buildPatchCommand({ channel: 10 });
+      expect(result).toBe('Chan 10');
+    });
+  });
+
+  // ─── buildBatchPatchCommands ──────────────────────────────────────────────
+
+  describe('buildBatchPatchCommands', () => {
+    it('returns commands for all valid fixtures', () => {
+      const fixtures = [
+        { channel: '1', universe: 1, dmx_address: 1 },
+        { channel: '2', universe: 1, dmx_address: 2 },
+      ];
+      expect(builder.buildBatchPatchCommands(fixtures)).toHaveLength(2);
+    });
+
+    it('skips fixtures without a channel', () => {
+      const fixtures = [{ universe: 1, dmx_address: 1 }, { channel: '2' }];
+      const result = builder.buildBatchPatchCommands(fixtures);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toContain('Chan 2');
+    });
+
+    it('returns empty array for empty input', () => {
+      expect(builder.buildBatchPatchCommands([])).toEqual([]);
+    });
+  });
+
+  // ─── buildLabelCommand ────────────────────────────────────────────────────
+
+  describe('buildLabelCommand', () => {
+    it('builds a label update command', () => {
+      expect(builder.buildLabelCommand(5, 'FOH L 12')).toBe('Chan 5 Label "FOH L 12"');
+    });
+
+    it('accepts string channel', () => {
+      expect(builder.buildLabelCommand('10', 'SR 10')).toBe('Chan 10 Label "SR 10"');
+    });
+  });
+
+  // ─── buildNotesCommand ────────────────────────────────────────────────────
+
+  describe('buildNotesCommand', () => {
+    it('builds a notes update command', () => {
+      expect(builder.buildNotesCommand(3, 'check gobo')).toBe('Chan 3 Note "check gobo"');
+    });
+  });
+
+  // ─── mapToEosProfile ──────────────────────────────────────────────────────
+
+  describe('mapToEosProfile', () => {
+    it('maps known ShowStack types to Eos profiles', () => {
+      expect(mapToEosProfile('ETC Source Four 19°')).toBe('Source Four 19deg');
+      expect(mapToEosProfile('Martin MAC Aura')).toBe('MAC Aura');
+      expect(mapToEosProfile('LED PAR')).toBe('LED Par');
+    });
+
+    it('returns the input unchanged for unknown types', () => {
+      expect(mapToEosProfile('Unknown Fixture')).toBe('Unknown Fixture');
+    });
+  });
+});

--- a/apps/desktop/src/main/console/eos/__tests__/eosOSCClient.test.ts
+++ b/apps/desktop/src/main/console/eos/__tests__/eosOSCClient.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
+
+vi.mock('../../../utils/logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const mocks = vi.hoisted(() => {
+  const { EventEmitter: EE } = require('events') as { EventEmitter: typeof EventEmitter };
+
+  const clientInstance = {
+    send: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+
+  // Tracks all Server instances so tests can inspect them
+  const serverInstances: EventEmitter[] = [];
+
+  class ServerMock extends EE {
+    close = vi.fn().mockResolvedValue(undefined);
+    constructor() {
+      super();
+      serverInstances.push(this);
+      setTimeout(() => this.emit('listening'), 0);
+    }
+  }
+
+  const ClientMock = vi.fn().mockReturnValue(clientInstance);
+  const ServerMockFn = vi.fn().mockImplementation(() => new ServerMock());
+
+  return { ClientMock, ServerMockFn, ServerMock, clientInstance, serverInstances };
+});
+
+vi.mock('node-osc', () => ({
+  Client: mocks.ClientMock,
+  Server: mocks.ServerMockFn,
+}));
+
+import { EosOSCClient, EOS_OSC_PORT } from '../eosOSCClient';
+
+describe('EosOSCClient', () => {
+  let client: EosOSCClient;
+
+  beforeEach(() => {
+    mocks.clientInstance.send.mockResolvedValue(undefined);
+    mocks.clientInstance.close.mockResolvedValue(undefined);
+    mocks.ClientMock.mockClear();
+    mocks.ClientMock.mockReturnValue(mocks.clientInstance);
+    mocks.serverInstances.length = 0;
+    mocks.ServerMockFn.mockClear();
+    mocks.ServerMockFn.mockImplementation(() => new mocks.ServerMock());
+    client = new EosOSCClient('10.0.0.100');
+  });
+
+  // ─── constructor ──────────────────────────────────────────────────────────
+
+  it('creates an OSC Client with the given IP and default port', () => {
+    expect(mocks.ClientMock).toHaveBeenCalledWith('10.0.0.100', EOS_OSC_PORT);
+  });
+
+  it('accepts a custom port', () => {
+    new EosOSCClient('10.0.0.1', 8000);
+    expect(mocks.ClientMock).toHaveBeenCalledWith('10.0.0.1', 8000);
+  });
+
+  // ─── connect ──────────────────────────────────────────────────────────────
+
+  it('resolves when the Server emits listening', async () => {
+    await expect(client.connect()).resolves.toBeUndefined();
+    expect(mocks.ServerMockFn).toHaveBeenCalled();
+  });
+
+  it('is a no-op if already connected', async () => {
+    await client.connect();
+    const callCount = mocks.ServerMockFn.mock.calls.length;
+    await client.connect();
+    expect(mocks.ServerMockFn.mock.calls.length).toBe(callCount);
+  });
+
+  // ─── disconnect ───────────────────────────────────────────────────────────
+
+  it('closes the client socket', async () => {
+    await client.disconnect();
+    expect(mocks.clientInstance.close).toHaveBeenCalled();
+  });
+
+  it('closes the server if connected', async () => {
+    await client.connect();
+    const serverInstance = mocks.serverInstances[0] as unknown as {
+      close: ReturnType<typeof vi.fn>;
+    };
+    await client.disconnect();
+    expect(serverInstance.close).toHaveBeenCalled();
+  });
+
+  // ─── send ─────────────────────────────────────────────────────────────────
+
+  it('delegates to client.send with address and args', async () => {
+    await client.send('/eos/newcmd', 'Chan 1 Patch 1/1');
+    expect(mocks.clientInstance.send).toHaveBeenCalledWith('/eos/newcmd', 'Chan 1 Patch 1/1');
+  });
+
+  it('sends address-only message when no args provided', async () => {
+    await client.send('/eos/get/patch');
+    expect(mocks.clientInstance.send).toHaveBeenCalledWith('/eos/get/patch');
+  });
+
+  // ─── getPatch ─────────────────────────────────────────────────────────────
+
+  it('resolves with empty array when count is 0', async () => {
+    await client.connect();
+    const serverInstance = mocks.serverInstances[0] as EventEmitter;
+
+    const patchPromise = client.getPatch();
+    setTimeout(() => serverInstance.emit('message', ['/eos/out/patch/count', 0]), 0);
+
+    await expect(patchPromise).resolves.toEqual([]);
+  });
+
+  it('collects all channel messages then resolves', async () => {
+    await client.connect();
+    const serverInstance = mocks.serverInstances[0] as EventEmitter;
+
+    const patchPromise = client.getPatch();
+    setTimeout(() => {
+      serverInstance.emit('message', ['/eos/out/patch/count', 2]);
+      serverInstance.emit('message', ['/eos/out/patch/0', 1, '1/1', 'Leko', 'SR 1', '']);
+      serverInstance.emit('message', ['/eos/out/patch/1', 2, '1/2', 'Fresnel', 'SR 2', '']);
+    }, 0);
+
+    const result = await patchPromise;
+    expect(result).toHaveLength(2);
+    expect(result[0][0]).toBe('/eos/out/patch/0');
+    expect(result[1][0]).toBe('/eos/out/patch/1');
+  });
+
+  it('rejects if timeout elapses before count message', async () => {
+    await client.connect();
+    await expect(client.getPatch(50)).rejects.toThrow('timed out');
+  });
+
+  it('rejects if not connected', async () => {
+    await expect(client.getPatch()).rejects.toThrow('Not connected');
+  });
+});

--- a/apps/desktop/src/main/console/eos/__tests__/eosOSCClient.test.ts
+++ b/apps/desktop/src/main/console/eos/__tests__/eosOSCClient.test.ts
@@ -157,4 +157,19 @@ describe('EosOSCClient', () => {
   it('rejects if not connected', async () => {
     await expect(client.getPatch()).rejects.toThrow('Not connected');
   });
+
+  it('rejects concurrent getPatch calls immediately', async () => {
+    await client.connect();
+    const serverInstance = mocks.serverInstances[0] as EventEmitter;
+
+    // Start a query but never resolve it (no messages sent)
+    const first = client.getPatch(5_000);
+
+    // Second call should be rejected synchronously before any I/O
+    await expect(client.getPatch()).rejects.toThrow('already in progress');
+
+    // Clean up: resolve the first query
+    serverInstance.emit('message', ['/eos/out/patch/count', 0]);
+    await first;
+  });
 });

--- a/apps/desktop/src/main/console/eos/__tests__/eosOSCClient.test.ts
+++ b/apps/desktop/src/main/console/eos/__tests__/eosOSCClient.test.ts
@@ -139,6 +139,21 @@ describe('EosOSCClient', () => {
     await expect(client.getPatch(50)).rejects.toThrow('timed out');
   });
 
+  it('rejects via inactivity timer if channel messages stall mid-stream', async () => {
+    await client.connect();
+    const serverInstance = mocks.serverInstances[0] as EventEmitter;
+
+    const patchPromise = client.getPatch(5_000);
+    setTimeout(() => {
+      // Send count (2 channels) but only deliver one — simulates a stall
+      serverInstance.emit('message', ['/eos/out/patch/count', 2]);
+      serverInstance.emit('message', ['/eos/out/patch/0', 1, '1/1', 'Leko', 'SR 1', '']);
+      // Second channel message never arrives → inactivity timer fires
+    }, 0);
+
+    await expect(patchPromise).rejects.toThrow('timed out');
+  });
+
   it('rejects if not connected', async () => {
     await expect(client.getPatch()).rejects.toThrow('Not connected');
   });

--- a/apps/desktop/src/main/console/eos/__tests__/eosPatchParser.test.ts
+++ b/apps/desktop/src/main/console/eos/__tests__/eosPatchParser.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import { EosPatchParser } from '../eosPatchParser';
+
+describe('EosPatchParser', () => {
+  const parser = new EosPatchParser();
+
+  // ─── parseChannelMessage ───────────────────────────────────────────────────
+
+  describe('parseChannelMessage', () => {
+    it('parses a fully-populated channel message', () => {
+      const msg: [string, ...unknown[]] = [
+        '/eos/out/patch/0',
+        5,
+        '1/42',
+        'Source Four 26deg',
+        '1st Electric 5',
+        'spare unit',
+      ];
+      const result = parser.parseChannelMessage(msg as [string, ...(string | number | boolean)[]]);
+      expect(result).toEqual({
+        channelNumber: 5,
+        universe: 1,
+        address: 42,
+        fixtureType: 'Source Four 26deg',
+        label: '1st Electric 5',
+        notes: 'spare unit',
+      });
+    });
+
+    it('returns null if address string does not match patch pattern', () => {
+      const msg: [string, ...unknown[]] = ['/eos/out/patch/count', 10];
+      expect(
+        parser.parseChannelMessage(msg as [string, ...(string | number | boolean)[]]),
+      ).toBeNull();
+    });
+
+    it('returns null if channel number is missing', () => {
+      const msg: [string] = ['/eos/out/patch/0'];
+      expect(
+        parser.parseChannelMessage(msg as unknown as [string, ...(string | number | boolean)[]]),
+      ).toBeNull();
+    });
+
+    it('returns null if channel number is non-positive', () => {
+      const msg: [string, ...unknown[]] = ['/eos/out/patch/0', 0, '1/1', 'Dimmer', '', ''];
+      expect(
+        parser.parseChannelMessage(msg as [string, ...(string | number | boolean)[]]),
+      ).toBeNull();
+    });
+
+    it('handles un-patched channel (empty address string)', () => {
+      const msg: [string, ...unknown[]] = ['/eos/out/patch/0', 3, '', 'Dimmer', 'SR 3', ''];
+      const result = parser.parseChannelMessage(msg as [string, ...(string | number | boolean)[]]);
+      expect(result?.universe).toBeNull();
+      expect(result?.address).toBeNull();
+    });
+
+    it('parses high universe/address values', () => {
+      const msg: [string, ...unknown[]] = ['/eos/out/patch/0', 200, '4/512', 'LED Par', '', ''];
+      const result = parser.parseChannelMessage(msg as [string, ...(string | number | boolean)[]]);
+      expect(result?.universe).toBe(4);
+      expect(result?.address).toBe(512);
+    });
+  });
+
+  // ─── parsePatch ───────────────────────────────────────────────────────────
+
+  describe('parsePatch', () => {
+    it('parses multiple messages and sorts by channel number', () => {
+      const messages: [string, ...(string | number | boolean)[]][] = [
+        ['/eos/out/patch/1', 10, '1/10', 'Fresnel', 'Balcony 10', ''],
+        ['/eos/out/patch/0', 1, '1/1', 'Leko', 'SR 1', ''],
+        ['/eos/out/patch/2', 5, '1/5', 'Wash', 'OH 5', ''],
+      ];
+      const result = parser.parsePatch(messages);
+      expect(result).toHaveLength(3);
+      expect(result[0].channelNumber).toBe(1);
+      expect(result[1].channelNumber).toBe(5);
+      expect(result[2].channelNumber).toBe(10);
+    });
+
+    it('silently skips unparseable messages', () => {
+      const messages: [string, ...(string | number | boolean)[]][] = [
+        ['/eos/out/patch/count', 2],
+        ['/eos/out/patch/0', 1, '1/1', 'Leko', 'SR 1', ''],
+      ];
+      const result = parser.parsePatch(messages);
+      expect(result).toHaveLength(1);
+    });
+
+    it('returns empty array for empty input', () => {
+      expect(parser.parsePatch([])).toEqual([]);
+    });
+  });
+
+  // ─── toImportedFixture ────────────────────────────────────────────────────
+
+  describe('toImportedFixture', () => {
+    it('maps EosPatchChannel to ImportedFixture correctly', () => {
+      const channel = {
+        channelNumber: 5,
+        universe: 1,
+        address: 42,
+        fixtureType: 'Source Four 26deg',
+        label: '1st Electric 5',
+        notes: 'check focus',
+      };
+      const result = parser.toImportedFixture(channel);
+      expect(result.channel).toBe('5');
+      expect(result.universe).toBe(1);
+      expect(result.dmx_address).toBe(42);
+      expect(result.type).toBe('ETC Source Four 26°');
+      expect(result.position).toBe('1st Electric');
+      expect(result.unit_number).toBe(5);
+      expect(result.notes).toBe('check focus');
+      expect(result.eos_channel).toBe(5);
+      expect(result.eos_profile).toBe('Source Four 26deg');
+    });
+
+    it('handles label with no trailing number', () => {
+      const channel = {
+        channelNumber: 1,
+        universe: null,
+        address: null,
+        fixtureType: 'Dimmer',
+        label: 'Downstage',
+        notes: '',
+      };
+      const result = parser.toImportedFixture(channel);
+      expect(result.position).toBe('Downstage');
+      expect(result.unit_number).toBeNull();
+    });
+
+    it('preserves unknown Eos profile names as-is', () => {
+      const channel = {
+        channelNumber: 1,
+        universe: 1,
+        address: 1,
+        fixtureType: 'Custom Profile XYZ',
+        label: '',
+        notes: '',
+      };
+      const result = parser.toImportedFixture(channel);
+      expect(result.type).toBe('Custom Profile XYZ');
+    });
+  });
+});

--- a/apps/desktop/src/main/console/eos/eosCommandBuilder.ts
+++ b/apps/desktop/src/main/console/eos/eosCommandBuilder.ts
@@ -1,0 +1,119 @@
+/**
+ * EosCommandBuilder
+ *
+ * Builds Eos OSC command strings from ShowStack fixture data.
+ *
+ * Eos accepts patch commands via the `/eos/newcmd` OSC address.
+ * Command syntax (Eos command line language):
+ *   Chan [channel] Patch [universe]/[address] [Type [profile]] [Label "[label]"]
+ *
+ * Reference: ETC Eos Family OSC Manual, "Command Line Commands via OSC"
+ */
+
+/** Minimum fixture fields required to build an Eos patch command */
+export interface FixturePatchInput {
+  channel?: string | number | null;
+  universe?: number | null;
+  dmx_address?: number | null;
+  type?: string | null;
+  position?: string | null;
+  unit_number?: string | number | null;
+}
+
+export class EosCommandBuilder {
+  /**
+   * Build the Eos newcmd string to patch a single fixture.
+   * Returns null if the minimum required fields (channel + address) are missing.
+   *
+   * Example output: `Chan 5 Patch 1/42 Type "Source Four 19deg" Label "1st Electric 1"`
+   */
+  buildPatchCommand(fixture: FixturePatchInput): string | null {
+    const channel = fixture.channel != null ? String(fixture.channel).trim() : '';
+    if (!channel) return null;
+
+    const parts: string[] = [`Chan ${channel}`];
+
+    if (fixture.universe != null && fixture.dmx_address != null) {
+      parts.push(`Patch ${fixture.universe}/${fixture.dmx_address}`);
+    }
+
+    if (fixture.type) {
+      const eosProfile = mapToEosProfile(fixture.type.trim());
+      parts.push(`Type "${eosProfile}"`);
+    }
+
+    const label = buildLabel(fixture);
+    if (label) {
+      parts.push(`Label "${label}"`);
+    }
+
+    return parts.join(' ');
+  }
+
+  /**
+   * Build patch commands for multiple fixtures.
+   * Fixtures that produce null commands (missing channel) are silently skipped.
+   */
+  buildBatchPatchCommands(fixtures: FixturePatchInput[]): string[] {
+    const commands: string[] = [];
+    for (const f of fixtures) {
+      const cmd = this.buildPatchCommand(f);
+      if (cmd) commands.push(cmd);
+    }
+    return commands;
+  }
+
+  /**
+   * Build an Eos command to update a channel's label only.
+   * Useful for label-only sync without touching DMX patch.
+   */
+  buildLabelCommand(channel: string | number, label: string): string {
+    return `Chan ${channel} Label "${label}"`;
+  }
+
+  /**
+   * Build an Eos command to update a channel's notes field.
+   */
+  buildNotesCommand(channel: string | number, notes: string): string {
+    return `Chan ${channel} Note "${notes}"`;
+  }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Map a ShowStack fixture type to an Eos profile name.
+ * Falls back to the raw ShowStack type for unmapped values.
+ */
+export function mapToEosProfile(showstackType: string): string {
+  const mappings: Record<string, string> = {
+    'ETC Source Four 19°': 'Source Four 19deg',
+    'ETC Source Four 26°': 'Source Four 26deg',
+    'ETC Source Four 36°': 'Source Four 36deg',
+    'ETC Source Four 50°': 'Source Four 50deg',
+    'ETC Source Four Jr Zoom 25-50°': 'Source Four Jr 25-50',
+    'ETC Source Four PAR': 'Source Four PAR',
+    'ETC Source Four Revolution': 'Source Four Revolution',
+    'Martin MAC Aura': 'MAC Aura',
+    'Martin MAC Viper Profile': 'MAC Viper Profile',
+    'Martin MAC Viper Wash DX': 'MAC Viper Wash',
+    'Robe BMFL Spot': 'Robe BMFL Spot',
+    'Robe BMFL WashBeam': 'Robe BMFL Wash',
+    'LED PAR': 'LED Par',
+    'LED Strip': 'LED Strip',
+    Dimmer: 'Dimmer',
+    Fresnel: 'Fresnel',
+    Leko: 'Leko',
+    Spot: 'Spot',
+    Wash: 'Wash',
+  };
+  return mappings[showstackType] ?? showstackType;
+}
+
+/** Combine position + unit_number into an Eos label string */
+function buildLabel(fixture: FixturePatchInput): string {
+  const parts: string[] = [];
+  if (fixture.position) parts.push(String(fixture.position).trim());
+  if (fixture.unit_number != null) parts.push(String(fixture.unit_number).trim());
+  return parts.join(' ');
+}

--- a/apps/desktop/src/main/console/eos/eosOSCClient.ts
+++ b/apps/desktop/src/main/console/eos/eosOSCClient.ts
@@ -1,0 +1,154 @@
+/**
+ * EosOSCClient
+ *
+ * Manages a UDP OSC connection to an ETC Eos family console.
+ *
+ * Protocol overview:
+ *   - Send commands to the console on EOS_OSC_PORT (default 3032).
+ *   - Eos sends responses back to the source IP on EOS_LISTEN_PORT (default 3033).
+ *   - Patch query: send `/eos/get/patch` → receive `/eos/out/patch/count [n]`
+ *     followed by n messages at `/eos/out/patch/[index]`.
+ *
+ * Reachability pre-check is handled by PortStatusMonitorService before
+ * connect() is called, so this class focuses solely on the OSC protocol.
+ */
+
+import { Client, Server } from 'node-osc';
+import { logger } from '../../utils/logger';
+import type { EosPatchChannel } from '../../../renderer/src/types/console';
+
+export { EosPatchChannel };
+
+/** Default Eos OSC receive port (configurable in Eos: Setup → System Settings → Show Control → OSC) */
+export const EOS_OSC_PORT = 3032;
+/** Local port we open to receive Eos responses */
+export const EOS_LISTEN_PORT = 3033;
+/** How long to wait for all patch responses before giving up */
+const PATCH_TIMEOUT_MS = 10_000;
+
+/** Raw OSC message: [address, ...args] */
+type OscMessage = [string, ...(string | number | boolean)[]];
+
+export class EosOSCClient {
+  private client: Client;
+  private server: Server | null = null;
+  private readonly consoleIp: string;
+  private readonly consolePort: number;
+  private readonly listenPort: number;
+
+  constructor(consoleIp: string, consolePort = EOS_OSC_PORT, listenPort = EOS_LISTEN_PORT) {
+    this.consoleIp = consoleIp;
+    this.consolePort = consolePort;
+    this.listenPort = listenPort;
+    this.client = new Client(consoleIp, consolePort);
+  }
+
+  /**
+   * Open the local UDP server that receives Eos responses.
+   * Must be called before getPatch() or any query that expects a response.
+   */
+  async connect(): Promise<void> {
+    if (this.server) return; // already connected
+
+    this.server = new Server(this.listenPort, '0.0.0.0');
+    await new Promise<void>((resolve, reject) => {
+      this.server!.once('listening', resolve);
+      this.server!.once('error', reject);
+    });
+    logger.info(`EosOSCClient connected — listening on :${this.listenPort}`, {
+      consoleIp: this.consoleIp,
+      consolePort: this.consolePort,
+    });
+  }
+
+  /**
+   * Close both the outbound client socket and the inbound response server.
+   */
+  async disconnect(): Promise<void> {
+    await this.client.close();
+    if (this.server) {
+      await this.server.close();
+      this.server = null;
+    }
+    logger.info('EosOSCClient disconnected', { consoleIp: this.consoleIp });
+  }
+
+  /**
+   * Send a single OSC message to the console.
+   */
+  async send(address: string, ...args: (string | number | boolean)[]): Promise<void> {
+    if (args.length > 0) {
+      await this.client.send(address, ...args);
+    } else {
+      await this.client.send(address);
+    }
+  }
+
+  /**
+   * Query the full patch from Eos.
+   *
+   * Sends `/eos/get/patch` and collects:
+   *   1. `/eos/out/patch/count [n]` — total channel count
+   *   2. `/eos/out/patch/[0..n-1]` — one message per channel
+   *
+   * Resolves with an array of raw OSC messages for the caller to parse.
+   * Rejects if the count message does not arrive within PATCH_TIMEOUT_MS,
+   * or if all expected channel messages do not arrive in time.
+   */
+  async getPatch(timeoutMs = PATCH_TIMEOUT_MS): Promise<OscMessage[]> {
+    if (!this.server) throw new Error('Not connected — call connect() first');
+
+    return new Promise<OscMessage[]>((resolve, reject) => {
+      const channelMessages: OscMessage[] = [];
+      let expectedCount: number | null = null;
+      let settled = false;
+
+      const timer = setTimeout(() => {
+        if (!settled) {
+          settled = true;
+          cleanup();
+          reject(new Error(`Eos patch query timed out after ${timeoutMs}ms`));
+        }
+      }, timeoutMs);
+
+      const onMessage = (msg: OscMessage) => {
+        const [address] = msg;
+
+        if (address === '/eos/out/patch/count') {
+          expectedCount = Number(msg[1]) || 0;
+          if (expectedCount === 0) {
+            settled = true;
+            cleanup();
+            resolve([]);
+          }
+          return;
+        }
+
+        if (/^\/eos\/out\/patch\/\d+$/.test(address)) {
+          channelMessages.push(msg);
+          if (expectedCount !== null && channelMessages.length >= expectedCount) {
+            settled = true;
+            cleanup();
+            resolve(channelMessages);
+          }
+        }
+      };
+
+      const cleanup = () => {
+        clearTimeout(timer);
+        this.server?.off('message', onMessage);
+      };
+
+      this.server!.on('message', onMessage);
+
+      // Fire the query after attaching the listener
+      this.send('/eos/get/patch').catch((err: unknown) => {
+        if (!settled) {
+          settled = true;
+          cleanup();
+          reject(err instanceof Error ? err : new Error(String(err)));
+        }
+      });
+    });
+  }
+}

--- a/apps/desktop/src/main/console/eos/eosOSCClient.ts
+++ b/apps/desktop/src/main/console/eos/eosOSCClient.ts
@@ -34,6 +34,7 @@ type OscMessage = [string, ...(string | number | boolean)[]];
 export class EosOSCClient {
   private client: Client;
   private server: Server | null = null;
+  private isQueryingPatch = false;
   private readonly consoleIp: string;
   private readonly consolePort: number;
   private readonly listenPort: number;
@@ -98,90 +99,96 @@ export class EosOSCClient {
    * or if all expected channel messages do not arrive in time.
    */
   async getPatch(countTimeoutMs = PATCH_COUNT_TIMEOUT_MS): Promise<OscMessage[]> {
+    if (this.isQueryingPatch) throw new Error('A patch query is already in progress');
     if (!this.server) throw new Error('Not connected — call connect() first');
 
-    return new Promise<OscMessage[]>((resolve, reject) => {
-      const channelMessages: OscMessage[] = [];
-      let expectedCount: number | null = null;
-      let settled = false;
-      let inactivityTimer: ReturnType<typeof setTimeout> | null = null;
+    this.isQueryingPatch = true;
+    try {
+      return await new Promise<OscMessage[]>((resolve, reject) => {
+        const channelMessages: OscMessage[] = [];
+        let expectedCount: number | null = null;
+        let settled = false;
+        let inactivityTimer: ReturnType<typeof setTimeout> | null = null;
 
-      // Phase 1: wait for /eos/out/patch/count
-      const countTimer = setTimeout(() => {
-        if (!settled) {
-          settled = true;
-          cleanup();
-          reject(
-            new Error(`Eos patch query timed out waiting for count after ${countTimeoutMs}ms`),
-          );
-        }
-      }, countTimeoutMs);
-
-      const resetInactivity = () => {
-        if (inactivityTimer) clearTimeout(inactivityTimer);
-        inactivityTimer = setTimeout(() => {
+        // Phase 1: wait for /eos/out/patch/count
+        const countTimer = setTimeout(() => {
           if (!settled) {
             settled = true;
             cleanup();
             reject(
-              new Error(
-                `Eos patch query timed out — received ${channelMessages.length} of ${expectedCount} channels`,
-              ),
+              new Error(`Eos patch query timed out waiting for count after ${countTimeoutMs}ms`),
             );
           }
-        }, PATCH_INACTIVITY_TIMEOUT_MS);
-      };
+        }, countTimeoutMs);
 
-      const onMessage = (msg: OscMessage) => {
-        const [address] = msg;
+        const resetInactivity = () => {
+          if (inactivityTimer) clearTimeout(inactivityTimer);
+          inactivityTimer = setTimeout(() => {
+            if (!settled) {
+              settled = true;
+              cleanup();
+              reject(
+                new Error(
+                  `Eos patch query timed out — received ${channelMessages.length} of ${expectedCount} channels`,
+                ),
+              );
+            }
+          }, PATCH_INACTIVITY_TIMEOUT_MS);
+        };
 
-        if (address === '/eos/out/patch/count') {
-          clearTimeout(countTimer);
-          const rawCount = Number(msg[1]);
-          if (!Number.isFinite(rawCount)) {
-            logger.warn('Received invalid patch count from Eos; treating as 0', {
-              rawCount: msg[1],
-            });
+        const onMessage = (msg: OscMessage) => {
+          const [address] = msg;
+
+          if (address === '/eos/out/patch/count') {
+            clearTimeout(countTimer);
+            const rawCount = Number(msg[1]);
+            if (!Number.isFinite(rawCount)) {
+              logger.warn('Received invalid patch count from Eos; treating as 0', {
+                rawCount: msg[1],
+              });
+            }
+            expectedCount = Number.isFinite(rawCount) ? rawCount : 0;
+            if (expectedCount === 0) {
+              settled = true;
+              cleanup();
+              resolve([]);
+            } else {
+              // Phase 2: switch to inactivity-based timeout
+              resetInactivity();
+            }
+            return;
           }
-          expectedCount = Number.isFinite(rawCount) ? rawCount : 0;
-          if (expectedCount === 0) {
-            settled = true;
-            cleanup();
-            resolve([]);
-          } else {
-            // Phase 2: switch to inactivity-based timeout
+
+          if (/^\/eos\/out\/patch\/\d+$/.test(address)) {
+            channelMessages.push(msg);
             resetInactivity();
+            if (expectedCount !== null && channelMessages.length >= expectedCount) {
+              settled = true;
+              cleanup();
+              resolve(channelMessages);
+            }
           }
-          return;
-        }
+        };
 
-        if (/^\/eos\/out\/patch\/\d+$/.test(address)) {
-          channelMessages.push(msg);
-          resetInactivity();
-          if (expectedCount !== null && channelMessages.length >= expectedCount) {
+        const cleanup = () => {
+          clearTimeout(countTimer);
+          if (inactivityTimer) clearTimeout(inactivityTimer);
+          this.server?.off('message', onMessage);
+        };
+
+        this.server!.on('message', onMessage);
+
+        // Fire the query after attaching the listener
+        this.send('/eos/get/patch').catch((err: unknown) => {
+          if (!settled) {
             settled = true;
             cleanup();
-            resolve(channelMessages);
+            reject(err instanceof Error ? err : new Error(String(err)));
           }
-        }
-      };
-
-      const cleanup = () => {
-        clearTimeout(countTimer);
-        if (inactivityTimer) clearTimeout(inactivityTimer);
-        this.server?.off('message', onMessage);
-      };
-
-      this.server!.on('message', onMessage);
-
-      // Fire the query after attaching the listener
-      this.send('/eos/get/patch').catch((err: unknown) => {
-        if (!settled) {
-          settled = true;
-          cleanup();
-          reject(err instanceof Error ? err : new Error(String(err)));
-        }
+        });
       });
-    });
+    } finally {
+      this.isQueryingPatch = false;
+    }
   }
 }

--- a/apps/desktop/src/main/console/eos/eosOSCClient.ts
+++ b/apps/desktop/src/main/console/eos/eosOSCClient.ts
@@ -137,7 +137,13 @@ export class EosOSCClient {
 
         if (address === '/eos/out/patch/count') {
           clearTimeout(countTimer);
-          expectedCount = Number(msg[1]) || 0;
+          const rawCount = Number(msg[1]);
+          if (!Number.isFinite(rawCount)) {
+            logger.warn('Received invalid patch count from Eos; treating as 0', {
+              rawCount: msg[1],
+            });
+          }
+          expectedCount = Number.isFinite(rawCount) ? rawCount : 0;
           if (expectedCount === 0) {
             settled = true;
             cleanup();

--- a/apps/desktop/src/main/console/eos/eosOSCClient.ts
+++ b/apps/desktop/src/main/console/eos/eosOSCClient.ts
@@ -23,8 +23,10 @@ export { EosPatchChannel };
 export const EOS_OSC_PORT = 3032;
 /** Local port we open to receive Eos responses */
 export const EOS_LISTEN_PORT = 3033;
-/** How long to wait for all patch responses before giving up */
-const PATCH_TIMEOUT_MS = 10_000;
+/** How long to wait for the initial /eos/out/patch/count message */
+const PATCH_COUNT_TIMEOUT_MS = 10_000;
+/** Inactivity window after count is received — resets on every channel message */
+const PATCH_INACTIVITY_TIMEOUT_MS = 2_000;
 
 /** Raw OSC message: [address, ...args] */
 type OscMessage = [string, ...(string | number | boolean)[]];
@@ -95,37 +97,61 @@ export class EosOSCClient {
    * Rejects if the count message does not arrive within PATCH_TIMEOUT_MS,
    * or if all expected channel messages do not arrive in time.
    */
-  async getPatch(timeoutMs = PATCH_TIMEOUT_MS): Promise<OscMessage[]> {
+  async getPatch(countTimeoutMs = PATCH_COUNT_TIMEOUT_MS): Promise<OscMessage[]> {
     if (!this.server) throw new Error('Not connected — call connect() first');
 
     return new Promise<OscMessage[]>((resolve, reject) => {
       const channelMessages: OscMessage[] = [];
       let expectedCount: number | null = null;
       let settled = false;
+      let inactivityTimer: ReturnType<typeof setTimeout> | null = null;
 
-      const timer = setTimeout(() => {
+      // Phase 1: wait for /eos/out/patch/count
+      const countTimer = setTimeout(() => {
         if (!settled) {
           settled = true;
           cleanup();
-          reject(new Error(`Eos patch query timed out after ${timeoutMs}ms`));
+          reject(
+            new Error(`Eos patch query timed out waiting for count after ${countTimeoutMs}ms`),
+          );
         }
-      }, timeoutMs);
+      }, countTimeoutMs);
+
+      const resetInactivity = () => {
+        if (inactivityTimer) clearTimeout(inactivityTimer);
+        inactivityTimer = setTimeout(() => {
+          if (!settled) {
+            settled = true;
+            cleanup();
+            reject(
+              new Error(
+                `Eos patch query timed out — received ${channelMessages.length} of ${expectedCount} channels`,
+              ),
+            );
+          }
+        }, PATCH_INACTIVITY_TIMEOUT_MS);
+      };
 
       const onMessage = (msg: OscMessage) => {
         const [address] = msg;
 
         if (address === '/eos/out/patch/count') {
+          clearTimeout(countTimer);
           expectedCount = Number(msg[1]) || 0;
           if (expectedCount === 0) {
             settled = true;
             cleanup();
             resolve([]);
+          } else {
+            // Phase 2: switch to inactivity-based timeout
+            resetInactivity();
           }
           return;
         }
 
         if (/^\/eos\/out\/patch\/\d+$/.test(address)) {
           channelMessages.push(msg);
+          resetInactivity();
           if (expectedCount !== null && channelMessages.length >= expectedCount) {
             settled = true;
             cleanup();
@@ -135,7 +161,8 @@ export class EosOSCClient {
       };
 
       const cleanup = () => {
-        clearTimeout(timer);
+        clearTimeout(countTimer);
+        if (inactivityTimer) clearTimeout(inactivityTimer);
         this.server?.off('message', onMessage);
       };
 

--- a/apps/desktop/src/main/console/eos/eosPatchParser.ts
+++ b/apps/desktop/src/main/console/eos/eosPatchParser.ts
@@ -1,0 +1,147 @@
+/**
+ * EosPatchParser
+ *
+ * Parses raw Eos OSC patch messages into EosPatchChannel objects, then maps
+ * them to ShowStack Partial<Fixture> records ready for import.
+ *
+ * Eos OSC patch message format (per /eos/out/patch/[index]):
+ *   args[0]  channel number  (number)
+ *   args[1]  address string  "universe/address", e.g. "1/42" — empty if un-patched
+ *   args[2]  fixture type    (string) — Eos profile name
+ *   args[3]  label           (string) — channel label shown in live display
+ *   args[4]  notes           (string) — free-text notes field
+ *
+ * Fields beyond index 4 are ignored (forward-compatible with future Eos versions).
+ */
+
+import type { EosPatchChannel } from '../../../renderer/src/types/console';
+
+/** ShowStack fixture fields that a patch import can populate. */
+export interface ImportedFixture {
+  channel: string | null;
+  universe: number | null;
+  dmx_address: number | null;
+  type: string;
+  position: string | null;
+  unit_number: number | null;
+  notes: string;
+  /** Eos-specific metadata kept for round-trip fidelity */
+  eos_channel: number;
+  eos_profile: string;
+}
+
+/** Raw OSC message tuple */
+type OscMessage = [string, ...(string | number | boolean)[]];
+
+export class EosPatchParser {
+  /**
+   * Parse a single `/eos/out/patch/[index]` OSC message into an EosPatchChannel.
+   * Returns null if the message cannot be parsed (wrong address, missing args, etc.).
+   */
+  parseChannelMessage(msg: OscMessage): EosPatchChannel | null {
+    const [address, ...args] = msg;
+    if (!/^\/eos\/out\/patch\/\d+$/.test(address)) return null;
+    if (args.length < 1) return null;
+
+    const channelNumber = Number(args[0]);
+    if (!Number.isFinite(channelNumber) || channelNumber <= 0) return null;
+
+    const { universe, address: dmxAddress } = parseEosAddress(String(args[1] ?? ''));
+    const fixtureType = String(args[2] ?? '').trim();
+    const label = String(args[3] ?? '').trim();
+    const notes = String(args[4] ?? '').trim();
+
+    return { channelNumber, universe, address: dmxAddress, fixtureType, label, notes };
+  }
+
+  /**
+   * Parse a full set of patch messages (output of EosOSCClient.getPatch())
+   * into an array of EosPatchChannel objects.
+   * Messages that cannot be parsed are silently skipped.
+   */
+  parsePatch(messages: OscMessage[]): EosPatchChannel[] {
+    const channels: EosPatchChannel[] = [];
+    for (const msg of messages) {
+      const ch = this.parseChannelMessage(msg);
+      if (ch) channels.push(ch);
+    }
+    return channels.sort((a, b) => a.channelNumber - b.channelNumber);
+  }
+
+  /**
+   * Convert an EosPatchChannel to a ShowStack ImportedFixture.
+   * The label is parsed into position + unit_number using the heuristic that
+   * the trailing integer (if present) is the unit number and the rest is position.
+   */
+  toImportedFixture(channel: EosPatchChannel): ImportedFixture {
+    const { position, unitNumber } = parseEosLabel(channel.label);
+    return {
+      channel: String(channel.channelNumber),
+      universe: channel.universe,
+      dmx_address: channel.address,
+      type: mapFromEosProfile(channel.fixtureType),
+      position,
+      unit_number: unitNumber,
+      notes: channel.notes,
+      eos_channel: channel.channelNumber,
+      eos_profile: channel.fixtureType,
+    };
+  }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Parse an Eos address string like "1/42" → { universe: 1, address: 42 }.
+ * Returns nulls for un-patched channels (empty string or invalid format).
+ */
+function parseEosAddress(raw: string): { universe: number | null; address: number | null } {
+  const match = raw.match(/^(\d+)\/(\d+)$/);
+  if (!match) return { universe: null, address: null };
+  return { universe: parseInt(match[1], 10), address: parseInt(match[2], 10) };
+}
+
+/**
+ * Parse an Eos label into position and unit number.
+ * Common formats:
+ *   "1st Electric 1"  → position: "1st Electric",   unit: 1
+ *   "FOH L 12"        → position: "FOH L",           unit: 12
+ *   "Downstage"       → position: "Downstage",       unit: null
+ */
+function parseEosLabel(label: string): { position: string | null; unitNumber: number | null } {
+  if (!label) return { position: null, unitNumber: null };
+  const match = label.match(/^(.+?)\s+(\d+)$/);
+  if (match) {
+    return { position: match[1].trim(), unitNumber: parseInt(match[2], 10) };
+  }
+  return { position: label, unitNumber: null };
+}
+
+/**
+ * Map an Eos profile name to a ShowStack fixture type string.
+ * Falls back to the raw Eos profile name for unmapped types.
+ */
+function mapFromEosProfile(eosProfile: string): string {
+  const mappings: Record<string, string> = {
+    'Source Four 19deg': 'ETC Source Four 19°',
+    'Source Four 26deg': 'ETC Source Four 26°',
+    'Source Four 36deg': 'ETC Source Four 36°',
+    'Source Four 50deg': 'ETC Source Four 50°',
+    'Source Four Jr 25-50': 'ETC Source Four Jr Zoom 25-50°',
+    'Source Four PAR': 'ETC Source Four PAR',
+    'Source Four Revolution': 'ETC Source Four Revolution',
+    Leko: 'Leko',
+    Fresnel: 'Fresnel',
+    'MAC Aura': 'Martin MAC Aura',
+    'MAC Viper Profile': 'Martin MAC Viper Profile',
+    'MAC Viper Wash': 'Martin MAC Viper Wash DX',
+    'Robe BMFL Spot': 'Robe BMFL Spot',
+    'Robe BMFL Wash': 'Robe BMFL WashBeam',
+    Spot: 'Spot',
+    Wash: 'Wash',
+    'LED Par': 'LED PAR',
+    'LED Strip': 'LED Strip',
+    Dimmer: 'Dimmer',
+  };
+  return mappings[eosProfile] ?? eosProfile;
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -36,6 +36,7 @@ import { registerCollaborationHandlers } from './ipc/collaboration';
 import { registerGroupHandlers } from './ipc/groups';
 import { registerGdtfHandlers, initGdtfLibrary, initGdtfUpdateCheck } from './ipc/gdtf';
 import { registerMvrHandlers } from './ipc/mvr';
+import { registerConsoleHandlers } from './ipc/console';
 import { backgroundVerifier } from './services/BackgroundVerifier';
 import { backupService } from './services/BackupService';
 import { crashRecoveryService } from './services/CrashRecoveryService';
@@ -142,6 +143,7 @@ app.on('ready', async () => {
   registerGroupHandlers();
   registerGdtfHandlers();
   registerMvrHandlers();
+  registerConsoleHandlers();
 
   // Scan bundled GDTF fixtures into cache (non-blocking)
   initGdtfLibrary();

--- a/apps/desktop/src/main/ipc/__tests__/console.test.ts
+++ b/apps/desktop/src/main/ipc/__tests__/console.test.ts
@@ -100,7 +100,10 @@ describe('console IPC handlers', () => {
     it('returns success after connecting to Eos', async () => {
       const handler = getHandler('console:connect');
       const result = await handler(FAKE_EVENT, 'eos', '10.0.0.1');
-      expect(result).toEqual({ success: true });
+      expect(result).toEqual({
+        success: true,
+        connection: { type: 'eos', ip: '10.0.0.1', port: 3032 },
+      });
       expect(mocks.connect).toHaveBeenCalled();
     });
 

--- a/apps/desktop/src/main/ipc/__tests__/console.test.ts
+++ b/apps/desktop/src/main/ipc/__tests__/console.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ipcMain } from 'electron';
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: vi.fn() },
+}));
+
+vi.mock('../../utils/logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// Use vi.hoisted so mock functions are available inside vi.mock factories
+const mocks = vi.hoisted(() => ({
+  connect: vi.fn().mockResolvedValue(undefined),
+  disconnect: vi.fn().mockResolvedValue(undefined),
+  send: vi.fn().mockResolvedValue(undefined),
+  getPatch: vi.fn().mockResolvedValue([]),
+  parsePatch: vi
+    .fn()
+    .mockReturnValue([
+      { channelNumber: 1, universe: 1, address: 1, fixtureType: 'Leko', label: 'SR 1', notes: '' },
+    ]),
+  buildBatchPatchCommands: vi.fn().mockReturnValue(['Chan 1 Patch 1/1']),
+}));
+
+vi.mock('../../console/eos/eosOSCClient', () => ({
+  EosOSCClient: vi.fn().mockImplementation(() => ({
+    connect: mocks.connect,
+    disconnect: mocks.disconnect,
+    send: mocks.send,
+    getPatch: mocks.getPatch,
+  })),
+  EOS_OSC_PORT: 3032,
+}));
+
+vi.mock('../../console/eos/eosPatchParser', () => ({
+  EosPatchParser: vi.fn().mockImplementation(() => ({
+    parsePatch: mocks.parsePatch,
+  })),
+}));
+
+vi.mock('../../console/eos/eosCommandBuilder', () => ({
+  EosCommandBuilder: vi.fn().mockImplementation(() => ({
+    buildBatchPatchCommands: mocks.buildBatchPatchCommands,
+  })),
+}));
+
+import { registerConsoleHandlers, resetConsoleClients } from '../console';
+import { EosOSCClient } from '../../console/eos/eosOSCClient';
+import { EosPatchParser } from '../../console/eos/eosPatchParser';
+import { EosCommandBuilder } from '../../console/eos/eosCommandBuilder';
+
+/** Capture the handler registered for a given channel */
+function getHandler(channel: string) {
+  const calls = vi.mocked(ipcMain.handle).mock.calls;
+  const call = calls.find((c) => c[0] === channel);
+  if (!call) throw new Error(`No handler registered for ${channel}`);
+  return call[1] as (...args: unknown[]) => Promise<unknown>;
+}
+
+const FAKE_EVENT = {} as Electron.IpcMainInvokeEvent;
+
+describe('console IPC handlers', () => {
+  beforeEach(() => {
+    vi.mocked(ipcMain.handle).mockClear();
+    // Re-set implementations cleared by mockReset: true
+    mocks.connect.mockResolvedValue(undefined);
+    mocks.disconnect.mockResolvedValue(undefined);
+    mocks.send.mockResolvedValue(undefined);
+    mocks.getPatch.mockResolvedValue([]);
+    mocks.parsePatch.mockReturnValue([
+      { channelNumber: 1, universe: 1, address: 1, fixtureType: 'Leko', label: 'SR 1', notes: '' },
+    ]);
+    mocks.buildBatchPatchCommands.mockReturnValue(['Chan 1 Patch 1/1']);
+    vi.mocked(EosOSCClient).mockImplementation(
+      () =>
+        ({
+          connect: mocks.connect,
+          disconnect: mocks.disconnect,
+          send: mocks.send,
+          getPatch: mocks.getPatch,
+        }) as unknown as EosOSCClient,
+    );
+    vi.mocked(EosPatchParser).mockImplementation(
+      () => ({ parsePatch: mocks.parsePatch }) as unknown as EosPatchParser,
+    );
+    vi.mocked(EosCommandBuilder).mockImplementation(
+      () =>
+        ({
+          buildBatchPatchCommands: mocks.buildBatchPatchCommands,
+        }) as unknown as EosCommandBuilder,
+    );
+    resetConsoleClients();
+    registerConsoleHandlers();
+  });
+
+  // ── console:connect ───────────────────────────────────────────────────────
+
+  describe('console:connect', () => {
+    it('returns success after connecting to Eos', async () => {
+      const handler = getHandler('console:connect');
+      const result = await handler(FAKE_EVENT, 'eos', '10.0.0.1');
+      expect(result).toEqual({ success: true });
+      expect(mocks.connect).toHaveBeenCalled();
+    });
+
+    it('returns error for unsupported console type', async () => {
+      const handler = getHandler('console:connect');
+      const result = (await handler(FAKE_EVENT, 'grandma2', '10.0.0.1')) as {
+        success: boolean;
+        error?: string;
+      };
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/not yet supported/i);
+    });
+
+    it('returns error when connect throws', async () => {
+      mocks.connect.mockRejectedValueOnce(new Error('UDP bind failed'));
+      const handler = getHandler('console:connect');
+      const result = (await handler(FAKE_EVENT, 'eos', '10.0.0.1')) as {
+        success: boolean;
+        error?: string;
+      };
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('UDP bind failed');
+    });
+
+    it('disconnects an existing client before reconnecting', async () => {
+      const handler = getHandler('console:connect');
+      await handler(FAKE_EVENT, 'eos', '10.0.0.1');
+      await handler(FAKE_EVENT, 'eos', '10.0.0.2');
+      expect(mocks.disconnect).toHaveBeenCalledTimes(1);
+      expect(mocks.connect).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // ── console:disconnect ────────────────────────────────────────────────────
+
+  describe('console:disconnect', () => {
+    it('returns success when no client is connected', async () => {
+      const handler = getHandler('console:disconnect');
+      const result = await handler(FAKE_EVENT, 'eos');
+      expect(result).toEqual({ success: true });
+    });
+
+    it('calls disconnect on the active client', async () => {
+      await getHandler('console:connect')(FAKE_EVENT, 'eos', '10.0.0.1');
+      const result = await getHandler('console:disconnect')(FAKE_EVENT, 'eos');
+      expect(result).toEqual({ success: true });
+      expect(mocks.disconnect).toHaveBeenCalled();
+    });
+  });
+
+  // ── console:importPatch ───────────────────────────────────────────────────
+
+  describe('console:importPatch', () => {
+    it('returns channels after successful import', async () => {
+      await getHandler('console:connect')(FAKE_EVENT, 'eos', '10.0.0.1');
+      const result = (await getHandler('console:importPatch')(FAKE_EVENT, 'eos')) as {
+        success: boolean;
+        channels?: unknown[];
+      };
+      expect(result.success).toBe(true);
+      expect(result.channels).toHaveLength(1);
+    });
+
+    it('returns error when not connected', async () => {
+      const result = (await getHandler('console:importPatch')(FAKE_EVENT, 'eos')) as {
+        success: boolean;
+        error?: string;
+      };
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/not connected/i);
+    });
+
+    it('returns error for unsupported console type', async () => {
+      const result = (await getHandler('console:importPatch')(FAKE_EVENT, 'grandma2')) as {
+        success: boolean;
+        error?: string;
+      };
+      expect(result.success).toBe(false);
+    });
+  });
+
+  // ── console:exportPatch ───────────────────────────────────────────────────
+
+  describe('console:exportPatch', () => {
+    it('sends commands and returns success with count', async () => {
+      await getHandler('console:connect')(FAKE_EVENT, 'eos', '10.0.0.1');
+      const result = (await getHandler('console:exportPatch')(FAKE_EVENT, 'eos', [
+        { channel: '1', universe: 1, dmx_address: 1 },
+      ])) as { success: boolean; sent?: number };
+      expect(result.success).toBe(true);
+      expect(result.sent).toBe(1);
+      expect(mocks.send).toHaveBeenCalledWith('/eos/newcmd', 'Chan 1 Patch 1/1');
+    });
+
+    it('returns error when not connected', async () => {
+      const result = (await getHandler('console:exportPatch')(FAKE_EVENT, 'eos', [])) as {
+        success: boolean;
+        error?: string;
+      };
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/apps/desktop/src/main/ipc/__tests__/infrastructure.test.ts
+++ b/apps/desktop/src/main/ipc/__tests__/infrastructure.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tests for infrastructure IPC handlers.
+ * Currently covers: infrastructure:getPortStatusReport (cache miss, cache hit).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockHandle, mockCheckAll } = vi.hoisted(() => ({
+  mockHandle: vi.fn(),
+  mockCheckAll: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: mockHandle },
+  dialog: {},
+}));
+
+vi.mock('../../utils/logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('../../services/PortStatusMonitorService', () => ({
+  portStatusMonitor: { checkAll: mockCheckAll },
+}));
+
+// Stub all other heavy dependencies — we only test getPortStatusReport here
+vi.mock('../../database/queries/infrastructure', () => ({
+  getPortLinkages: vi.fn(),
+  getFixtureConnections: vi.fn(),
+  getEquipmentConnections: vi.fn(),
+  validatePortAssignment: vi.fn(),
+  getPortUsageStats: vi.fn(),
+  getAllPortUsageStats: vi.fn(),
+  exportInfrastructureToCSV: vi.fn(),
+  importInfrastructureFromCSV: vi.fn(),
+}));
+vi.mock('../../services/InfrastructureService', () => ({
+  infrastructureService: {
+    getAll: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+vi.mock('../../errors', () => ({
+  errorHandler: { executeWithRetry: vi.fn(async (fn: () => unknown) => fn()) },
+  DatabaseError: class DatabaseError extends Error {},
+  ValidationError: class ValidationError extends Error {},
+}));
+vi.mock('@showstack/shared', () => ({
+  CreateInfrastructureEquipmentSchema: { parse: vi.fn((v: unknown) => v) },
+  UpdateInfrastructureEquipmentSchema: { parse: vi.fn((v: unknown) => v) },
+  parseWithZod: vi.fn(),
+  formatValidationErrors: vi.fn(),
+}));
+
+import { registerInfrastructureHandlers } from '../infrastructure';
+
+/** Extract a registered handler by IPC channel name */
+function getHandler(channel: string) {
+  const call = mockHandle.mock.calls.find((c: unknown[]) => c[0] === channel);
+  if (!call) throw new Error(`No handler registered for "${channel}"`);
+  return call[1] as (...args: unknown[]) => Promise<unknown>;
+}
+
+const FAKE_EVENT = {};
+
+describe('infrastructure:getPortStatusReport', () => {
+  beforeEach(() => {
+    mockHandle.mockClear();
+    mockCheckAll.mockResolvedValue([
+      {
+        equipment_id: 'eq-1',
+        ip: '10.0.0.1',
+        status: 'reachable',
+        latency_ms: 5,
+        last_checked: 1000,
+      },
+    ]);
+    registerInfrastructureHandlers();
+  });
+
+  it('calls portStatusMonitor.checkAll and returns results on cache miss', async () => {
+    const handler = getHandler('infrastructure:getPortStatusReport');
+    const equipment = [{ id: 'eq-1', ip_address: '10.0.0.1' }];
+    const result = await handler(FAKE_EVENT, 'project-1', equipment);
+
+    expect(mockCheckAll).toHaveBeenCalledWith('project-1', equipment);
+    expect(result).toEqual([
+      {
+        equipment_id: 'eq-1',
+        ip: '10.0.0.1',
+        status: 'reachable',
+        latency_ms: 5,
+        last_checked: 1000,
+      },
+    ]);
+  });
+
+  it('returns the value from checkAll (caching is handled inside the service)', async () => {
+    const handler = getHandler('infrastructure:getPortStatusReport');
+    const equipment = [{ id: 'eq-1', ip_address: '10.0.0.1' }];
+
+    // Call twice — both should return results; service handles its own TTL
+    await handler(FAKE_EVENT, 'project-1', equipment);
+    const result = await handler(FAKE_EVENT, 'project-1', equipment);
+
+    expect(result).toBeDefined();
+    expect(mockCheckAll).toHaveBeenCalledTimes(2);
+  });
+
+  it('propagates errors thrown by checkAll', async () => {
+    mockCheckAll.mockRejectedValueOnce(new Error('network error'));
+    const handler = getHandler('infrastructure:getPortStatusReport');
+    await expect(handler(FAKE_EVENT, 'project-1', [])).rejects.toThrow('network error');
+  });
+});

--- a/apps/desktop/src/main/ipc/console.ts
+++ b/apps/desktop/src/main/ipc/console.ts
@@ -24,6 +24,9 @@ import type {
   ConsolePatchExportResult,
 } from '../../renderer/src/types/console';
 
+/** Delay between consecutive /eos/newcmd sends to avoid overwhelming the console's OSC buffer */
+const EOS_COMMAND_DELAY_MS = 20;
+
 // ─── In-process client registry ──────────────────────────────────────────────
 
 // One client per console type; reset on disconnect.
@@ -156,7 +159,7 @@ export function registerConsoleHandlers(): void {
 
         for (const command of commands) {
           await client.send('/eos/newcmd', command);
-          await new Promise((resolve) => setTimeout(resolve, 100));
+          await new Promise((resolve) => setTimeout(resolve, EOS_COMMAND_DELAY_MS));
         }
 
         logger.info('Eos patch export complete', { commandCount: commands.length });

--- a/apps/desktop/src/main/ipc/console.ts
+++ b/apps/desktop/src/main/ipc/console.ts
@@ -156,6 +156,7 @@ export function registerConsoleHandlers(): void {
 
         for (const command of commands) {
           await client.send('/eos/newcmd', command);
+          await new Promise((resolve) => setTimeout(resolve, 20));
         }
 
         logger.info('Eos patch export complete', { commandCount: commands.length });

--- a/apps/desktop/src/main/ipc/console.ts
+++ b/apps/desktop/src/main/ipc/console.ts
@@ -71,8 +71,9 @@ export function registerConsoleHandlers(): void {
         await client.connect();
         activeClients.set('eos', client);
 
-        logger.info('Console connected', { consoleType, ip, port: port ?? EOS_OSC_PORT });
-        return { success: true };
+        const effectivePort = port ?? EOS_OSC_PORT;
+        logger.info('Console connected', { consoleType, ip, port: effectivePort });
+        return { success: true, connection: { type: consoleType, ip, port: effectivePort } };
       } catch (error) {
         logger.error('console:connect failed', {
           consoleType,

--- a/apps/desktop/src/main/ipc/console.ts
+++ b/apps/desktop/src/main/ipc/console.ts
@@ -1,0 +1,174 @@
+/**
+ * Console IPC Handlers
+ *
+ * Bridges the renderer's window.api.console calls to the EosOSCClient /
+ * EosPatchParser / EosCommandBuilder in the main process.
+ *
+ * IPC channels:
+ *   console:connect      (consoleType, ip, port?)   → ConsoleConnectResult
+ *   console:disconnect   (consoleType)               → ConsoleDisconnectResult
+ *   console:importPatch  (consoleType)               → ConsolePatchImportResult
+ *   console:exportPatch  (consoleType, fixtures[])   → ConsolePatchExportResult
+ */
+
+import { ipcMain, IpcMainInvokeEvent } from 'electron';
+import { logger } from '../utils/logger';
+import { EosOSCClient, EOS_OSC_PORT } from '../console/eos/eosOSCClient';
+import { EosPatchParser } from '../console/eos/eosPatchParser';
+import { EosCommandBuilder, FixturePatchInput } from '../console/eos/eosCommandBuilder';
+import type {
+  ConsoleType,
+  ConsoleConnectResult,
+  ConsoleDisconnectResult,
+  ConsolePatchImportResult,
+  ConsolePatchExportResult,
+} from '../../renderer/src/types/console';
+
+// ─── In-process client registry ──────────────────────────────────────────────
+
+// One client per console type; reset on disconnect.
+const activeClients = new Map<ConsoleType, EosOSCClient>();
+
+function getEosClient(): EosOSCClient {
+  const client = activeClients.get('eos');
+  if (!client) throw new Error('Not connected to Eos — call console:connect first');
+  return client;
+}
+
+/** Exported for testing */
+export function resetConsoleClients(): void {
+  activeClients.clear();
+}
+
+// ─── IPC registration ─────────────────────────────────────────────────────────
+
+export function registerConsoleHandlers(): void {
+  // ── connect ──────────────────────────────────────────────────────────────
+  ipcMain.handle(
+    'console:connect',
+    async (
+      _event: IpcMainInvokeEvent,
+      consoleType: ConsoleType,
+      ip: string,
+      port?: number,
+    ): Promise<ConsoleConnectResult> => {
+      try {
+        if (consoleType !== 'eos') {
+          return { success: false, error: `Console type "${consoleType}" is not yet supported` };
+        }
+
+        // Disconnect any existing client for this type
+        const existing = activeClients.get('eos');
+        if (existing) {
+          await existing.disconnect().catch(() => undefined);
+          activeClients.delete('eos');
+        }
+
+        const client = new EosOSCClient(ip, port ?? EOS_OSC_PORT);
+        await client.connect();
+        activeClients.set('eos', client);
+
+        logger.info('Console connected', { consoleType, ip, port: port ?? EOS_OSC_PORT });
+        return { success: true };
+      } catch (error) {
+        logger.error('console:connect failed', {
+          consoleType,
+          ip,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return { success: false, error: error instanceof Error ? error.message : String(error) };
+      }
+    },
+  );
+
+  // ── disconnect ────────────────────────────────────────────────────────────
+  ipcMain.handle(
+    'console:disconnect',
+    async (
+      _event: IpcMainInvokeEvent,
+      consoleType: ConsoleType,
+    ): Promise<ConsoleDisconnectResult> => {
+      try {
+        if (consoleType === 'eos') {
+          const client = activeClients.get('eos');
+          if (client) {
+            await client.disconnect();
+            activeClients.delete('eos');
+          }
+        }
+        logger.info('Console disconnected', { consoleType });
+        return { success: true };
+      } catch (error) {
+        logger.error('console:disconnect failed', {
+          consoleType,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return { success: false, error: error instanceof Error ? error.message : String(error) };
+      }
+    },
+  );
+
+  // ── importPatch ───────────────────────────────────────────────────────────
+  ipcMain.handle(
+    'console:importPatch',
+    async (
+      _event: IpcMainInvokeEvent,
+      consoleType: ConsoleType,
+    ): Promise<ConsolePatchImportResult> => {
+      try {
+        if (consoleType !== 'eos') {
+          return { success: false, error: `Patch import not supported for "${consoleType}"` };
+        }
+
+        const client = getEosClient();
+        const rawMessages = await client.getPatch();
+        const parser = new EosPatchParser();
+        const channels = parser.parsePatch(rawMessages);
+
+        logger.info('Eos patch import complete', { channelCount: channels.length });
+        return { success: true, channels };
+      } catch (error) {
+        logger.error('console:importPatch failed', {
+          consoleType,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return { success: false, error: error instanceof Error ? error.message : String(error) };
+      }
+    },
+  );
+
+  // ── exportPatch ───────────────────────────────────────────────────────────
+  ipcMain.handle(
+    'console:exportPatch',
+    async (
+      _event: IpcMainInvokeEvent,
+      consoleType: ConsoleType,
+      fixtures: FixturePatchInput[],
+    ): Promise<ConsolePatchExportResult> => {
+      try {
+        if (consoleType !== 'eos') {
+          return { success: false, error: `Patch export not supported for "${consoleType}"` };
+        }
+
+        const client = getEosClient();
+        const builder = new EosCommandBuilder();
+        const commands = builder.buildBatchPatchCommands(fixtures);
+
+        for (const command of commands) {
+          await client.send('/eos/newcmd', command);
+        }
+
+        logger.info('Eos patch export complete', { commandCount: commands.length });
+        return { success: true, sent: commands.length };
+      } catch (error) {
+        logger.error('console:exportPatch failed', {
+          consoleType,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return { success: false, error: error instanceof Error ? error.message : String(error) };
+      }
+    },
+  );
+
+  logger.info('✅ Console IPC handlers registered');
+}

--- a/apps/desktop/src/main/ipc/console.ts
+++ b/apps/desktop/src/main/ipc/console.ts
@@ -156,7 +156,7 @@ export function registerConsoleHandlers(): void {
 
         for (const command of commands) {
           await client.send('/eos/newcmd', command);
-          await new Promise((resolve) => setTimeout(resolve, 20));
+          await new Promise((resolve) => setTimeout(resolve, 100));
         }
 
         logger.info('Eos patch export complete', { commandCount: commands.length });

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -5,6 +5,14 @@ import type {
   PresenceMember,
 } from '../shared/types/collaboration.types';
 import type { PortStatusResult } from '../shared/types/network.types';
+import type {
+  ConsoleType,
+  ConsoleConnectResult,
+  ConsoleDisconnectResult,
+  ConsolePatchImportResult,
+  ConsolePatchExportResult,
+} from '../shared/types/console.types';
+import type { FixturePatchInput } from '../main/console/eos/eosCommandBuilder';
 
 // Define the Fixture type (will match renderer types)
 interface Fixture {
@@ -420,6 +428,17 @@ contextBridge.exposeInMainWorld('api', {
   mvr: {
     import: (projectId: string) => ipcRenderer.invoke('mvr:import', projectId),
     export: (projectId: string) => ipcRenderer.invoke('mvr:export', projectId),
+  },
+
+  // Console integration (Phase 1: ETC Eos OSC)
+  console: {
+    connect: (consoleType: ConsoleType, ip: string, port?: number) =>
+      ipcRenderer.invoke('console:connect', consoleType, ip, port),
+    disconnect: (consoleType: ConsoleType) => ipcRenderer.invoke('console:disconnect', consoleType),
+    importPatch: (consoleType: ConsoleType) =>
+      ipcRenderer.invoke('console:importPatch', consoleType),
+    exportPatch: (consoleType: ConsoleType, fixtures: FixturePatchInput[]) =>
+      ipcRenderer.invoke('console:exportPatch', consoleType, fixtures),
   },
 
   // Authentication operations
@@ -848,6 +867,15 @@ export interface ElectronAPI {
       layerCount: number;
       gdtfBundled: number;
     }>;
+  };
+  console: {
+    connect: (consoleType: ConsoleType, ip: string, port?: number) => Promise<ConsoleConnectResult>;
+    disconnect: (consoleType: ConsoleType) => Promise<ConsoleDisconnectResult>;
+    importPatch: (consoleType: ConsoleType) => Promise<ConsolePatchImportResult>;
+    exportPatch: (
+      consoleType: ConsoleType,
+      fixtures: FixturePatchInput[],
+    ) => Promise<ConsolePatchExportResult>;
   };
   auth: {
     signIn: (email: string, password: string) => Promise<{ success: boolean; error?: string }>;

--- a/apps/desktop/src/renderer/src/components/console/ConsoleConnectionDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/console/ConsoleConnectionDialog.tsx
@@ -1,0 +1,238 @@
+import { useState, useEffect, useRef } from 'react';
+import { parseIPWithPort } from '@showstack/shared';
+import { useConsoleStore } from '../../store/consoleStore';
+import { logger } from '../../utils/logger';
+import type { ConsoleType } from '../../types/console';
+
+interface Props {
+  isOpen: boolean;
+  projectId: string;
+  onClose: () => void;
+}
+
+const CONSOLE_HINTS: Record<ConsoleType, string> = {
+  eos: 'Enable OSC RX on Eos: Setup → System Settings → Show Control → OSC',
+  grandma2: 'Enable Telnet on GrandMA2: Setup → Network → Telnet (port 30000)',
+  grandma3: 'Configure MA-Net3 on GrandMA3: Setup → Network',
+};
+
+export function ConsoleConnectionDialog({ isOpen, projectId, onClose }: Props) {
+  const { status, connection, connect, disconnect } = useConsoleStore();
+
+  const [consoleType, setConsoleType] = useState<ConsoleType>('eos');
+  const [ipInput, setIpInput] = useState('');
+  const [ipError, setIpError] = useState('');
+  const [reachabilityWarning, setReachabilityWarning] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const reachabilityChecked = useRef<string>('');
+
+  // Pre-populate IP from existing connection
+  useEffect(() => {
+    if (isOpen && connection) {
+      setConsoleType(connection.type);
+      setIpInput(connection.ip);
+    }
+    if (!isOpen) {
+      setIpError('');
+      setReachabilityWarning('');
+      setErrorMessage('');
+      reachabilityChecked.current = '';
+    }
+  }, [isOpen, connection]);
+
+  if (!isOpen) return null;
+
+  const validateIP = (value: string): boolean => {
+    if (!value) {
+      setIpError('');
+      return false;
+    }
+    const parsed = parseIPWithPort(value);
+    if (!parsed) {
+      setIpError('Invalid IP address (e.g. 192.168.1.100 or 192.168.1.100:3032)');
+      return false;
+    }
+    setIpError('');
+    return true;
+  };
+
+  const checkReachability = async (value: string) => {
+    if (reachabilityChecked.current === value) return;
+    reachabilityChecked.current = value;
+
+    const parsed = parseIPWithPort(value);
+    if (!parsed) return;
+
+    try {
+      // We don't have equipment IDs for a console IP — use the IP itself as a synthetic id
+      const results = await window.api.infrastructure.getPortStatusReport(projectId, [
+        { id: '__console__', ip_address: parsed.ip },
+      ]);
+      const result = results.find((r) => r.ip === parsed.ip);
+      if (result && result.status !== 'reachable') {
+        setReachabilityWarning(`${parsed.ip} is currently ${result.status} — connection may fail`);
+      } else {
+        setReachabilityWarning('');
+      }
+    } catch (error) {
+      logger.warn('Reachability check failed:', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  };
+
+  const handleBlur = () => {
+    if (validateIP(ipInput)) {
+      checkReachability(ipInput);
+    }
+  };
+
+  const handleConnect = async () => {
+    if (!validateIP(ipInput)) return;
+
+    const parsed = parseIPWithPort(ipInput);
+    if (!parsed) return;
+
+    setErrorMessage('');
+
+    // If already connected to this console type, disconnect first
+    if (connection?.type === consoleType) {
+      await disconnect(consoleType);
+    }
+
+    const ok = await connect(consoleType, parsed.ip, parsed.port);
+    if (!ok) {
+      setErrorMessage(
+        `Failed to connect to ${parsed.ip}. Check that ${consoleType === 'eos' ? 'OSC RX is enabled on the console' : 'the console is reachable'}.`,
+      );
+    }
+  };
+
+  const handleDisconnect = async () => {
+    if (connection) {
+      await disconnect(connection.type);
+    }
+  };
+
+  const isConnected = status === 'connected';
+  const isConnecting = status === 'connecting';
+  const ipValid = !ipError && ipInput.length > 0;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-[480px]">
+        {/* Header */}
+        <div className="flex items-center justify-between p-6 border-b border-gray-200 dark:border-gray-700">
+          <h2 className="text-xl font-bold text-gray-900 dark:text-white">Connect to Console</h2>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+          >
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="p-6 space-y-4">
+          {/* Console type */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Console Type
+            </label>
+            <select
+              value={consoleType}
+              onChange={(e) => setConsoleType(e.target.value as ConsoleType)}
+              disabled={isConnected || isConnecting}
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white disabled:opacity-60"
+            >
+              <option value="eos">ETC Eos Family (Eos, Ion, Gio, Element)</option>
+              <option value="grandma2">GrandMA2 (coming soon)</option>
+              <option value="grandma3">GrandMA3 (coming soon)</option>
+            </select>
+          </div>
+
+          {/* IP address */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Console IP Address
+            </label>
+            <input
+              type="text"
+              value={ipInput}
+              onChange={(e) => {
+                setIpInput(e.target.value);
+                if (ipError) setIpError('');
+                if (reachabilityWarning) setReachabilityWarning('');
+                reachabilityChecked.current = '';
+              }}
+              onBlur={handleBlur}
+              disabled={isConnected || isConnecting}
+              placeholder="192.168.1.100 or 192.168.1.100:3032"
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white disabled:opacity-60"
+            />
+            {ipError && <p className="text-xs text-red-600 dark:text-red-400 mt-1">{ipError}</p>}
+            {reachabilityWarning && !ipError && (
+              <p className="text-xs text-yellow-600 dark:text-yellow-400 mt-1">
+                {reachabilityWarning}
+              </p>
+            )}
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              {CONSOLE_HINTS[consoleType]}
+            </p>
+          </div>
+
+          {/* Status banner */}
+          {isConnected && connection && (
+            <div className="flex items-center gap-2 p-3 bg-green-50 dark:bg-green-900/20 rounded border border-green-200 dark:border-green-800">
+              <span className="w-2 h-2 rounded-full bg-green-500 flex-shrink-0" />
+              <span className="text-sm text-green-800 dark:text-green-400">
+                Connected to {connection.ip}
+              </span>
+            </div>
+          )}
+
+          {errorMessage && <p className="text-xs text-red-600 dark:text-red-400">{errorMessage}</p>}
+        </div>
+
+        {/* Footer */}
+        <div className="p-6 border-t border-gray-200 dark:border-gray-700 flex justify-between">
+          {isConnected ? (
+            <button
+              onClick={handleDisconnect}
+              className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition text-sm"
+            >
+              Disconnect
+            </button>
+          ) : (
+            <span />
+          )}
+          <div className="flex gap-3">
+            <button
+              onClick={onClose}
+              className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition text-sm"
+            >
+              {isConnected ? 'Close' : 'Cancel'}
+            </button>
+            {!isConnected && (
+              <button
+                onClick={handleConnect}
+                disabled={!ipValid || isConnecting}
+                className="px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white rounded transition text-sm"
+              >
+                {isConnecting ? 'Connecting…' : 'Connect'}
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/console/ConsoleConnectionDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/console/ConsoleConnectionDialog.tsx
@@ -67,7 +67,7 @@ export function ConsoleConnectionDialog({ isOpen, projectId, onClose }: Props) {
     try {
       // We don't have equipment IDs for a console IP — use the IP itself as a synthetic id
       const results = await window.api.infrastructure.getPortStatusReport(projectId, [
-        { id: '__console__', ip_address: parsed.ip },
+        { id: parsed.ip, ip_address: parsed.ip },
       ]);
       const result = results.find((r) => r.ip === parsed.ip);
       if (result && result.status !== 'reachable') {

--- a/apps/desktop/src/renderer/src/components/console/ConsoleConnectionDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/console/ConsoleConnectionDialog.tsx
@@ -96,11 +96,6 @@ export function ConsoleConnectionDialog({ isOpen, projectId, onClose }: Props) {
 
     setErrorMessage('');
 
-    // If already connected to this console type, disconnect first
-    if (connection?.type === consoleType) {
-      await disconnect(consoleType);
-    }
-
     const ok = await connect(consoleType, parsed.ip, parsed.port);
     if (!ok) {
       setErrorMessage(

--- a/apps/desktop/src/renderer/src/components/console/ConsoleStatusIndicator.tsx
+++ b/apps/desktop/src/renderer/src/components/console/ConsoleStatusIndicator.tsx
@@ -1,0 +1,50 @@
+import { useConsoleStore } from '../../store/consoleStore';
+
+interface Props {
+  onClick?: () => void;
+}
+
+const STATUS_DOT: Record<string, string> = {
+  connected: 'bg-green-500',
+  connecting: 'bg-yellow-400 animate-pulse',
+  error: 'bg-red-500',
+  idle: 'bg-gray-400',
+};
+
+function formatLastSync(ts: number | null): string {
+  if (!ts) return '';
+  const diff = Date.now() - ts;
+  if (diff < 60_000) return 'synced just now';
+  if (diff < 3_600_000) return `synced ${Math.floor(diff / 60_000)}m ago`;
+  return `synced ${Math.floor(diff / 3_600_000)}h ago`;
+}
+
+export function ConsoleStatusIndicator({ onClick }: Props) {
+  const { status, connection, lastSync } = useConsoleStore();
+
+  if (status === 'idle' && !connection) return null;
+
+  const dotClass = STATUS_DOT[status] ?? STATUS_DOT.idle;
+  const label =
+    status === 'connected' && connection
+      ? `${connection.type.toUpperCase()} ${connection.ip}`
+      : status === 'connecting'
+        ? 'Connecting…'
+        : status === 'error'
+          ? 'Connection error'
+          : 'Disconnected';
+
+  const syncLabel = status === 'connected' ? formatLastSync(lastSync) : '';
+
+  return (
+    <button
+      onClick={onClick}
+      className="flex items-center gap-1.5 px-2 py-1 rounded text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition"
+      title={`Console: ${label}${syncLabel ? ` — ${syncLabel}` : ''}`}
+    >
+      <span className={`w-2 h-2 rounded-full flex-shrink-0 ${dotClass}`} />
+      <span className="font-medium">{label}</span>
+      {syncLabel && <span className="text-gray-400 dark:text-gray-500">{syncLabel}</span>}
+    </button>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/console/ConsoleSyncDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/console/ConsoleSyncDialog.tsx
@@ -1,0 +1,285 @@
+import { useState } from 'react';
+import { useConsoleStore } from '../../store/consoleStore';
+import { logger } from '../../utils/logger';
+import type { EosPatchChannel } from '../../types/console';
+
+interface ImportedRow {
+  channel: EosPatchChannel;
+  conflict: boolean; // true if a fixture with matching channel already exists
+}
+
+interface Props {
+  isOpen: boolean;
+  /** Current project fixture channel numbers — used for conflict detection */
+  existingChannels?: Set<number>;
+  onImportApply: (channels: EosPatchChannel[]) => void;
+  onClose: () => void;
+}
+
+type SyncDirection = 'import' | 'export';
+
+export function ConsoleSyncDialog({ isOpen, existingChannels, onImportApply, onClose }: Props) {
+  const { connection, status, setLastSync, setLastImport } = useConsoleStore();
+  const [direction, setDirection] = useState<SyncDirection>('import');
+  const [busy, setBusy] = useState(false);
+  const [importRows, setImportRows] = useState<ImportedRow[] | null>(null);
+  const [exportSent, setExportSent] = useState<number | null>(null);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  if (!isOpen) return null;
+
+  const isConnected = status === 'connected' && connection !== null;
+
+  const handleImport = async () => {
+    if (!isConnected || !connection) return;
+    setBusy(true);
+    setErrorMessage('');
+    setImportRows(null);
+    setExportSent(null);
+
+    try {
+      const result = await window.api.console.importPatch(connection.type);
+      if (!result.success || !result.channels) {
+        setErrorMessage(result.error ?? 'Import failed — no data received');
+        return;
+      }
+      const rows: ImportedRow[] = result.channels.map((ch) => ({
+        channel: ch,
+        conflict: existingChannels?.has(ch.channelNumber) ?? false,
+      }));
+      setImportRows(rows);
+      setLastImport(result.channels);
+    } catch (error) {
+      logger.error('Console import failed:', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      setErrorMessage('Import failed — see logs for details');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleExport = async () => {
+    if (!isConnected || !connection) return;
+    setBusy(true);
+    setErrorMessage('');
+    setImportRows(null);
+    setExportSent(null);
+
+    try {
+      const fixtures = await window.api.fixtures.getAll();
+      const result = await window.api.console.exportPatch(connection.type, fixtures);
+      if (!result.success) {
+        setErrorMessage(result.error ?? 'Export failed');
+        return;
+      }
+      setExportSent(result.sent ?? 0);
+      setLastSync(Date.now());
+    } catch (error) {
+      logger.error('Console export failed:', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      setErrorMessage('Export failed — see logs for details');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleApplyImport = () => {
+    if (!importRows) return;
+    const selected = importRows.map((r) => r.channel);
+    onImportApply(selected);
+    setLastSync(Date.now());
+    onClose();
+  };
+
+  const conflictCount = importRows?.filter((r) => r.conflict).length ?? 0;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-[700px] max-h-[85vh] flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+          <h2 className="text-xl font-bold text-gray-900 dark:text-white">
+            Sync with {connection ? connection.ip : 'Console'}
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+          >
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto p-6 space-y-4">
+          {!isConnected && (
+            <div className="p-3 bg-yellow-50 dark:bg-yellow-900/20 text-yellow-800 dark:text-yellow-400 rounded text-sm border border-yellow-200 dark:border-yellow-800">
+              Not connected to a console. Use the Connect button to establish a connection first.
+            </div>
+          )}
+
+          {/* Direction toggle */}
+          <div className="flex gap-2">
+            <button
+              onClick={() => {
+                setDirection('import');
+                setImportRows(null);
+                setExportSent(null);
+                setErrorMessage('');
+              }}
+              className={`flex-1 py-2 px-4 rounded text-sm font-medium transition ${
+                direction === 'import'
+                  ? 'bg-blue-600 text-white'
+                  : 'border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'
+              }`}
+            >
+              Import Console → ShowStack
+            </button>
+            <button
+              onClick={() => {
+                setDirection('export');
+                setImportRows(null);
+                setExportSent(null);
+                setErrorMessage('');
+              }}
+              className={`flex-1 py-2 px-4 rounded text-sm font-medium transition ${
+                direction === 'export'
+                  ? 'bg-blue-600 text-white'
+                  : 'border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'
+              }`}
+            >
+              Export ShowStack → Console
+            </button>
+          </div>
+
+          {/* Direction description */}
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            {direction === 'import'
+              ? 'Reads the full patch from the console and previews it below. You choose which channels to apply.'
+              : 'Sends all ShowStack fixtures to the console as patch commands. Existing console patch may be overwritten.'}
+          </p>
+
+          {errorMessage && <p className="text-xs text-red-600 dark:text-red-400">{errorMessage}</p>}
+
+          {/* Import preview */}
+          {direction === 'import' && importRows !== null && (
+            <div>
+              {conflictCount > 0 && (
+                <p className="text-xs text-yellow-600 dark:text-yellow-400 mb-2">
+                  {conflictCount} channel{conflictCount !== 1 ? 's' : ''} already exist in this
+                  project and will be updated.
+                </p>
+              )}
+              <div className="border border-gray-200 dark:border-gray-700 rounded overflow-hidden">
+                <table className="w-full text-xs">
+                  <thead className="bg-gray-50 dark:bg-gray-700">
+                    <tr>
+                      <th className="px-3 py-2 text-left font-medium text-gray-600 dark:text-gray-300">
+                        Ch
+                      </th>
+                      <th className="px-3 py-2 text-left font-medium text-gray-600 dark:text-gray-300">
+                        Address
+                      </th>
+                      <th className="px-3 py-2 text-left font-medium text-gray-600 dark:text-gray-300">
+                        Fixture
+                      </th>
+                      <th className="px-3 py-2 text-left font-medium text-gray-600 dark:text-gray-300">
+                        Label
+                      </th>
+                      <th className="px-3 py-2 text-left font-medium text-gray-600 dark:text-gray-300"></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {importRows.map((row) => (
+                      <tr
+                        key={row.channel.channelNumber}
+                        className={`border-t border-gray-100 dark:border-gray-700 ${
+                          row.conflict ? 'bg-yellow-50 dark:bg-yellow-900/10' : ''
+                        }`}
+                      >
+                        <td className="px-3 py-1.5 text-gray-900 dark:text-white">
+                          {row.channel.channelNumber}
+                        </td>
+                        <td className="px-3 py-1.5 text-gray-500 dark:text-gray-400">
+                          {row.channel.universe != null && row.channel.address != null
+                            ? `${row.channel.universe}/${row.channel.address}`
+                            : '—'}
+                        </td>
+                        <td className="px-3 py-1.5 text-gray-500 dark:text-gray-400">
+                          {row.channel.fixtureType || '—'}
+                        </td>
+                        <td className="px-3 py-1.5 text-gray-500 dark:text-gray-400">
+                          {row.channel.label || '—'}
+                        </td>
+                        <td className="px-3 py-1.5 text-yellow-600 dark:text-yellow-400 text-xs">
+                          {row.conflict ? 'update' : ''}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                {importRows.length} channel{importRows.length !== 1 ? 's' : ''} ready to import
+              </p>
+            </div>
+          )}
+
+          {/* Export result */}
+          {direction === 'export' && exportSent !== null && (
+            <div className="p-3 bg-green-50 dark:bg-green-900/20 text-green-800 dark:text-green-400 rounded text-sm border border-green-200 dark:border-green-800">
+              Sent {exportSent} command{exportSent !== 1 ? 's' : ''} to console.
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="px-6 py-4 border-t border-gray-200 dark:border-gray-700 flex justify-end gap-3">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition text-sm"
+          >
+            Close
+          </button>
+
+          {direction === 'import' && importRows === null && (
+            <button
+              onClick={handleImport}
+              disabled={!isConnected || busy}
+              className="px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white rounded transition text-sm"
+            >
+              {busy ? 'Fetching patch…' : 'Fetch Patch from Console'}
+            </button>
+          )}
+
+          {direction === 'import' && importRows !== null && (
+            <button
+              onClick={handleApplyImport}
+              className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded transition text-sm"
+            >
+              Apply Import ({importRows.length})
+            </button>
+          )}
+
+          {direction === 'export' && exportSent === null && (
+            <button
+              onClick={handleExport}
+              disabled={!isConnected || busy}
+              className="px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white rounded transition text-sm"
+            >
+              {busy ? 'Sending…' : 'Send to Console'}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/console/ConsoleSyncDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/console/ConsoleSyncDialog.tsx
@@ -48,7 +48,6 @@ export function ConsoleSyncDialog({ isOpen, existingChannels, onImportApply, onC
         conflict: existingChannels?.has(ch.channelNumber) ?? false,
       }));
       setImportRows(rows);
-      setLastImport(result.channels);
     } catch (error) {
       logger.error('Console import failed:', {
         error: error instanceof Error ? error.message : String(error),
@@ -89,6 +88,7 @@ export function ConsoleSyncDialog({ isOpen, existingChannels, onImportApply, onC
     if (!importRows) return;
     const selected = importRows.map((r) => r.channel);
     onImportApply(selected);
+    setLastImport(selected);
     setLastSync(Date.now());
     onClose();
   };

--- a/apps/desktop/src/renderer/src/components/console/__tests__/ConsoleConnectionDialog.test.tsx
+++ b/apps/desktop/src/renderer/src/components/console/__tests__/ConsoleConnectionDialog.test.tsx
@@ -10,7 +10,11 @@ vi.mock('../../../utils/logger', () => ({
 
 // Extend the global window.api mock (set up in test/setup.ts) with the console + infrastructure methods needed
 const consoleMock = {
-  connect: vi.fn().mockResolvedValue({ success: true }),
+  connect: vi
+    .fn()
+    .mockImplementation((_type: string, ip: string, port?: number) =>
+      Promise.resolve({ success: true, connection: { type: 'eos', ip, port: port ?? 3032 } }),
+    ),
   disconnect: vi.fn().mockResolvedValue({ success: true }),
   importPatch: vi.fn(),
   exportPatch: vi.fn(),
@@ -30,7 +34,9 @@ beforeEach(() => {
       getPortStatusReport: infrastructureMock.getPortStatusReport,
     },
   };
-  consoleMock.connect.mockResolvedValue({ success: true });
+  consoleMock.connect.mockImplementation((_type: string, ip: string, port?: number) =>
+    Promise.resolve({ success: true, connection: { type: 'eos', ip, port: port ?? 3032 } }),
+  );
   consoleMock.disconnect.mockResolvedValue({ success: true });
   infrastructureMock.getPortStatusReport.mockResolvedValue([]);
   useConsoleStore.getState().clearConnection();

--- a/apps/desktop/src/renderer/src/components/console/__tests__/ConsoleConnectionDialog.test.tsx
+++ b/apps/desktop/src/renderer/src/components/console/__tests__/ConsoleConnectionDialog.test.tsx
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ConsoleConnectionDialog } from '../ConsoleConnectionDialog';
+import { useConsoleStore } from '../../../store/consoleStore';
+
+vi.mock('../../../utils/logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// Extend the global window.api mock (set up in test/setup.ts) with the console + infrastructure methods needed
+const consoleMock = {
+  connect: vi.fn().mockResolvedValue({ success: true }),
+  disconnect: vi.fn().mockResolvedValue({ success: true }),
+  importPatch: vi.fn(),
+  exportPatch: vi.fn(),
+};
+const infrastructureMock = {
+  getPortStatusReport: vi.fn().mockResolvedValue([]),
+};
+
+beforeEach(() => {
+  // Attach mocks to window.api
+  (window as unknown as { api: Record<string, unknown> }).api = {
+    ...((window as unknown as { api: Record<string, unknown> }).api ?? {}),
+    console: consoleMock,
+    infrastructure: {
+      ...((window as unknown as { api: { infrastructure?: Record<string, unknown> } }).api
+        ?.infrastructure ?? {}),
+      getPortStatusReport: infrastructureMock.getPortStatusReport,
+    },
+  };
+  consoleMock.connect.mockResolvedValue({ success: true });
+  consoleMock.disconnect.mockResolvedValue({ success: true });
+  infrastructureMock.getPortStatusReport.mockResolvedValue([]);
+  useConsoleStore.getState().clearConnection();
+});
+
+const defaultProps = {
+  isOpen: true,
+  projectId: 'proj-1',
+  onClose: vi.fn(),
+};
+
+describe('ConsoleConnectionDialog', () => {
+  it('renders nothing when isOpen is false', () => {
+    render(<ConsoleConnectionDialog {...defaultProps} isOpen={false} />);
+    expect(screen.queryByText('Connect to Console')).toBeNull();
+  });
+
+  it('renders the dialog when isOpen is true', () => {
+    render(<ConsoleConnectionDialog {...defaultProps} />);
+    expect(screen.getByText('Connect to Console')).toBeDefined();
+  });
+
+  // ─── IP validation ────────────────────────────────────────────────────────
+
+  it('shows inline IP error on blur with invalid value', async () => {
+    render(<ConsoleConnectionDialog {...defaultProps} />);
+    const input = screen.getByPlaceholderText(/192\.168\.1\.100/);
+    await userEvent.type(input, 'not-an-ip');
+    fireEvent.blur(input);
+    await waitFor(() => {
+      expect(screen.getByText(/Invalid IP address/i)).toBeDefined();
+    });
+  });
+
+  it('clears IP error when input becomes valid', async () => {
+    render(<ConsoleConnectionDialog {...defaultProps} />);
+    const input = screen.getByPlaceholderText(/192\.168\.1\.100/);
+    await userEvent.type(input, 'bad');
+    fireEvent.blur(input);
+    await waitFor(() => expect(screen.queryByText(/Invalid IP address/i)).toBeDefined());
+
+    await userEvent.clear(input);
+    await userEvent.type(input, '10.0.0.1');
+    fireEvent.blur(input);
+    await waitFor(() => expect(screen.queryByText(/Invalid IP address/i)).toBeNull());
+  });
+
+  it('Connect button is disabled when IP field is empty', () => {
+    render(<ConsoleConnectionDialog {...defaultProps} />);
+    const button = screen.getByRole('button', { name: /connect/i });
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('Connect button becomes enabled after valid IP is entered', async () => {
+    render(<ConsoleConnectionDialog {...defaultProps} />);
+    const input = screen.getByPlaceholderText(/192\.168\.1\.100/);
+    await userEvent.type(input, '10.0.0.100');
+    await waitFor(() => {
+      const button = screen.getByRole('button', { name: /connect/i });
+      expect((button as HTMLButtonElement).disabled).toBe(false);
+    });
+  });
+
+  // ─── reachability warning ─────────────────────────────────────────────────
+
+  it('shows reachability warning when IP is unreachable', async () => {
+    infrastructureMock.getPortStatusReport.mockResolvedValueOnce([
+      {
+        equipment_id: '__console__',
+        ip: '10.0.0.1',
+        status: 'unreachable',
+        last_checked: Date.now(),
+      },
+    ]);
+
+    render(<ConsoleConnectionDialog {...defaultProps} />);
+    const input = screen.getByPlaceholderText(/192\.168\.1\.100/);
+    await userEvent.type(input, '10.0.0.1');
+    fireEvent.blur(input);
+
+    await waitFor(() => {
+      expect(screen.getByText(/currently unreachable/i)).toBeDefined();
+    });
+  });
+
+  it('does not show reachability warning when IP is reachable', async () => {
+    infrastructureMock.getPortStatusReport.mockResolvedValueOnce([
+      {
+        equipment_id: '__console__',
+        ip: '10.0.0.1',
+        status: 'reachable',
+        last_checked: Date.now(),
+      },
+    ]);
+
+    render(<ConsoleConnectionDialog {...defaultProps} />);
+    const input = screen.getByPlaceholderText(/192\.168\.1\.100/);
+    await userEvent.type(input, '10.0.0.1');
+    fireEvent.blur(input);
+
+    await waitFor(() => {
+      expect(screen.queryByText(/currently/i)).toBeNull();
+    });
+  });
+
+  // ─── connect action ───────────────────────────────────────────────────────
+
+  it('calls window.api.console.connect when Connect is clicked', async () => {
+    render(<ConsoleConnectionDialog {...defaultProps} />);
+    const input = screen.getByPlaceholderText(/192\.168\.1\.100/);
+    await userEvent.type(input, '10.0.0.100');
+    fireEvent.blur(input);
+    await waitFor(() => {
+      const button = screen.getByRole('button', { name: /connect/i });
+      expect((button as HTMLButtonElement).disabled).toBe(false);
+    });
+    await userEvent.click(screen.getByRole('button', { name: /connect/i }));
+    await waitFor(() =>
+      expect(consoleMock.connect).toHaveBeenCalledWith('eos', '10.0.0.100', undefined),
+    );
+  });
+
+  it('shows connected banner after successful connect', async () => {
+    render(<ConsoleConnectionDialog {...defaultProps} />);
+    const input = screen.getByPlaceholderText(/192\.168\.1\.100/);
+    await userEvent.type(input, '10.0.0.100');
+    await userEvent.click(screen.getByRole('button', { name: /connect/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/Connected to/i)).toBeDefined();
+    });
+  });
+
+  it('shows error message when connect fails', async () => {
+    consoleMock.connect.mockResolvedValueOnce({ success: false, error: 'UDP bind failed' });
+    render(<ConsoleConnectionDialog {...defaultProps} />);
+    const input = screen.getByPlaceholderText(/192\.168\.1\.100/);
+    await userEvent.type(input, '10.0.0.100');
+    await userEvent.click(screen.getByRole('button', { name: /connect/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to connect/i)).toBeDefined();
+    });
+  });
+});

--- a/apps/desktop/src/renderer/src/components/console/__tests__/ConsoleSyncDialog.test.tsx
+++ b/apps/desktop/src/renderer/src/components/console/__tests__/ConsoleSyncDialog.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ConsoleSyncDialog } from '../ConsoleSyncDialog';
+import { useConsoleStore } from '../../../store/consoleStore';
+
+vi.mock('../../../utils/logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const consoleMock = {
+  connect: vi.fn().mockResolvedValue({ success: true }),
+  disconnect: vi.fn().mockResolvedValue({ success: true }),
+  importPatch: vi.fn(),
+  exportPatch: vi.fn(),
+};
+const fixturesMock = {
+  getAll: vi.fn().mockResolvedValue([]),
+};
+
+const defaultProps = {
+  isOpen: true,
+  onImportApply: vi.fn(),
+  onClose: vi.fn(),
+};
+
+const MOCK_CHANNELS = [
+  { channelNumber: 1, universe: 1, address: 1, fixtureType: 'Leko', label: 'SR 1', notes: '' },
+  { channelNumber: 2, universe: 1, address: 10, fixtureType: 'Fresnel', label: 'SR 2', notes: '' },
+];
+
+beforeEach(() => {
+  (window as unknown as { api: Record<string, unknown> }).api = {
+    ...((window as unknown as { api: Record<string, unknown> }).api ?? {}),
+    console: consoleMock,
+    fixtures: fixturesMock,
+  };
+  consoleMock.importPatch.mockResolvedValue({ success: true, channels: MOCK_CHANNELS });
+  consoleMock.exportPatch.mockResolvedValue({ success: true, sent: 2 });
+  fixturesMock.getAll.mockResolvedValue([{ channel: '1', universe: 1, dmx_address: 1 }]);
+
+  // Start connected
+  useConsoleStore.setState({
+    status: 'connected',
+    connection: { type: 'eos', ip: '10.0.0.1', port: 3032, connected: true, lastSync: null },
+    lastSync: null,
+    lastImport: null,
+  });
+});
+
+describe('ConsoleSyncDialog', () => {
+  it('renders nothing when isOpen is false', () => {
+    render(<ConsoleSyncDialog {...defaultProps} isOpen={false} />);
+    expect(screen.queryByText('Sync with')).toBeNull();
+  });
+
+  it('renders the dialog with console IP in title', () => {
+    render(<ConsoleSyncDialog {...defaultProps} />);
+    expect(screen.getByText(/10\.0\.0\.1/)).toBeDefined();
+  });
+
+  it('shows not-connected warning when status is idle', () => {
+    useConsoleStore.setState({ status: 'idle', connection: null });
+    render(<ConsoleSyncDialog {...defaultProps} />);
+    expect(screen.getByText(/Not connected/i)).toBeDefined();
+  });
+
+  // ─── import flow ──────────────────────────────────────────────────────────
+
+  it('calls importPatch and renders preview table on fetch', async () => {
+    render(<ConsoleSyncDialog {...defaultProps} />);
+    await userEvent.click(screen.getByRole('button', { name: /Fetch Patch/i }));
+
+    await waitFor(() => {
+      expect(consoleMock.importPatch).toHaveBeenCalledWith('eos');
+      expect(screen.getByText('SR 1')).toBeDefined();
+      expect(screen.getByText('SR 2')).toBeDefined();
+    });
+  });
+
+  it('shows conflict indicator for channels matching existingChannels', async () => {
+    render(<ConsoleSyncDialog {...defaultProps} existingChannels={new Set([1])} />);
+    await userEvent.click(screen.getByRole('button', { name: /Fetch Patch/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/1 channel.*already exist/i)).toBeDefined();
+    });
+  });
+
+  it('calls onImportApply with channels when Apply Import is clicked', async () => {
+    render(<ConsoleSyncDialog {...defaultProps} />);
+    await userEvent.click(screen.getByRole('button', { name: /Fetch Patch/i }));
+    await waitFor(() => screen.getByRole('button', { name: /Apply Import/i }));
+    await userEvent.click(screen.getByRole('button', { name: /Apply Import/i }));
+
+    expect(defaultProps.onImportApply).toHaveBeenCalledWith(MOCK_CHANNELS);
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+
+  it('shows error when importPatch fails', async () => {
+    consoleMock.importPatch.mockResolvedValueOnce({ success: false, error: 'timeout' });
+    render(<ConsoleSyncDialog {...defaultProps} />);
+    await userEvent.click(screen.getByRole('button', { name: /Fetch Patch/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/timeout/i)).toBeDefined();
+    });
+  });
+
+  // ─── export flow ──────────────────────────────────────────────────────────
+
+  it('switches to export direction and calls exportPatch', async () => {
+    render(<ConsoleSyncDialog {...defaultProps} />);
+    await userEvent.click(screen.getByRole('button', { name: /Export ShowStack/i }));
+    await userEvent.click(screen.getByRole('button', { name: /Send to Console/i }));
+
+    await waitFor(() => {
+      expect(consoleMock.exportPatch).toHaveBeenCalledWith('eos', expect.any(Array));
+      expect(screen.getByText(/Sent 2 commands/i)).toBeDefined();
+    });
+  });
+
+  it('shows error when exportPatch fails', async () => {
+    consoleMock.exportPatch.mockResolvedValueOnce({ success: false, error: 'connection lost' });
+    render(<ConsoleSyncDialog {...defaultProps} />);
+    await userEvent.click(screen.getByRole('button', { name: /Export ShowStack/i }));
+    await userEvent.click(screen.getByRole('button', { name: /Send to Console/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/connection lost/i)).toBeDefined();
+    });
+  });
+});

--- a/apps/desktop/src/renderer/src/store/__tests__/consoleStore.test.ts
+++ b/apps/desktop/src/renderer/src/store/__tests__/consoleStore.test.ts
@@ -21,7 +21,12 @@ import { useConsoleStore } from '../consoleStore';
 
 describe('consoleStore', () => {
   beforeEach(() => {
-    apiMock.console.connect.mockResolvedValue({ success: true });
+    apiMock.console.connect.mockImplementation((_type: string, ip: string, port?: number) =>
+      Promise.resolve({
+        success: true,
+        connection: { type: 'eos', ip, port: port ?? 3032 },
+      }),
+    );
     apiMock.console.disconnect.mockResolvedValue({ success: true });
     useConsoleStore.getState().clearConnection();
   });

--- a/apps/desktop/src/renderer/src/store/__tests__/consoleStore.test.ts
+++ b/apps/desktop/src/renderer/src/store/__tests__/consoleStore.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../utils/logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// Provide a window.api mock so hasAPI() returns true
+const apiMock = {
+  console: {
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    importPatch: vi.fn(),
+    exportPatch: vi.fn(),
+  },
+};
+(globalThis as unknown as { window: { api: typeof apiMock } }).window = {
+  api: apiMock,
+};
+
+import { useConsoleStore } from '../consoleStore';
+
+describe('consoleStore', () => {
+  beforeEach(() => {
+    apiMock.console.connect.mockResolvedValue({ success: true });
+    apiMock.console.disconnect.mockResolvedValue({ success: true });
+    useConsoleStore.getState().clearConnection();
+  });
+
+  // ─── connect ──────────────────────────────────────────────────────────────
+
+  describe('connect', () => {
+    it('sets status to connected and stores connection on success', async () => {
+      const ok = await useConsoleStore.getState().connect('eos', '10.0.0.1');
+      const state = useConsoleStore.getState();
+
+      expect(ok).toBe(true);
+      expect(state.status).toBe('connected');
+      expect(state.connection).toMatchObject({ type: 'eos', ip: '10.0.0.1', port: 3032 });
+    });
+
+    it('uses the supplied port', async () => {
+      await useConsoleStore.getState().connect('eos', '10.0.0.1', 9000);
+      expect(useConsoleStore.getState().connection?.port).toBe(9000);
+    });
+
+    it('sets status to error on failure', async () => {
+      apiMock.console.connect.mockResolvedValueOnce({ success: false, error: 'refused' });
+      const ok = await useConsoleStore.getState().connect('eos', '10.0.0.1');
+
+      expect(ok).toBe(false);
+      expect(useConsoleStore.getState().status).toBe('error');
+      expect(useConsoleStore.getState().connection).toBeNull();
+    });
+
+    it('sets status to error on thrown exception', async () => {
+      apiMock.console.connect.mockRejectedValueOnce(new Error('boom'));
+      const ok = await useConsoleStore.getState().connect('eos', '10.0.0.1');
+
+      expect(ok).toBe(false);
+      expect(useConsoleStore.getState().status).toBe('error');
+    });
+  });
+
+  // ─── disconnect ───────────────────────────────────────────────────────────
+
+  describe('disconnect', () => {
+    it('clears connection and returns to idle', async () => {
+      await useConsoleStore.getState().connect('eos', '10.0.0.1');
+      await useConsoleStore.getState().disconnect('eos');
+
+      const state = useConsoleStore.getState();
+      expect(state.connection).toBeNull();
+      expect(state.status).toBe('idle');
+    });
+
+    it('does not clear connection when disconnecting a different type', async () => {
+      await useConsoleStore.getState().connect('eos', '10.0.0.1');
+      await useConsoleStore.getState().disconnect('grandma2');
+
+      // Eos connection should still be there
+      expect(useConsoleStore.getState().connection?.type).toBe('eos');
+    });
+  });
+
+  // ─── setLastSync / setLastImport ──────────────────────────────────────────
+
+  it('setLastSync updates lastSync and connection.lastSync', async () => {
+    await useConsoleStore.getState().connect('eos', '10.0.0.1');
+    useConsoleStore.getState().setLastSync(12345);
+
+    const state = useConsoleStore.getState();
+    expect(state.lastSync).toBe(12345);
+    expect(state.connection?.lastSync).toBe(12345);
+  });
+
+  it('setLastImport stores the channel array', () => {
+    const channels = [
+      { channelNumber: 1, universe: 1, address: 1, fixtureType: 'Leko', label: 'SR 1', notes: '' },
+    ];
+    useConsoleStore.getState().setLastImport(channels);
+    expect(useConsoleStore.getState().lastImport).toEqual(channels);
+  });
+
+  // ─── clearConnection ──────────────────────────────────────────────────────
+
+  it('clearConnection resets all state', async () => {
+    await useConsoleStore.getState().connect('eos', '10.0.0.1');
+    useConsoleStore.getState().setLastSync(9999);
+    useConsoleStore.getState().clearConnection();
+
+    const state = useConsoleStore.getState();
+    expect(state.connection).toBeNull();
+    expect(state.status).toBe('idle');
+    expect(state.lastSync).toBeNull();
+    expect(state.lastImport).toBeNull();
+  });
+});

--- a/apps/desktop/src/renderer/src/store/consoleStore.ts
+++ b/apps/desktop/src/renderer/src/store/consoleStore.ts
@@ -1,0 +1,89 @@
+import { create } from 'zustand';
+import { logger } from '../utils/logger';
+import type { ConsoleType, ConsoleConnection, EosPatchChannel } from '../types/console';
+
+// Type guard for window.api
+const hasAPI = (): boolean =>
+  typeof window !== 'undefined' && 'api' in window && window.api !== undefined;
+
+export type ConsoleStatus = 'idle' | 'connecting' | 'connected' | 'error';
+
+interface ConsoleState {
+  connection: ConsoleConnection | null;
+  status: ConsoleStatus;
+  lastSync: number | null;
+  lastImport: EosPatchChannel[] | null;
+
+  // Actions
+  connect: (type: ConsoleType, ip: string, port?: number) => Promise<boolean>;
+  disconnect: (type: ConsoleType) => Promise<void>;
+  setLastSync: (t: number) => void;
+  setLastImport: (channels: EosPatchChannel[]) => void;
+  clearConnection: () => void;
+}
+
+export const useConsoleStore = create<ConsoleState>((set, get) => ({
+  connection: null,
+  status: 'idle',
+  lastSync: null,
+  lastImport: null,
+
+  connect: async (type, ip, port) => {
+    if (!hasAPI()) {
+      logger.warn('API not available');
+      return false;
+    }
+
+    set({ status: 'connecting' });
+    try {
+      const result = await window.api.console.connect(type, ip, port);
+      if (result.success) {
+        set({
+          status: 'connected',
+          connection: { type, ip, port: port ?? 3032, connected: true, lastSync: null },
+        });
+        logger.info(`Console connected: ${type} @ ${ip}`);
+        return true;
+      } else {
+        set({ status: 'error' });
+        logger.error('Console connect failed:', { error: result.error });
+        return false;
+      }
+    } catch (error) {
+      set({ status: 'error' });
+      logger.error('Console connect threw:', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return false;
+    }
+  },
+
+  disconnect: async (type) => {
+    if (!hasAPI()) return;
+
+    try {
+      await window.api.console.disconnect(type);
+    } catch (error) {
+      logger.error('Console disconnect threw:', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      const { connection } = get();
+      if (connection?.type === type) {
+        set({ connection: null, status: 'idle' });
+      }
+    }
+  },
+
+  setLastSync: (t) => {
+    set((state) => ({
+      lastSync: t,
+      connection: state.connection ? { ...state.connection, lastSync: t } : null,
+    }));
+  },
+
+  setLastImport: (channels) => set({ lastImport: channels }),
+
+  clearConnection: () =>
+    set({ connection: null, status: 'idle', lastSync: null, lastImport: null }),
+}));

--- a/apps/desktop/src/renderer/src/store/consoleStore.ts
+++ b/apps/desktop/src/renderer/src/store/consoleStore.ts
@@ -37,12 +37,12 @@ export const useConsoleStore = create<ConsoleState>((set, get) => ({
     set({ status: 'connecting' });
     try {
       const result = await window.api.console.connect(type, ip, port);
-      if (result.success) {
+      if (result.success && result.connection) {
         set({
           status: 'connected',
-          connection: { type, ip, port: port ?? 3032, connected: true, lastSync: null },
+          connection: { ...result.connection, connected: true, lastSync: null },
         });
-        logger.info(`Console connected: ${type} @ ${ip}`);
+        logger.info(`Console connected: ${result.connection.type} @ ${result.connection.ip}`);
         return true;
       } else {
         set({ status: 'error' });

--- a/apps/desktop/src/renderer/src/types/console.ts
+++ b/apps/desktop/src/renderer/src/types/console.ts
@@ -1,0 +1,62 @@
+/**
+ * Console integration type definitions.
+ * Shared between renderer, preload, and (via import) main process.
+ */
+
+// ─── Console connection ───────────────────────────────────────────────────────
+
+export type ConsoleType = 'eos' | 'grandma2' | 'grandma3';
+
+export interface ConsoleConnection {
+  type: ConsoleType;
+  ip: string;
+  port: number;
+  connected: boolean;
+  lastSync: number | null;
+}
+
+// ─── Eos patch data ───────────────────────────────────────────────────────────
+
+/**
+ * One channel as reported by Eos OSC `/eos/out/patch/[index]`.
+ * All fields except channelNumber are optional because Eos may omit them
+ * for un-patched channels or older software versions.
+ */
+export interface EosPatchChannel {
+  /** Eos channel number (1-based) */
+  channelNumber: number;
+  /** DMX universe (1-based), null if un-patched */
+  universe: number | null;
+  /** DMX address within the universe (1-based), null if un-patched */
+  address: number | null;
+  /** Eos fixture profile name, e.g. "Source Four 19deg" */
+  fixtureType: string;
+  /** Channel label as shown in Eos live display */
+  label: string;
+  /** Free-text notes field */
+  notes: string;
+}
+
+// ─── IPC result envelopes ─────────────────────────────────────────────────────
+
+export interface ConsoleConnectResult {
+  success: boolean;
+  error?: string;
+}
+
+export interface ConsoleDisconnectResult {
+  success: boolean;
+  error?: string;
+}
+
+export interface ConsolePatchImportResult {
+  success: boolean;
+  channels?: EosPatchChannel[];
+  error?: string;
+}
+
+export interface ConsolePatchExportResult {
+  success: boolean;
+  sent?: number;
+  error?: string;
+}

--- a/apps/desktop/src/renderer/src/types/console.ts
+++ b/apps/desktop/src/renderer/src/types/console.ts
@@ -42,6 +42,8 @@ export interface EosPatchChannel {
 export interface ConsoleConnectResult {
   success: boolean;
   error?: string;
+  /** Effective connection parameters used by the main process — present on success */
+  connection?: { type: ConsoleType; ip: string; port: number };
 }
 
 export interface ConsoleDisconnectResult {

--- a/apps/desktop/src/shared/types/console.types.ts
+++ b/apps/desktop/src/shared/types/console.types.ts
@@ -1,0 +1,9 @@
+export type {
+  ConsoleType,
+  ConsoleConnection,
+  EosPatchChannel,
+  ConsoleConnectResult,
+  ConsoleDisconnectResult,
+  ConsolePatchImportResult,
+  ConsolePatchExportResult,
+} from '../../renderer/src/types/console';

--- a/docs/features/console-integration-plan.md
+++ b/docs/features/console-integration-plan.md
@@ -4,7 +4,7 @@
 **Delivery:** Phased approach with 5 iterative milestones
 **Timeline:** 10 weeks (2.5 months)
 **Effort:** 1 developer full-time
-**Status:** In progress — network prerequisites complete; Phase 1 (Eos OSC) next
+**Status:** In progress — network prerequisites + Phase 1 (Eos OSC backend) complete; Phase 2 (UI + live sync) next
 **Created:** January 20, 2026
 **Updated:** March 27, 2026
 **Priority:** High (competitive gap with Lightwright, professional workflow integration)
@@ -116,7 +116,7 @@ Both console integration and IP/VLAN port validation (Issue #17) require network
 ### 1. Protocol Strategy
 
 - **ETC Eos:** OSC (Open Sound Control) over UDP
-  - Library: `osc` or `node-osc`
+  - Library: `node-osc@11.3.0` (chosen over `osc@2.4.4` — clean security audit, CJS-compatible)
   - Port: 3032 (default Eos OSC RX port)
   - Bi-directional: Send commands, receive updates
 
@@ -159,607 +159,138 @@ Both console integration and IP/VLAN port validation (Issue #17) require network
 
 ---
 
-## Phase 1: ETC Eos - OSC Import (Weeks 1-2)
+## Phase 1: ETC Eos - OSC Backend ✅ COMPLETE (branch: `feature/eos-osc-phase1`)
 
-**Milestone:** Import patch from Eos console into ShowStack
+**Milestone:** Import/export patch from Eos via OSC — backend only (no UI)
 
-### New Files to Create
+### Shipped Files
 
 ```
-src/main/console/
-├── eos/
-│   ├── eosOSCClient.ts                       (400 lines) - OSC client
-│   ├── eosCommandBuilder.ts                  (300 lines) - Build OSC commands
-│   ├── eosPatchParser.ts                     (350 lines) - Parse Eos patch data
-│   └── __tests__/
-│       ├── eosOSCClient.test.ts              (300 lines, 80%+ coverage)
-│       ├── eosCommandBuilder.test.ts         (200 lines, 80%+ coverage)
-│       └── eosPatchParser.test.ts            (250 lines, 80%+ coverage)
-
-src/main/ipc/
-├── console.ts                                (500 lines) - Console IPC handlers
+apps/desktop/src/main/console/eos/
+├── eosOSCClient.ts          — node-osc Client (send) + Server (receive); connect/disconnect/send/getPatch
+├── eosCommandBuilder.ts     — buildPatchCommand, buildBatchPatchCommands, buildLabelCommand, buildNotesCommand, mapToEosProfile
+├── eosPatchParser.ts        — parseChannelMessage, parsePatch, toImportedFixture; parseEosAddress, parseEosLabel
 └── __tests__/
-    └── console.test.ts                       (350 lines, 70%+ coverage)
+    ├── eosOSCClient.test.ts       (12 tests — constructor, connect, disconnect, send, getPatch with timeout)
+    ├── eosCommandBuilder.test.ts  (16 tests — all buildPatch variants, mapToEosProfile)
+    └── eosPatchParser.test.ts     (12 tests — parseChannelMessage, parsePatch, toImportedFixture)
 
-src/renderer/src/types/
-└── console.ts                                (200 lines) - TypeScript interfaces
+apps/desktop/src/main/ipc/
+├── console.ts               — console:connect, console:disconnect, console:importPatch, console:exportPatch
+└── __tests__/
+    └── console.test.ts      (11 tests — all four handlers, error cases, reconnect)
+
+apps/desktop/src/renderer/src/types/console.ts       — ConsoleType, EosPatchChannel, Connect/Disconnect/Import/ExportResult
+apps/desktop/src/shared/types/console.types.ts       — re-exports for preload
+apps/desktop/src/preload/index.ts                    — console bridge added to ElectronAPI
+apps/desktop/src/main/index.ts                       — registerConsoleHandlers() wired
 ```
 
-### Dependencies
+**Dependency:** `node-osc@11.3.0` (CJS-compatible; passed `npm audit --audit-level=high`)
 
-```bash
-npm install osc@2.4.4
-npm install -D @types/osc
-```
+**Protocol notes:**
 
-### ETC Eos OSC Implementation
+- Send to console on port 3032 (`EOS_OSC_PORT`)
+- Listen for responses on local port 3033 (`EOS_LISTEN_PORT`)
+- Patch query: send `/eos/get/patch` → receive `/eos/out/patch/count [n]` + `/eos/out/patch/[0..n-1]`
+- Export: send each command string as arg to `/eos/newcmd`
+- Command format: `Chan N Patch U/A Type "Profile" Label "Position Unit"`
 
-#### 1. OSC Client
-
-```typescript
-// src/main/console/eos/eosOSCClient.ts
-
-import { UDPPort } from 'osc';
-
-export class EosOSCClient {
-  private udpPort: UDPPort;
-  private consoleIP: string;
-  private consolePort: number = 3032; // Eos OSC RX port
-  private connected: boolean = false;
-
-  constructor(consoleIP: string) {
-    this.consoleIP = consoleIP;
-
-    this.udpPort = new UDPPort({
-      localAddress: '0.0.0.0',
-      localPort: 0, // Auto-assign
-      remoteAddress: this.consoleIP,
-      remotePort: this.consolePort,
-      metadata: true,
-    });
-
-    this.udpPort.on('ready', () => {
-      this.connected = true;
-      console.log('Connected to Eos console:', this.consoleIP);
-    });
-
-    this.udpPort.on('message', (message) => {
-      this.handleMessage(message);
-    });
-
-    this.udpPort.on('error', (error) => {
-      console.error('OSC error:', error);
-      this.connected = false;
-    });
-  }
-
-  async connect(): Promise<void> {
-    return new Promise((resolve, reject) => {
-      this.udpPort.open();
-
-      // Wait for ready event or timeout
-      const timeout = setTimeout(() => {
-        reject(new Error('Connection timeout'));
-      }, 5000);
-
-      this.udpPort.once('ready', () => {
-        clearTimeout(timeout);
-        resolve();
-      });
-    });
-  }
-
-  disconnect(): void {
-    this.udpPort.close();
-    this.connected = false;
-  }
-
-  /**
-   * Send OSC command to Eos console
-   */
-  sendCommand(address: string, args: any[] = []): void {
-    if (!this.connected) {
-      throw new Error('Not connected to console');
-    }
-
-    this.udpPort.send({
-      address,
-      args,
-    });
-  }
-
-  /**
-   * Get patch data from Eos
-   */
-  async getPatch(): Promise<EosPatchData> {
-    // Request patch data from Eos
-    // Eos OSC address: /eos/out/patch/[channel]
-    this.sendCommand('/eos/get/patch');
-
-    // Wait for response (collected via handleMessage)
-    return new Promise((resolve) => {
-      // Implement response collection logic
-    });
-  }
-
-  /**
-   * Patch fixture to Eos
-   */
-  patchFixture(channel: number, address: number, type: string, universe: number = 1): void {
-    // Eos OSC command: /eos/newcmd
-    // Command format: "Chan [channel] Patch [universe]/[address] Type [type]"
-    const command = `Chan ${channel} Patch ${universe}/${address} Type ${type}`;
-    this.sendCommand('/eos/newcmd', [command]);
-  }
-
-  /**
-   * Update channel label
-   */
-  updateChannelLabel(channel: number, label: string): void {
-    const command = `Chan ${channel} Label ${label}`;
-    this.sendCommand('/eos/newcmd', [command]);
-  }
-
-  private handleMessage(message: any): void {
-    // Parse incoming OSC messages from Eos
-    console.log('Received OSC message:', message);
-  }
-}
-```
-
-#### 2. Command Builder
-
-```typescript
-// src/main/console/eos/eosCommandBuilder.ts
-
-export class EosCommandBuilder {
-  /**
-   * Build Eos patch command from fixture data
-   */
-  buildPatchCommand(fixture: Fixture): string {
-    const parts: string[] = [];
-
-    // Channel
-    if (fixture.channel) {
-      parts.push(`Chan ${fixture.channel}`);
-    }
-
-    // Patch address
-    if (fixture.universe && fixture.dmx_address) {
-      parts.push(`Patch ${fixture.universe}/${fixture.dmx_address}`);
-    }
-
-    // Type
-    if (fixture.type) {
-      // Map ShowStack type to Eos profile
-      const eosType = mapToEosProfile(fixture.type);
-      parts.push(`Type ${eosType}`);
-    }
-
-    // Label (position + unit)
-    const label = [fixture.position, fixture.unit_number].filter(Boolean).join(' ');
-    if (label) {
-      parts.push(`Label "${label}"`);
-    }
-
-    return parts.join(' ');
-  }
-
-  /**
-   * Build batch patch commands for multiple fixtures
-   */
-  buildBatchPatchCommands(fixtures: Fixture[]): string[] {
-    return fixtures.map((f) => this.buildPatchCommand(f));
-  }
-}
-
-/**
- * Map ShowStack fixture type to Eos profile name
- */
-function mapToEosProfile(showstackType: string): string {
-  // Map common fixture types to Eos profiles
-  const mappings: Record<string, string> = {
-    'ETC Source Four 19°': 'Source Four 19deg',
-    'ETC Source Four 26°': 'Source Four 26deg',
-    'MAC Aura': 'MAC Aura',
-    'MAC Viper Profile': 'MAC Viper Profile',
-    // ... extensive fixture type mappings
-  };
-
-  return mappings[showstackType] || showstackType;
-}
-```
-
-#### 3. Patch Parser
-
-```typescript
-// src/main/console/eos/eosPatchParser.ts
-
-export class EosPatchParser {
-  /**
-   * Parse Eos patch data into ShowStack fixture format
-   */
-  parsePatch(eosPatchData: EosPatchData): Partial<Fixture>[] {
-    const fixtures: Partial<Fixture>[] = [];
-
-    for (const channel of eosPatchData.channels) {
-      fixtures.push({
-        channel: String(channel.number),
-        universe: channel.universe,
-        dmx_address: channel.address,
-        type: mapFromEosProfile(channel.profile),
-        position: parseLabel(channel.label).position,
-        unit_number: parseLabel(channel.label).unit,
-        manufacturer: extractManufacturer(channel.profile),
-        mode: channel.mode,
-        // Eos-specific fields
-        eos_channel: channel.number,
-        eos_profile: channel.profile,
-        import_source: 'eos',
-        last_console_sync: Date.now(),
-      });
-    }
-
-    return fixtures;
-  }
-}
-
-/**
- * Map Eos profile to ShowStack fixture type
- */
-function mapFromEosProfile(eosProfile: string): string {
-  const mappings: Record<string, string> = {
-    'Source Four 19deg': 'ETC Source Four 19°',
-    'Source Four 26deg': 'ETC Source Four 26°',
-    'MAC Aura': 'MAC Aura',
-    // ... extensive mappings
-  };
-
-  return mappings[eosProfile] || eosProfile;
-}
-
-/**
- * Parse Eos channel label into position and unit
- */
-function parseLabel(label: string): { position: string; unit: number | null } {
-  // Common formats:
-  // "1st Electric 1"
-  // "FOH L 12"
-  // "Floor 3"
-
-  const match = label.match(/^(.+?)\s+(\d+)$/);
-  if (match) {
-    return {
-      position: match[1],
-      unit: parseInt(match[2]),
-    };
-  }
-
-  return { position: label, unit: null };
-}
-```
-
-### IPC Handlers
-
-```typescript
-// src/main/ipc/console.ts
-
-export function registerConsoleHandlers(): void {
-  // Connect to console
-  ipcMain.handle('console:connect', async (_event, consoleType: string, consoleIP: string) => {
-    try {
-      if (consoleType === 'eos') {
-        const client = new EosOSCClient(consoleIP);
-        await client.connect();
-        // Store client instance
-        return { success: true, connected: true };
-      }
-      return { success: false, error: 'Unknown console type' };
-    } catch (error) {
-      return { success: false, error: error.message };
-    }
-  });
-
-  // Import patch from console
-  ipcMain.handle('console:importPatch', async (_event, consoleType: string) => {
-    try {
-      if (consoleType === 'eos') {
-        const client = getEosClient(); // Retrieve stored client
-        const patchData = await client.getPatch();
-        const parser = new EosPatchParser();
-        const fixtures = parser.parsePatch(patchData);
-        return { success: true, fixtures };
-      }
-      return { success: false, error: 'Unknown console type' };
-    } catch (error) {
-      return { success: false, error: error.message };
-    }
-  });
-
-  // Send patch to console
-  ipcMain.handle(
-    'console:exportPatch',
-    async (_event, consoleType: string, fixtures: Fixture[]) => {
-      try {
-        if (consoleType === 'eos') {
-          const client = getEosClient();
-          const builder = new EosCommandBuilder();
-          const commands = builder.buildBatchPatchCommands(fixtures);
-
-          for (const command of commands) {
-            client.sendCommand('/eos/newcmd', [command]);
-            await delay(100); // Rate limit to avoid overwhelming console
-          }
-
-          return { success: true, sent: commands.length };
-        }
-        return { success: false, error: 'Unknown console type' };
-      } catch (error) {
-        return { success: false, error: error.message };
-      }
-    },
-  );
-
-  // Disconnect from console
-  ipcMain.handle('console:disconnect', async (_event, consoleType: string) => {
-    if (consoleType === 'eos') {
-      const client = getEosClient();
-      client.disconnect();
-      return { success: true };
-    }
-    return { success: false, error: 'Unknown console type' };
-  });
-}
-```
-
-### Testing Strategy
-
-**Key Tests:**
-
-- OSC client connection/disconnection
-- OSC command sending
-- Patch data parsing
-- Fixture type mapping (Eos ↔ ShowStack)
-- Label parsing
-- Command building
-- Error handling (network timeout, invalid commands)
-
-**Coverage Targets:**
-
-- OSC Client: 80%+ (critical utility)
-- Command Builder: 80%+ (critical utility)
-- Patch Parser: 80%+ (critical utility)
-- IPC Handlers: 70%+ (IPC handlers)
+**Test results:** 51 tests passing (12 + 16 + 12 + 11); 2098 total suite passing; 0 TS errors; 851 lint warnings
 
 ### Deliverables
 
-- [x] ETC Eos OSC client with 80%+ coverage
-- [x] Patch import from Eos
-- [x] Command builder with fixture type mapping
-- [x] IPC handlers with 70%+ coverage
-- [x] Integration tests
-- [x] Documentation: Eos setup guide, supported profiles
+- [x] ETC Eos OSC client — 12 tests
+- [x] Patch import from Eos (OSC receive + parse)
+- [x] Patch export to Eos (command builder + send)
+- [x] IPC handlers for all four console operations
+- [x] TypeScript types + preload bridge
+- [x] 51 tests across 4 test files
 
 **Effort:** 2 weeks
 
 ---
 
-## Phase 2: ETC Eos - OSC Export & Live Sync (Weeks 3-4)
+## Phase 2: ETC Eos - UI & Deferred Prereqs (Weeks 3-4)
 
-**Milestone:** Send patch updates to Eos, real-time sync
+**Milestone:** Console UI surface — connection dialog, sync dialog, status indicator, Zustand store; plus deferred Steps 5 and 10 from the network prerequisites.
 
 ### New Files to Create
 
 ```
-src/renderer/src/components/console/
-├── ConsoleConnectionDialog.tsx               (400 lines) - Connection UI
-├── ConsoleSyncDialog.tsx                     (500 lines) - Sync UI with conflict resolution
-├── ConsoleStatusIndicator.tsx                (150 lines) - Connection status
+apps/desktop/src/renderer/src/components/console/
+├── ConsoleConnectionDialog.tsx     — console type selector, IP input w/ inline validation + reachability warning, connect/disconnect
+├── ConsoleSyncDialog.tsx           — import/export direction toggle, fixture preview table, conflict resolution, progress state
+├── ConsoleStatusIndicator.tsx      — compact badge: dot + console name + last-sync time; used in toolbar/sidebar
 └── __tests__/
-    ├── ConsoleConnectionDialog.test.tsx      (250 lines, 50%+ coverage)
-    └── ConsoleSyncDialog.test.tsx            (300 lines, 50%+ coverage)
+    ├── ConsoleConnectionDialog.test.tsx   (50%+ coverage)
+    └── ConsoleSyncDialog.test.tsx         (50%+ coverage)
 
-src/renderer/src/store/
-├── consoleStore.ts                           (350 lines) - Console state
+apps/desktop/src/renderer/src/store/
+├── consoleStore.ts        — Zustand: connection state, last-sync timestamp, import result cache
 └── __tests__/
-    └── consoleStore.test.ts                  (200 lines)
+    └── consoleStore.test.ts
 ```
 
-### Console Connection Dialog
+### Deferred Items to Complete in This Phase
+
+These were deferred from the network prerequisites branch because `ConsoleConnectionDialog.tsx` did not exist yet:
+
+**Step 5 — Wire `parseIPWithPort()` into `ConsoleConnectionDialog.tsx`**
+
+- Import `parseIPWithPort` from `@showstack/shared`
+- On blur of the IP field: validate with `parseIPWithPort()`; if invalid show inline error `<p className="text-xs text-red-600 mt-1">…</p>` (same pattern as infrastructure dialogs)
+- Disable the Connect button when IP is blank or invalid
+- Support optional port suffix: `192.168.1.100:3032` — parsed port overrides the default
+
+**Step 10 — Reachability pre-check in `ConsoleConnectionDialog.tsx`**
+
+- After IP validates, call `window.api.infrastructure.getPortStatusReport(projectId)` and check the entered IP against the results
+- If status is `unreachable` or `timeout`: show an inline warning (not a blocker) below the IP field: `"This IP is currently unreachable — connection may fail"`
+- Connect button stays enabled (non-blocking; user can still attempt connection)
+- Do not call the status report on every keystroke — debounce or call once on blur after IP validates
+
+**Remaining test gap from prereqs**
+
+- `apps/desktop/src/main/ipc/__tests__/infrastructure.test.ts` — add `infrastructure:getPortStatusReport` handler test: cache miss calls service, cache hit returns cached result
+
+### ConsoleConnectionDialog Key Behaviors
+
+- Console type: `eos` | `grandma2` | `grandma3` (select; Phase 2 only wires up `eos`)
+- IP field: blur-triggered inline validation via `parseIPWithPort()`; reachability warning via `getPortStatusReport`
+- Status states: `idle → connecting → connected | error`
+- On connect success: store connection in `consoleStore`
+- On reconnect: existing client is disconnected first (already handled by IPC handler)
+- Console-specific hint text below IP field (Eos: "Enable OSC RX in Setup → System Settings → Show Control → OSC")
+
+### ConsoleSyncDialog Key Behaviors
+
+- Requires active connection from `consoleStore` (disabled / warning if not connected)
+- Import flow: call `console:importPatch` → display parsed channels in a preview table → "Apply Import" merges into project fixtures
+- Export flow: read project fixtures → call `console:exportPatch` → show sent count
+- Conflict resolution: if imported channel number matches an existing fixture, show side-by-side diff; user chooses keep-console / keep-showstack / merge per row
+- Progress: spinner + "Sent N of M commands" while export is running
+
+### ConsoleStatusIndicator
+
+- Color dot: green (connected), yellow (connecting), red (error/disconnected), grey (no connection configured)
+- Shows console type label + last-sync timestamp
+- Clicking opens `ConsoleConnectionDialog`
+
+### consoleStore
 
 ```typescript
-// src/renderer/src/components/console/ConsoleConnectionDialog.tsx
-
-export function ConsoleConnectionDialog({ onClose }: Props) {
-  const [consoleType, setConsoleType] = useState<'eos' | 'grandma2' | 'grandma3'>('eos');
-  const [consoleIP, setConsoleIP] = useState('');
-  const [status, setStatus] = useState<'idle' | 'connecting' | 'connected' | 'error'>('idle');
-
-  const handleConnect = async () => {
-    setStatus('connecting');
-
-    const result = await window.api.console.connect(consoleType, consoleIP);
-
-    if (result.success) {
-      setStatus('connected');
-      // Save connection to console store
-      useConsoleStore.getState().setConnection({
-        type: consoleType,
-        ip: consoleIP,
-        connected: true,
-        lastSync: null
-      });
-    } else {
-      setStatus('error');
-      alert(`Connection failed: ${result.error}`);
-    }
-  };
-
-  return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-[500px] p-6">
-        <h2 className="text-2xl font-bold mb-4">Connect to Console</h2>
-
-        <div className="space-y-4">
-          {/* Console Type */}
-          <div className="form-group">
-            <label>Console Type</label>
-            <select
-              value={consoleType}
-              onChange={(e) => setConsoleType(e.target.value as any)}
-              className="form-select"
-            >
-              <option value="eos">ETC Eos Family</option>
-              <option value="grandma2">GrandMA2</option>
-              <option value="grandma3">GrandMA3</option>
-            </select>
-          </div>
-
-          {/* IP Address */}
-          <div className="form-group">
-            <label>Console IP Address</label>
-            <input
-              type="text"
-              value={consoleIP}
-              onChange={(e) => setConsoleIP(e.target.value)}
-              placeholder="192.168.1.100"
-              className="form-input"
-            />
-            <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
-              {consoleType === 'eos' && 'Ensure OSC RX is enabled on Eos (Setup → System Settings → Show Control → OSC)'}
-              {consoleType === 'grandma2' && 'Ensure Telnet is enabled on GrandMA2 (Setup → Network → Telnet)'}
-              {consoleType === 'grandma3' && 'Ensure MA-Net3 is configured on GrandMA3'}
-            </p>
-          </div>
-
-          {/* Status */}
-          {status !== 'idle' && (
-            <div className={`p-3 rounded ${
-              status === 'connected' ? 'bg-green-100 dark:bg-green-900/20 text-green-800 dark:text-green-400' :
-              status === 'error' ? 'bg-red-100 dark:bg-red-900/20 text-red-800 dark:text-red-400' :
-              'bg-blue-100 dark:bg-blue-900/20 text-blue-800 dark:text-blue-400'
-            }`}>
-              {status === 'connecting' && 'Connecting...'}
-              {status === 'connected' && '✓ Connected successfully'}
-              {status === 'error' && '✗ Connection failed'}
-            </div>
-          )}
-        </div>
-
-        {/* Footer */}
-        <div className="mt-6 flex justify-end gap-3">
-          <button onClick={onClose} className="btn-secondary">
-            {status === 'connected' ? 'Close' : 'Cancel'}
-          </button>
-          <button
-            onClick={handleConnect}
-            disabled={!consoleIP || status === 'connecting' || status === 'connected'}
-            className="btn-primary"
-          >
-            {status === 'connecting' ? 'Connecting...' : 'Connect'}
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
-```
-
-### Console Sync Dialog
-
-```typescript
-// src/renderer/src/components/console/ConsoleSyncDialog.tsx
-
-export function ConsoleSyncDialog({ onClose }: Props) {
-  const [syncDirection, setSyncDirection] = useState<'import' | 'export'>('import');
-  const [syncing, setSyncing] = useState(false);
-  const [result, setResult] = useState<SyncResult | null>(null);
-  const connection = useConsoleStore(state => state.connection);
-
-  const handleImport = async () => {
-    setSyncing(true);
-
-    const result = await window.api.console.importPatch(connection.type);
-
-    if (result.success) {
-      // Show fixtures to import with conflict resolution
-      setResult({
-        fixtures: result.fixtures,
-        conflicts: detectConflicts(result.fixtures)
-      });
-    }
-
-    setSyncing(false);
-  };
-
-  const handleExport = async () => {
-    setSyncing(true);
-
-    const fixtures = useFixtureStore.getState().fixtures;
-    const result = await window.api.console.exportPatch(connection.type, fixtures);
-
-    if (result.success) {
-      setResult({ sent: result.sent, errors: [] });
-    }
-
-    setSyncing(false);
-  };
-
-  return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-[800px] max-h-[80vh] flex flex-col">
-        <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
-          <h2 className="text-2xl font-bold">Sync with {connection.type.toUpperCase()}</h2>
-        </div>
-
-        <div className="flex-1 overflow-auto p-6">
-          {/* Sync Direction */}
-          <div className="mb-6">
-            <label className="block text-sm font-medium mb-2">Sync Direction</label>
-            <div className="flex gap-4">
-              <button
-                onClick={() => setSyncDirection('import')}
-                className={`px-4 py-2 rounded ${
-                  syncDirection === 'import' ? 'bg-blue-600 text-white' : 'bg-gray-200 dark:bg-gray-700'
-                }`}
-              >
-                Import from Console → ShowStack
-              </button>
-              <button
-                onClick={() => setSyncDirection('export')}
-                className={`px-4 py-2 rounded ${
-                  syncDirection === 'export' ? 'bg-blue-600 text-white' : 'bg-gray-200 dark:bg-gray-700'
-                }`}
-              >
-                Export from ShowStack → Console
-              </button>
-            </div>
-          </div>
-
-          {/* Result Display */}
-          {result && (
-            <div>
-              {/* Show import result with conflicts */}
-              {/* Show export result with success count */}
-            </div>
-          )}
-        </div>
-
-        <div className="px-6 py-4 border-t border-gray-200 dark:border-gray-700 flex justify-end gap-3">
-          <button onClick={onClose} className="btn-secondary">
-            Close
-          </button>
-          <button
-            onClick={syncDirection === 'import' ? handleImport : handleExport}
-            disabled={syncing}
-            className="btn-primary"
-          >
-            {syncing ? 'Syncing...' : syncDirection === 'import' ? 'Import Patch' : 'Export Patch'}
-          </button>
-        </div>
-      </div>
-    </div>
-  );
+// Zustand store shape
+interface ConsoleState {
+  connection: ConsoleConnection | null; // { type, ip, port?, connectedAt }
+  status: 'idle' | 'connecting' | 'connected' | 'error';
+  lastSync: number | null; // Date.now() after successful import or export
+  lastImport: ImportedFixture[] | null; // cached last import result for conflict resolution
+  setConnection(c: ConsoleConnection): void;
+  setStatus(s: ConsoleState['status']): void;
+  setLastSync(t: number): void;
+  setLastImport(fixtures: ImportedFixture[]): void;
+  clearConnection(): void;
 }
 ```
 
@@ -767,24 +298,23 @@ export function ConsoleSyncDialog({ onClose }: Props) {
 
 **Key Tests:**
 
-- Connection dialog UI
-- Sync dialog with import/export
-- Status indicator updates
-- Error handling (connection timeout, sync failures)
-- Conflict detection and resolution
+- `ConsoleConnectionDialog`: renders, IP validation shows/clears error on blur, connect button disabled when IP invalid, reachability warning appears, calls `window.api.console.connect` on submit
+- `ConsoleSyncDialog`: import triggers `console:importPatch`, export triggers `console:exportPatch`, conflict table renders when duplicates detected
+- `consoleStore`: setConnection, setStatus, clearConnection
 
 **Coverage Targets:**
 
 - UI Components: 50%+ (standard for UI)
+- consoleStore: 80%+ (pure state logic)
 
 ### Deliverables
 
-- [x] Console connection dialog
-- [x] Sync dialog with conflict resolution
-- [x] Export patch to Eos
-- [x] Status indicator
-- [x] 50%+ component test coverage
-- [x] Documentation: Export guide, sync workflows
+- [ ] `ConsoleConnectionDialog.tsx` with inline IP validation (Step 5) and reachability pre-check (Step 10)
+- [ ] `ConsoleSyncDialog.tsx` with import preview + conflict resolution
+- [ ] `ConsoleStatusIndicator.tsx`
+- [ ] `consoleStore.ts` with Zustand state
+- [ ] `infrastructure:getPortStatusReport` handler test added to `infrastructure.test.ts`
+- [ ] 50%+ component test coverage
 
 **Effort:** 2 weeks
 
@@ -973,10 +503,7 @@ src/main/console/grandma3/
    - Watch for changes on console → auto-update ShowStack
    - Configurable sync rules
 
-3. **Fixture Profile Management**
-   - Downloadable fixture profile database
-   - User-editable profile mappings
-   - Profile import from manufacturers
+3. **Fixture Profile Management** ✅ Already handled — GDTF personality library (PR #90) provides the fixture profile database and profile mappings. Phase 5 only needs to wire GDTF profiles into the console type-mapping layer (replace the static `mapToEosProfile` table with GDTF-backed lookups).
 
 4. **Multi-Console Support**
    - Connect to multiple consoles simultaneously
@@ -1088,14 +615,14 @@ Week 9-10: Phase 5 - Advanced Features & Polish
 
 ## Next Steps
 
-1. **Team Review** - Review plan with stakeholders
-2. **Console Access** - Obtain test consoles (Eos offline, MA2/MA3 onPC)
-3. **Network Setup** - Set up test network environment
-4. **Protocol Research** - Detailed protocol documentation review
-5. **Begin Phase 1** - Start with ETC Eos OSC implementation
+1. **Phase 2** — `ConsoleConnectionDialog`, `ConsoleSyncDialog`, `ConsoleStatusIndicator`, `consoleStore`; close out deferred Steps 5 + 10 + `infrastructure.test.ts` gap
+2. **Console Access** — Obtain test consoles (Eos offline, MA2/MA3 onPC) before Phase 3
+3. **Phase 3** — GrandMA2 Telnet + XML integration
+4. **Phase 4** — GrandMA3 MA-Net3 + OSC integration
+5. **Phase 5** — Auto-discovery, live sync, GDTF-backed profile mapping (profile DB already complete)
 
 ---
 
 **Last Updated:** March 27, 2026
 **Author:** Claude Code
-**Version:** 1.1
+**Version:** 1.2

--- a/docs/features/console-integration-plan.md
+++ b/docs/features/console-integration-plan.md
@@ -4,7 +4,7 @@
 **Delivery:** Phased approach with 5 iterative milestones
 **Timeline:** 10 weeks (2.5 months)
 **Effort:** 1 developer full-time
-**Status:** In progress — network prerequisites + Phase 1 (Eos OSC backend) complete; Phase 2 (UI + live sync) next
+**Status:** In progress — network prerequisites, Phase 1 (Eos OSC backend), and Phase 2 (UI) complete; paused for hardware testing with Eos console before Phase 3
 **Created:** January 20, 2026
 **Updated:** March 27, 2026
 **Priority:** High (competitive gap with Lightwright, professional workflow integration)
@@ -211,112 +211,71 @@ apps/desktop/src/main/index.ts                       — registerConsoleHandlers
 
 ---
 
-## Phase 2: ETC Eos - UI & Deferred Prereqs (Weeks 3-4)
+## Phase 2: ETC Eos - UI & Deferred Prereqs ✅ COMPLETE (branch: `feature/eos-osc-phase1`)
 
-**Milestone:** Console UI surface — connection dialog, sync dialog, status indicator, Zustand store; plus deferred Steps 5 and 10 from the network prerequisites.
+**Milestone:** Console UI surface + all deferred prereq items closed
 
-### New Files to Create
+### Shipped Files
 
 ```
 apps/desktop/src/renderer/src/components/console/
-├── ConsoleConnectionDialog.tsx     — console type selector, IP input w/ inline validation + reachability warning, connect/disconnect
-├── ConsoleSyncDialog.tsx           — import/export direction toggle, fixture preview table, conflict resolution, progress state
-├── ConsoleStatusIndicator.tsx      — compact badge: dot + console name + last-sync time; used in toolbar/sidebar
+├── ConsoleConnectionDialog.tsx       — console type selector; IP validation via parseIPWithPort() (Step 5);
+│                                       reachability warning via getPortStatusReport (Step 10); connect/disconnect flow
+├── ConsoleSyncDialog.tsx             — import/export toggle; channel preview table with conflict highlighting;
+│                                       Apply Import callback; export sent-count result
+├── ConsoleStatusIndicator.tsx        — color dot (green/yellow/red/grey) + console label + last-sync time; hidden when idle
 └── __tests__/
-    ├── ConsoleConnectionDialog.test.tsx   (50%+ coverage)
-    └── ConsoleSyncDialog.test.tsx         (50%+ coverage)
+    ├── ConsoleConnectionDialog.test.tsx   (12 tests — render, IP validation, reachability warning, connect/error)
+    └── ConsoleSyncDialog.test.tsx         (8 tests — import preview, conflict indicator, apply, export, errors)
 
 apps/desktop/src/renderer/src/store/
-├── consoleStore.ts        — Zustand: connection state, last-sync timestamp, import result cache
+├── consoleStore.ts                   — Zustand: connect, disconnect, setLastSync, setLastImport, clearConnection
 └── __tests__/
-    └── consoleStore.test.ts
+    └── consoleStore.test.ts          (12 tests — connect success/error/throw, disconnect, setLastSync, clearConnection)
+
+apps/desktop/src/main/ipc/__tests__/
+└── infrastructure.test.ts            — getPortStatusReport handler: calls service, propagates error (3 tests; deferred prereq gap)
 ```
 
-### Deferred Items to Complete in This Phase
+**Deferred items closed:**
 
-These were deferred from the network prerequisites branch because `ConsoleConnectionDialog.tsx` did not exist yet:
+- ✅ Step 5 — `parseIPWithPort()` wired into `ConsoleConnectionDialog` (blur-triggered, disables Connect on invalid input)
+- ✅ Step 10 — reachability pre-check wired (`getPortStatusReport` on blur after IP validates; yellow warning, non-blocking)
+- ✅ `infrastructure:getPortStatusReport` handler test
 
-**Step 5 — Wire `parseIPWithPort()` into `ConsoleConnectionDialog.tsx`**
-
-- Import `parseIPWithPort` from `@showstack/shared`
-- On blur of the IP field: validate with `parseIPWithPort()`; if invalid show inline error `<p className="text-xs text-red-600 mt-1">…</p>` (same pattern as infrastructure dialogs)
-- Disable the Connect button when IP is blank or invalid
-- Support optional port suffix: `192.168.1.100:3032` — parsed port overrides the default
-
-**Step 10 — Reachability pre-check in `ConsoleConnectionDialog.tsx`**
-
-- After IP validates, call `window.api.infrastructure.getPortStatusReport(projectId)` and check the entered IP against the results
-- If status is `unreachable` or `timeout`: show an inline warning (not a blocker) below the IP field: `"This IP is currently unreachable — connection may fail"`
-- Connect button stays enabled (non-blocking; user can still attempt connection)
-- Do not call the status report on every keystroke — debounce or call once on blur after IP validates
-
-**Remaining test gap from prereqs**
-
-- `apps/desktop/src/main/ipc/__tests__/infrastructure.test.ts` — add `infrastructure:getPortStatusReport` handler test: cache miss calls service, cache hit returns cached result
-
-### ConsoleConnectionDialog Key Behaviors
-
-- Console type: `eos` | `grandma2` | `grandma3` (select; Phase 2 only wires up `eos`)
-- IP field: blur-triggered inline validation via `parseIPWithPort()`; reachability warning via `getPortStatusReport`
-- Status states: `idle → connecting → connected | error`
-- On connect success: store connection in `consoleStore`
-- On reconnect: existing client is disconnected first (already handled by IPC handler)
-- Console-specific hint text below IP field (Eos: "Enable OSC RX in Setup → System Settings → Show Control → OSC")
-
-### ConsoleSyncDialog Key Behaviors
-
-- Requires active connection from `consoleStore` (disabled / warning if not connected)
-- Import flow: call `console:importPatch` → display parsed channels in a preview table → "Apply Import" merges into project fixtures
-- Export flow: read project fixtures → call `console:exportPatch` → show sent count
-- Conflict resolution: if imported channel number matches an existing fixture, show side-by-side diff; user chooses keep-console / keep-showstack / merge per row
-- Progress: spinner + "Sent N of M commands" while export is running
-
-### ConsoleStatusIndicator
-
-- Color dot: green (connected), yellow (connecting), red (error/disconnected), grey (no connection configured)
-- Shows console type label + last-sync timestamp
-- Clicking opens `ConsoleConnectionDialog`
-
-### consoleStore
-
-```typescript
-// Zustand store shape
-interface ConsoleState {
-  connection: ConsoleConnection | null; // { type, ip, port?, connectedAt }
-  status: 'idle' | 'connecting' | 'connected' | 'error';
-  lastSync: number | null; // Date.now() after successful import or export
-  lastImport: ImportedFixture[] | null; // cached last import result for conflict resolution
-  setConnection(c: ConsoleConnection): void;
-  setStatus(s: ConsoleState['status']): void;
-  setLastSync(t: number): void;
-  setLastImport(fixtures: ImportedFixture[]): void;
-  clearConnection(): void;
-}
-```
-
-### Testing Strategy
-
-**Key Tests:**
-
-- `ConsoleConnectionDialog`: renders, IP validation shows/clears error on blur, connect button disabled when IP invalid, reachability warning appears, calls `window.api.console.connect` on submit
-- `ConsoleSyncDialog`: import triggers `console:importPatch`, export triggers `console:exportPatch`, conflict table renders when duplicates detected
-- `consoleStore`: setConnection, setStatus, clearConnection
-
-**Coverage Targets:**
-
-- UI Components: 50%+ (standard for UI)
-- consoleStore: 80%+ (pure state logic)
+**Test results:** 32 new tests; 2130 total suite passing; 0 TS errors; 851 lint warnings
 
 ### Deliverables
 
-- [ ] `ConsoleConnectionDialog.tsx` with inline IP validation (Step 5) and reachability pre-check (Step 10)
-- [ ] `ConsoleSyncDialog.tsx` with import preview + conflict resolution
-- [ ] `ConsoleStatusIndicator.tsx`
-- [ ] `consoleStore.ts` with Zustand state
-- [ ] `infrastructure:getPortStatusReport` handler test added to `infrastructure.test.ts`
-- [ ] 50%+ component test coverage
+- [x] `ConsoleConnectionDialog.tsx` with IP validation (Step 5) and reachability pre-check (Step 10)
+- [x] `ConsoleSyncDialog.tsx` with import preview and conflict highlighting
+- [x] `ConsoleStatusIndicator.tsx`
+- [x] `consoleStore.ts` with Zustand state
+- [x] `infrastructure:getPortStatusReport` handler test
+- [x] 32 new tests (12 + 8 + 12 component/store tests)
 
 **Effort:** 2 weeks
+
+---
+
+## Eos Hardware Testing Checkpoint
+
+**Status:** Paused — awaiting access to physical Eos console (or Eos offline software) before proceeding to Phase 3.
+
+**What to validate against real hardware:**
+
+1. **OSC connectivity** — confirm `EosOSCClient.connect()` successfully opens the local UDP listen server and Eos can reach it
+2. **Patch import** — send `/eos/get/patch`, verify `/eos/out/patch/count` and `/eos/out/patch/[n]` messages arrive in expected format; check that `EosPatchParser` correctly maps real Eos profile names and label strings
+3. **Patch export** — send a batch of `/eos/newcmd` commands and confirm they land in Eos as expected channel/patch/type/label assignments
+4. **Port** — verify default port 3032 matches the console's OSC RX setting; test optional port override (`:3032` suffix in IP field)
+5. **Connection dialog UX** — connect, status indicator updates, disconnect, reconnect flow
+6. **Sync dialog UX** — import preview renders correctly, Apply Import populates fixtures, export sends correct count
+
+**Known risks to verify:**
+
+- Eos OSC RX must be explicitly enabled: Setup → System Settings → Show Control → OSC
+- Firewall / VLAN isolation may block UDP; `PortStatusMonitorService` TCP check may succeed while UDP is blocked — document this limitation
+- Very large patches (500+ channels) may hit the `PATCH_TIMEOUT_MS` (10s) limit — test and adjust if needed
 
 ---
 
@@ -615,14 +574,13 @@ Week 9-10: Phase 5 - Advanced Features & Polish
 
 ## Next Steps
 
-1. **Phase 2** — `ConsoleConnectionDialog`, `ConsoleSyncDialog`, `ConsoleStatusIndicator`, `consoleStore`; close out deferred Steps 5 + 10 + `infrastructure.test.ts` gap
-2. **Console Access** — Obtain test consoles (Eos offline, MA2/MA3 onPC) before Phase 3
-3. **Phase 3** — GrandMA2 Telnet + XML integration
-4. **Phase 4** — GrandMA3 MA-Net3 + OSC integration
-5. **Phase 5** — Auto-discovery, live sync, GDTF-backed profile mapping (profile DB already complete)
+1. **Hardware testing** — Validate Eos OSC import/export against a real console; address any protocol edge cases found (see Eos Hardware Testing Checkpoint above)
+2. **Phase 3** — GrandMA2 Telnet + XML integration (needs onPC or physical console access)
+3. **Phase 4** — GrandMA3 MA-Net3 + OSC integration
+4. **Phase 5** — Auto-discovery, live sync, GDTF-backed profile mapping (profile DB already complete)
 
 ---
 
 **Last Updated:** March 27, 2026
 **Author:** Claude Code
-**Version:** 1.2
+**Version:** 1.3

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "fast-xml-parser": "^5.5.5",
         "file-type": "^19.6.0",
         "lucide-react": "^0.460.0",
+        "node-osc": "^11.3.0",
         "posthog-js": "^1.328.0",
         "puppeteer": "^24.34.0",
         "react": "^19.2.0",
@@ -9821,6 +9822,15 @@
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/node-osc": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/node-osc/-/node-osc-11.3.0.tgz",
+      "integrity": "sha512-MtXBBcdzBO00ykGdoe23TB0Ex6Yv9bEf0yB4d4HjWB6hyaFzPg/QGTyw/YaLR2Uwaro+4eM7VCWtzRHu1El4ng==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.9.0 || ^22.11.0 || >=24.0.0"
       }
     },
     "node_modules/node-releases": {

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "fast-xml-parser": "^5.5.5",
     "file-type": "^19.6.0",
     "lucide-react": "^0.460.0",
+    "node-osc": "^11.3.0",
     "posthog-js": "^1.328.0",
     "puppeteer": "^24.34.0",
     "react": "^19.2.0",


### PR DESCRIPTION
## Summary

- **Phase 1** — Full Eos OSC backend: `EosOSCClient`, `EosPatchParser`, `EosCommandBuilder`, IPC handlers (`console:connect/disconnect/importPatch/exportPatch`), TypeScript types, preload bridge
- **Phase 2** — Console UI: `ConsoleConnectionDialog` (IP validation + reachability pre-check), `ConsoleSyncDialog` (import preview with conflict detection, export), `ConsoleStatusIndicator`, `consoleStore` (Zustand)
- **Deferred prereq items closed** — Step 5 (`parseIPWithPort` in connection dialog), Step 10 (reachability warning via `getPortStatusReport`), `infrastructure:getPortStatusReport` handler test

## What's included

### Backend (Phase 1)
- `apps/desktop/src/main/console/eos/eosOSCClient.ts` — UDP send (`node-osc` Client) + receive (Server); `connect/disconnect/send/getPatch`
- `apps/desktop/src/main/console/eos/eosPatchParser.ts` — parse `/eos/out/patch/*` messages → `EosPatchChannel`; `toImportedFixture` mapping
- `apps/desktop/src/main/console/eos/eosCommandBuilder.ts` — `Chan N Patch U/A Type "…" Label "…"` command builder; `mapToEosProfile`
- `apps/desktop/src/main/ipc/console.ts` — four IPC handlers with client lifecycle management
- `apps/desktop/src/renderer/src/types/console.ts` — `ConsoleType`, `EosPatchChannel`, result envelope types
- `apps/desktop/src/shared/types/console.types.ts` — re-exports for preload
- Preload bridge + `registerConsoleHandlers()` wired into main process
- Dependency: `node-osc@11.3.0` (clean `npm audit --audit-level=high`)

### UI (Phase 2)
- `ConsoleConnectionDialog.tsx` — console type selector; blur-triggered IP validation; reachability pre-check (non-blocking yellow warning); connect/disconnect with status banner
- `ConsoleSyncDialog.tsx` — import/export toggle; channel preview table; conflict highlighting for existing channel numbers; Apply Import callback; export sent-count result
- `ConsoleStatusIndicator.tsx` — color dot + label + last-sync time; hidden when idle
- `consoleStore.ts` — Zustand store: `connect`, `disconnect`, `setLastSync`, `setLastImport`, `clearConnection`
- `infrastructure.test.ts` — `getPortStatusReport` handler tests (deferred from #93)

## Test plan

- [ ] 83 new tests across 7 files; 2130 total suite passing
- [ ] 0 TypeScript errors (`npx tsc --noEmit`)
- [ ] 851 lint warnings (< 855 CI budget)
- [ ] `npm audit --audit-level=high` passes
- [ ] Hardware validation against Eos console pending (see testing checkpoint in `console-integration-plan.md`)

## Notes

- Branch is paused for hardware testing before Phase 3 (GrandMA2)
- Closes #17 and #20 (already closed — delivered in PR #93)

🤖 Generated with [Claude Code](https://claude.com/claude-code)