### PR TITLE
feat: wire console dialogs into Equipment Manager toolbar

### DIFF
--- a/apps/desktop/src/renderer/src/components/fixture/Toolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/fixture/Toolbar.tsx
@@ -13,6 +13,9 @@ interface ToolbarProps {
   onExportCSV?: () => void;
   onImportMvr?: () => void;
   onExportMvr?: () => void;
+  onConsole?: () => void;
+  onConsoleSync?: () => void;
+  consoleSyncAvailable?: boolean;
   onUserColumnSettings: () => void;
   columnVisibility: ColumnVisibility;
   onColumnVisibilityChange: (visibility: ColumnVisibility) => void;
@@ -36,6 +39,9 @@ export function Toolbar({
   onExportCSV,
   onImportMvr,
   onExportMvr,
+  onConsole,
+  onConsoleSync,
+  consoleSyncAvailable,
   onUserColumnSettings,
   columnVisibility,
   onColumnVisibilityChange,
@@ -122,6 +128,26 @@ export function Toolbar({
           onChange={(e) => onSearchChange(e.target.value)}
           className="px-2.5 py-1.5 bg-gray-50 dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded text-sm w-44 text-gray-900 dark:text-white focus:outline-none focus:border-blue-500 focus:bg-white dark:focus:bg-gray-600 transition-colors"
         />
+
+        {onConsole && (
+          <button
+            onClick={onConsole}
+            className="px-3 py-1.5 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 rounded text-sm font-medium transition flex-shrink-0"
+            title="Connect to lighting console"
+          >
+            Console
+          </button>
+        )}
+
+        {consoleSyncAvailable && onConsoleSync && (
+          <button
+            onClick={onConsoleSync}
+            className="px-3 py-1.5 bg-white dark:bg-gray-700 border border-green-400 dark:border-green-600 hover:bg-green-50 dark:hover:bg-green-900/20 text-green-700 dark:text-green-400 rounded text-sm font-medium transition flex-shrink-0"
+            title="Import or export patch to/from console"
+          >
+            Sync
+          </button>
+        )}
 
         {onImportMvr && (
           <button

--- a/apps/desktop/src/renderer/src/pages/modules/EquipmentManager.tsx
+++ b/apps/desktop/src/renderer/src/pages/modules/EquipmentManager.tsx
@@ -57,6 +57,9 @@ import { getGroupMembers, computeFixtureGroupMap } from '../../utils/groupMember
 import { InspectorPanel, InspectorContent } from '../../components/inspector/InspectorPanel';
 import { GroupsInspector } from '../../components/inspector/GroupsInspector';
 import { ConditionalFormattingInspector } from '../../components/inspector/ConditionalFormattingInspector';
+import { ConsoleConnectionDialog } from '../../components/console/ConsoleConnectionDialog';
+import { ConsoleSyncDialog } from '../../components/console/ConsoleSyncDialog';
+import { useConsoleStore } from '../../store/consoleStore';
 
 interface EquipmentManagerProps {
   initialTab?: 'fixtures' | 'infrastructure' | 'power';
@@ -154,6 +157,11 @@ export function EquipmentManager({ initialTab = 'fixtures' }: EquipmentManagerPr
   // Export dialog state
   const [isExportDialogOpen, setIsExportDialogOpen] = useState(false);
   const [exportFormat, setExportFormat] = useState<'csv' | 'eos' | 'grandma2' | 'grandma3'>('csv');
+
+  // Console integration dialog state
+  const [isConsoleDialogOpen, setIsConsoleDialogOpen] = useState(false);
+  const [isConsoleSyncDialogOpen, setIsConsoleSyncDialogOpen] = useState(false);
+  const { status: consoleStatus } = useConsoleStore();
 
   // Sort state - now supports multi-column sort
   interface SortConfig {
@@ -1246,6 +1254,9 @@ export function EquipmentManager({ initialTab = 'fixtures' }: EquipmentManagerPr
               onImportMvr={activeTab === 'fixtures' ? handleImportMvr : undefined}
               onExportMvr={activeTab === 'fixtures' ? handleExportMvr : undefined}
               onExportCSV={activeTab === 'fixtures' ? handleExportCSV : undefined}
+              onConsole={() => setIsConsoleDialogOpen(true)}
+              onConsoleSync={() => setIsConsoleSyncDialogOpen(true)}
+              consoleSyncAvailable={consoleStatus === 'connected'}
               onUserColumnSettings={() => setIsUserColumnSettingsOpen(true)}
               columnVisibility={columnVisibility}
               onColumnVisibilityChange={handleColumnVisibilityChange}
@@ -1830,6 +1841,23 @@ export function EquipmentManager({ initialTab = 'fixtures' }: EquipmentManagerPr
           </div>
         </div>
       )}
+
+      {/* Console Dialogs */}
+      <ConsoleConnectionDialog
+        isOpen={isConsoleDialogOpen}
+        projectId={currentProjectId}
+        onClose={() => setIsConsoleDialogOpen(false)}
+      />
+      <ConsoleSyncDialog
+        isOpen={isConsoleSyncDialogOpen}
+        existingChannels={
+          new Set(fixtures.map((f) => parseInt(f.channel ?? '', 10)).filter((n) => !isNaN(n)))
+        }
+        onClose={() => setIsConsoleSyncDialogOpen(false)}
+        onImportApply={(channels) => {
+          logger.info(`Console import applied: ${channels.length} channels`);
+        }}
+      />
 
       {/* Unsaved Changes Dialog */}
       <UnsavedChangesDialog {...unsavedChangesDialog} />

--- a/apps/desktop/src/renderer/src/pages/modules/EquipmentManager.tsx
+++ b/apps/desktop/src/renderer/src/pages/modules/EquipmentManager.tsx
@@ -162,10 +162,15 @@ export function EquipmentManager({ initialTab = 'fixtures' }: EquipmentManagerPr
   const [isConsoleDialogOpen, setIsConsoleDialogOpen] = useState(false);
   const [isConsoleSyncDialogOpen, setIsConsoleSyncDialogOpen] = useState(false);
   const { status: consoleStatus } = useConsoleStore();
-  const existingChannels = useMemo(
-    () => new Set(fixtures.map((f) => parseInt(f.channel ?? '', 10)).filter((n) => !isNaN(n))),
-    [fixtures],
-  );
+  const existingChannels = useMemo(() => {
+    const channels = new Set<number>();
+    for (const f of fixtures) {
+      if (f.channel && /^\d+$/.test(f.channel)) {
+        channels.add(Number(f.channel));
+      }
+    }
+    return channels;
+  }, [fixtures]);
 
   // Sort state - now supports multi-column sort
   interface SortConfig {
@@ -1258,9 +1263,11 @@ export function EquipmentManager({ initialTab = 'fixtures' }: EquipmentManagerPr
               onImportMvr={activeTab === 'fixtures' ? handleImportMvr : undefined}
               onExportMvr={activeTab === 'fixtures' ? handleExportMvr : undefined}
               onExportCSV={activeTab === 'fixtures' ? handleExportCSV : undefined}
-              onConsole={() => setIsConsoleDialogOpen(true)}
-              onConsoleSync={() => setIsConsoleSyncDialogOpen(true)}
-              consoleSyncAvailable={consoleStatus === 'connected'}
+              onConsole={activeTab === 'fixtures' ? () => setIsConsoleDialogOpen(true) : undefined}
+              onConsoleSync={
+                activeTab === 'fixtures' ? () => setIsConsoleSyncDialogOpen(true) : undefined
+              }
+              consoleSyncAvailable={activeTab === 'fixtures' && consoleStatus === 'connected'}
               onUserColumnSettings={() => setIsUserColumnSettingsOpen(true)}
               columnVisibility={columnVisibility}
               onColumnVisibilityChange={handleColumnVisibilityChange}

--- a/apps/desktop/src/renderer/src/pages/modules/EquipmentManager.tsx
+++ b/apps/desktop/src/renderer/src/pages/modules/EquipmentManager.tsx
@@ -162,6 +162,10 @@ export function EquipmentManager({ initialTab = 'fixtures' }: EquipmentManagerPr
   const [isConsoleDialogOpen, setIsConsoleDialogOpen] = useState(false);
   const [isConsoleSyncDialogOpen, setIsConsoleSyncDialogOpen] = useState(false);
   const { status: consoleStatus } = useConsoleStore();
+  const existingChannels = useMemo(
+    () => new Set(fixtures.map((f) => parseInt(f.channel ?? '', 10)).filter((n) => !isNaN(n))),
+    [fixtures],
+  );
 
   // Sort state - now supports multi-column sort
   interface SortConfig {
@@ -1850,11 +1854,10 @@ export function EquipmentManager({ initialTab = 'fixtures' }: EquipmentManagerPr
       />
       <ConsoleSyncDialog
         isOpen={isConsoleSyncDialogOpen}
-        existingChannels={
-          new Set(fixtures.map((f) => parseInt(f.channel ?? '', 10)).filter((n) => !isNaN(n)))
-        }
+        existingChannels={existingChannels}
         onClose={() => setIsConsoleSyncDialogOpen(false)}
         onImportApply={(channels) => {
+          // TODO: apply imported console channels to the fixture list (Phase 3)
           logger.info(`Console import applied: ${channels.length} channels`);
         }}
       />


### PR DESCRIPTION
## Summary

- Adds **Console** button to the Equipment Manager fixtures toolbar — always visible, opens `ConsoleConnectionDialog` to connect/disconnect from a lighting console
- Adds **Sync** button (green, only visible when connected) — opens `ConsoleSyncDialog` for patch import/export
- `existingChannels` derived from current fixture channel numbers for conflict detection in the import preview

## Test plan

- [ ] Open Equipment Manager → Fixtures tab → verify Console button appears in toolbar
- [ ] Click Console → enter an Eos IP → connect → verify green Sync button appears
- [ ] Click Sync → import patch from console → verify channel preview loads
- [ ] Click Sync → export patch → verify commands sent to console

🤖 Generated with [Claude Code](https://claude.com/claude-code)